### PR TITLE
Migrate block/unblock user endpoints to generated models

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -54,7 +54,6 @@ import io.getstream.chat.android.client.api2.model.requests.AddDeviceRequest
 import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.AddUserGroupMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
-import io.getstream.chat.android.client.api2.model.requests.BlockUserRequest
 import io.getstream.chat.android.client.api2.model.requests.CreatePollRequest
 import io.getstream.chat.android.client.api2.model.requests.CreateUserGroupRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
@@ -93,7 +92,6 @@ import io.getstream.chat.android.client.api2.model.requests.SendEventRequest
 import io.getstream.chat.android.client.api2.model.requests.SendMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.SyncHistoryRequest
 import io.getstream.chat.android.client.api2.model.requests.TruncateChannelRequest
-import io.getstream.chat.android.client.api2.model.requests.UnblockUserRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateChannelPartialRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownRequest
@@ -169,6 +167,8 @@ import io.getstream.chat.android.models.UserGroup
 import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.network.models.BlockUsersRequest
+import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
 import io.getstream.result.Result
@@ -1362,7 +1362,7 @@ constructor(
 
     override fun blockUser(userId: String): Call<UserBlock> {
         return userApi.blockUser(
-            body = BlockUserRequest(userId),
+            body = BlockUsersRequest(userId),
         ).mapDomain { response ->
             response.toDomain()
         }
@@ -1374,7 +1374,7 @@ constructor(
         }
 
     override fun unblockUser(userId: String): Call<Unit> {
-        return userApi.unblockUser(body = UnblockUserRequest(userId)).toUnitCall()
+        return userApi.unblockUser(body = UnblockUsersRequest(userId)).toUnitCall()
     }
 
     override fun partialUpdateUser(id: String, set: Map<String, Any>, unset: List<String>): Call<List<User>> {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
@@ -20,19 +20,19 @@ import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
-import io.getstream.chat.android.client.api2.model.requests.BlockUserRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryUsersRequest
-import io.getstream.chat.android.client.api2.model.requests.UnblockUserRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
-import io.getstream.chat.android.client.api2.model.response.BlockUserResponse
 import io.getstream.chat.android.client.api2.model.response.LiveLocationsResponse
 import io.getstream.chat.android.client.api2.model.response.QueryBlockedUsersResponse
-import io.getstream.chat.android.client.api2.model.response.UnblockUserResponse
 import io.getstream.chat.android.client.api2.model.response.UpdateUsersResponse
 import io.getstream.chat.android.client.api2.model.response.UsersResponse
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.BlockUsersRequest
+import io.getstream.chat.android.network.models.BlockUsersResponse
+import io.getstream.chat.android.network.models.UnblockUsersRequest
+import io.getstream.chat.android.network.models.UnblockUsersResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -51,10 +51,10 @@ internal interface UserApi {
 
     @POST("/users/block")
     @JvmSuppressWildcards
-    fun blockUser(@Body body: BlockUserRequest): RetrofitCall<BlockUserResponse>
+    fun blockUser(@Body body: BlockUsersRequest): RetrofitCall<BlockUsersResponse>
 
     @POST("/users/unblock")
-    fun unblockUser(@Body body: UnblockUserRequest): RetrofitCall<UnblockUserResponse>
+    fun unblockUser(@Body body: UnblockUsersRequest): RetrofitCall<UnblockUsersResponse>
 
     @GET("/users/block")
     fun queryBlockedUsers(): RetrofitCall<QueryBlockedUsersResponse>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -66,7 +66,6 @@ import io.getstream.chat.android.client.api2.model.dto.UnreadThreadDto
 import io.getstream.chat.android.client.api2.model.response.AppDto
 import io.getstream.chat.android.client.api2.model.response.AppSettingsResponse
 import io.getstream.chat.android.client.api2.model.response.BannedUserResponse
-import io.getstream.chat.android.client.api2.model.response.BlockUserResponse
 import io.getstream.chat.android.client.api2.model.response.FileUploadConfigDto
 import io.getstream.chat.android.client.api2.model.response.MessageResponse
 import io.getstream.chat.android.client.api2.model.response.QueryPollVotesResponse
@@ -137,6 +136,7 @@ import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.models.querysort.SortDirection
+import io.getstream.chat.android.network.models.BlockUsersResponse
 import java.util.Date
 
 @Suppress("TooManyFunctions", "LargeClass")
@@ -850,12 +850,12 @@ internal class DomainMapping(
     internal fun List<DownstreamUserBlockDto>.toDomain(): List<UserBlock> = map { it.toDomain() }
 
     /**
-     * Transforms [BlockUserResponse] into [UserBlock].
+     * Transforms [BlockUsersResponse] into [UserBlock].
      */
-    internal fun BlockUserResponse.toDomain(): UserBlock = UserBlock(
-        blockedBy = blocked_by_user_id,
-        userId = blocked_user_id,
-        blockedAt = created_at,
+    internal fun BlockUsersResponse.toDomain(): UserBlock = UserBlock(
+        blockedBy = blockedByUserId,
+        userId = blockedUserId,
+        blockedAt = createdAt,
     )
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/BlockUsersRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/BlockUsersRequest.kt
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.response
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
-import java.util.Date
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
 
 /**
- * Model representing the response from blocking a user.
  *
- * @param blocked_by_user_id The ID of the user who blocked the other user.
- * @param blocked_user_id The ID of the user who was blocked.
- * @param created_at The date when the block was created.
  */
-@JsonClass(generateAdapter = true)
-internal data class BlockUserResponse(
-    val blocked_by_user_id: String,
-    val blocked_user_id: String,
-    val created_at: Date,
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class BlockUsersRequest(
+    @Json(name = "blocked_user_id")
+    val blockedUserId: kotlin.String,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/BlockUsersResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/BlockUsersResponse.kt
@@ -14,11 +14,32 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class BlockUserRequest(
-    val blocked_user_id: String,
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class BlockUsersResponse(
+    @Json(name = "blocked_by_user_id")
+    val blockedByUserId: kotlin.String,
+
+    @Json(name = "blocked_user_id")
+    val blockedUserId: kotlin.String,
+
+    @Json(name = "created_at")
+    val createdAt: java.util.Date,
+
+    @Json(name = "duration")
+    val duration: kotlin.String,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UnblockUsersRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UnblockUsersRequest.kt
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.response
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class UnblockUserResponse(
-    val duration: String,
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class UnblockUsersRequest(
+    @Json(name = "blocked_user_id")
+    val blockedUserId: kotlin.String,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UnblockUsersResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UnblockUsersResponse.kt
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class UnblockUserRequest(
-    val blocked_user_id: String,
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class UnblockUsersResponse(
+    @Json(name = "duration")
+    val duration: kotlin.String,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -70,7 +70,6 @@ import io.getstream.chat.android.client.api2.model.dto.UnreadThreadDto
 import io.getstream.chat.android.client.api2.model.response.AppDto
 import io.getstream.chat.android.client.api2.model.response.AppSettingsResponse
 import io.getstream.chat.android.client.api2.model.response.BannedUserResponse
-import io.getstream.chat.android.client.api2.model.response.BlockUserResponse
 import io.getstream.chat.android.client.api2.model.response.DraftMessageResponse
 import io.getstream.chat.android.client.api2.model.response.FileUploadConfigDto
 import io.getstream.chat.android.client.api2.model.response.QueryDraftMessagesResponse
@@ -79,7 +78,6 @@ import io.getstream.chat.android.client.api2.model.response.QueryPollsResponse
 import io.getstream.chat.android.client.api2.model.response.QueryRemindersResponse
 import io.getstream.chat.android.client.api2.model.response.SocketErrorResponse
 import io.getstream.chat.android.client.api2.model.response.TokenResponse
-import io.getstream.chat.android.client.api2.model.response.UnblockUserResponse
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.UserPresenceChangedEvent
 import io.getstream.chat.android.client.logger.ChatLogLevel
@@ -104,6 +102,8 @@ import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.network.models.BlockUsersResponse
+import io.getstream.chat.android.network.models.UnblockUsersResponse
 import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.positiveRandomLong
 import io.getstream.chat.android.randomBoolean
@@ -1066,18 +1066,20 @@ internal object Mother {
         created_at = createdAt,
     )
 
-    fun randomBlockUserResponse(
+    fun randomBlockUsersResponse(
         blockedByUserId: String = randomString(),
         blockedUserId: String = randomString(),
         createdAt: Date = randomDate(),
-    ): BlockUserResponse = BlockUserResponse(
-        blocked_by_user_id = blockedByUserId,
-        blocked_user_id = blockedUserId,
-        created_at = createdAt,
+        duration: String = randomString(),
+    ): BlockUsersResponse = BlockUsersResponse(
+        blockedByUserId = blockedByUserId,
+        blockedUserId = blockedUserId,
+        createdAt = createdAt,
+        duration = duration,
     )
 
-    fun randomUnblockUserResponse(duration: String = randomString()): UnblockUserResponse =
-        UnblockUserResponse(duration)
+    fun randomUnblockUsersResponse(duration: String = randomString()): UnblockUsersResponse =
+        UnblockUsersResponse(duration)
 
     fun randomTokenResponse(
         user: DownstreamUserDto = randomDownstreamUserDto(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -50,7 +50,6 @@ import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddDeviceRequest
 import io.getstream.chat.android.client.api2.model.requests.AddUserGroupMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
-import io.getstream.chat.android.client.api2.model.requests.BlockUserRequest
 import io.getstream.chat.android.client.api2.model.requests.CreatePollRequest
 import io.getstream.chat.android.client.api2.model.requests.CreateUserGroupRequest
 import io.getstream.chat.android.client.api2.model.requests.DeliveredMessageDto
@@ -81,7 +80,6 @@ import io.getstream.chat.android.client.api2.model.requests.ReminderRequest
 import io.getstream.chat.android.client.api2.model.requests.RemoveUserGroupMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.SendActionRequest
 import io.getstream.chat.android.client.api2.model.requests.SendEventRequest
-import io.getstream.chat.android.client.api2.model.requests.UnblockUserRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateChannelPartialRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
@@ -92,7 +90,6 @@ import io.getstream.chat.android.client.api2.model.requests.UpsertPushPreference
 import io.getstream.chat.android.client.api2.model.requests.UpstreamOptionDto
 import io.getstream.chat.android.client.api2.model.requests.UpstreamVoteDto
 import io.getstream.chat.android.client.api2.model.response.AppSettingsResponse
-import io.getstream.chat.android.client.api2.model.response.BlockUserResponse
 import io.getstream.chat.android.client.api2.model.response.ChannelResponse
 import io.getstream.chat.android.client.api2.model.response.DevicesResponse
 import io.getstream.chat.android.client.api2.model.response.DraftMessageResponse
@@ -128,7 +125,6 @@ import io.getstream.chat.android.client.api2.model.response.ThreadInfoResponse
 import io.getstream.chat.android.client.api2.model.response.ThreadResponse
 import io.getstream.chat.android.client.api2.model.response.TokenResponse
 import io.getstream.chat.android.client.api2.model.response.TranslateMessageRequest
-import io.getstream.chat.android.client.api2.model.response.UnblockUserResponse
 import io.getstream.chat.android.client.api2.model.response.UpdateUsersResponse
 import io.getstream.chat.android.client.api2.model.response.UserGroupResponse
 import io.getstream.chat.android.client.api2.model.response.UserGroupsResponse
@@ -168,7 +164,11 @@ import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.ascByName
 import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.descByName
+import io.getstream.chat.android.network.models.BlockUsersRequest
+import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.Response
+import io.getstream.chat.android.network.models.UnblockUsersRequest
+import io.getstream.chat.android.network.models.UnblockUsersResponse
 import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
@@ -1727,7 +1727,7 @@ internal class MoshiChatApiTest {
 
     @ParameterizedTest
     @MethodSource("io.getstream.chat.android.client.api2.MoshiChatApiTestArguments#blockUserInput")
-    fun testBlockUser(call: RetrofitCall<BlockUserResponse>, expected: KClass<*>) = runTest {
+    fun testBlockUser(call: RetrofitCall<BlockUsersResponse>, expected: KClass<*>) = runTest {
         // given
         val api = mock<UserApi>()
         whenever(api.blockUser(any())).doReturn(call)
@@ -1738,14 +1738,14 @@ internal class MoshiChatApiTest {
         val targetId = randomString()
         val result = sut.blockUser(targetId).await()
         // then
-        val expectedBody = BlockUserRequest(targetId)
+        val expectedBody = BlockUsersRequest(targetId)
         result `should be instance of` expected
         verify(api, times(1)).blockUser(expectedBody)
     }
 
     @ParameterizedTest
     @MethodSource("io.getstream.chat.android.client.api2.MoshiChatApiTestArguments#unblockUserInput")
-    fun testUnblockUser(call: RetrofitCall<UnblockUserResponse>, expected: KClass<*>) = runTest {
+    fun testUnblockUser(call: RetrofitCall<UnblockUsersResponse>, expected: KClass<*>) = runTest {
         // given
         val api = mock<UserApi>()
         whenever(api.unblockUser(any())).doReturn(call)
@@ -1756,7 +1756,7 @@ internal class MoshiChatApiTest {
         val targetId = randomString()
         val result = sut.unblockUser(targetId).await()
         // then
-        val expectedBody = UnblockUserRequest(targetId)
+        val expectedBody = UnblockUsersRequest(targetId)
         result `should be instance of` expected
         verify(api, times(1)).unblockUser(expectedBody)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
@@ -33,7 +33,6 @@ import io.getstream.chat.android.client.api2.model.dto.utils.internal.ExactDate
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateMemberPartialResponse
 import io.getstream.chat.android.client.api2.model.response.AppSettingsResponse
-import io.getstream.chat.android.client.api2.model.response.BlockUserResponse
 import io.getstream.chat.android.client.api2.model.response.ChannelResponse
 import io.getstream.chat.android.client.api2.model.response.DevicesResponse
 import io.getstream.chat.android.client.api2.model.response.EventResponse
@@ -78,7 +77,9 @@ import io.getstream.chat.android.models.UnreadChannelByType
 import io.getstream.chat.android.models.UnreadCounts
 import io.getstream.chat.android.models.UnreadThread
 import io.getstream.chat.android.models.UploadedFile
+import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.Response
+import io.getstream.chat.android.network.models.UnblockUsersResponse
 import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomDate
@@ -382,14 +383,14 @@ internal object MoshiChatApiTestArguments {
 
     @JvmStatic
     fun blockUserInput() = listOf(
-        Arguments.of(RetroSuccess(Mother.randomBlockUserResponse()).toRetrofitCall(), Result.Success::class),
-        Arguments.of(RetroError<BlockUserResponse>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
+        Arguments.of(RetroSuccess(Mother.randomBlockUsersResponse()).toRetrofitCall(), Result.Success::class),
+        Arguments.of(RetroError<BlockUsersResponse>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
     )
 
     @JvmStatic
     fun unblockUserInput() = listOf(
-        Arguments.of(RetroSuccess(Mother.randomUnblockUserResponse()).toRetrofitCall(), Result.Success::class),
-        Arguments.of(RetroError<BlockUserResponse>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
+        Arguments.of(RetroSuccess(Mother.randomUnblockUsersResponse()).toRetrofitCall(), Result.Success::class),
+        Arguments.of(RetroError<UnblockUsersResponse>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
     )
 
     @JvmStatic

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -23,7 +23,7 @@ import io.getstream.chat.android.client.Mother.randomAnswerDownstreamVoteDto
 import io.getstream.chat.android.client.Mother.randomAppSettingsResponse
 import io.getstream.chat.android.client.Mother.randomAttachmentDto
 import io.getstream.chat.android.client.Mother.randomBannedUserResponse
-import io.getstream.chat.android.client.Mother.randomBlockUserResponse
+import io.getstream.chat.android.client.Mother.randomBlockUsersResponse
 import io.getstream.chat.android.client.Mother.randomChannelInfoDto
 import io.getstream.chat.android.client.Mother.randomCommandDto
 import io.getstream.chat.android.client.Mother.randomConfigDto
@@ -896,14 +896,14 @@ internal class DomainMappingTest {
     }
 
     @Test
-    fun `BlockUserResponse is correctly mapped to UserBlock`() {
-        val blockUserResponse = randomBlockUserResponse()
+    fun `BlockUsersResponse is correctly mapped to UserBlock`() {
+        val blockUsersResponse = randomBlockUsersResponse()
         val sut = Fixture().get()
-        val userBlock = with(sut) { blockUserResponse.toDomain() }
+        val userBlock = with(sut) { blockUsersResponse.toDomain() }
         val expected = UserBlock(
-            blockedBy = blockUserResponse.blocked_by_user_id,
-            userId = blockUserResponse.blocked_user_id,
-            blockedAt = blockUserResponse.created_at,
+            blockedBy = blockUsersResponse.blockedByUserId,
+            userId = blockUsersResponse.blockedUserId,
+            blockedAt = blockUsersResponse.createdAt,
         )
         assertEquals(expected, userBlock)
     }


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the `/users/block` and `/users/unblock` endpoints to generated request/response models. Part of the incremental OpenAPI model migration: generated models keep their generated package (`io.getstream.chat.android.network.models`) as `internal` classes inside the client module, one endpoint at a time.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Add generated `BlockUsersRequest`, `BlockUsersResponse`, `UnblockUsersRequest`, `UnblockUsersResponse` and delete the four hand-written DTOs.
- Point `UserApi`, `MoshiChatApi`, and the `toDomain()` mapper at the generated types (real names, no import aliases), updating field access to the generated camelCase names.
- `queryBlockedUsers` is left untouched (independent). Also fixes a pre-existing copy-paste where the unblock test argument used the block response type.

### Testing

- Project-wide `spotlessApply`, `apiDump` (no API drift), `lint`, `detekt`, and `testDebugUnitTest` all pass.
- Verified on device: block a real user, confirm the id round-trips through request -> response (`UserBlock`), then unblock succeeds.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated user blocking and unblocking support to work with the latest API format.
  * Block/unblock actions now handle the newer response details, including duration information where available.

* **Tests**
  * Refreshed automated coverage to match the updated block/unblock behavior and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->