### PR TITLE
client: Port grouped-channels tests to EventHandlerSequentialTest

### DIFF
--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequentialTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequentialTest.kt
@@ -41,6 +41,7 @@ import io.getstream.chat.android.client.test.randomNotificationMarkReadEvent
 import io.getstream.chat.android.client.test.randomNotificationMarkUnreadEvent
 import io.getstream.chat.android.client.test.randomNotificationMessageNewEvent
 import io.getstream.chat.android.client.test.randomNotificationMutesUpdatedEvent
+import io.getstream.chat.android.client.test.randomNotificationRemovedFromChannelEvent
 import io.getstream.chat.android.client.test.randomPollDeletedEvent
 import io.getstream.chat.android.client.test.randomThreadUpdatedEvent
 import io.getstream.chat.android.client.utils.observable.Disposable
@@ -55,6 +56,7 @@ import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomChannel
 import io.getstream.chat.android.randomChannelMute
 import io.getstream.chat.android.randomLocation
+import io.getstream.chat.android.randomMember
 import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomMute
 import io.getstream.chat.android.randomPoll
@@ -134,6 +136,163 @@ internal class EventHandlerSequentialTest {
         handler.handleEvents(*events.toTypedArray())
 
         mutableGlobalState.groupedUnreadChannels.value `should be equal to` expectedGroupedUnreadChannels
+    }
+
+    @Test
+    fun `ChannelUpdatedEvent migrates grouped unread count when group field changes`() = runTest {
+        val cid = "messaging:channel-id"
+        val mutableGlobalState = MutableGlobalState(currentUser.id).apply {
+            setGroupedUnreadChannels(mapOf("a" to 1, "b" to 0))
+        }
+        val newChannel = randomChannel(
+            id = "channel-id",
+            type = "messaging",
+            extraData = mapOf("group" to "b"),
+        )
+        val handler = Fixture()
+            .withCurrentUser(currentUser)
+            .withMutableGlobalState(mutableGlobalState)
+            .withActiveChannel(
+                channelType = "messaging",
+                channelId = "channel-id",
+                extraData = mapOf("group" to "a"),
+                unreadMessages = 1,
+            )
+            .get(this)
+
+        handler.handleEvents(randomChannelUpdatedEvent(cid = cid, channel = newChannel))
+
+        mutableGlobalState.groupedUnreadChannels.value `should be equal to` mapOf("a" to 0, "b" to 1)
+    }
+
+    @Test
+    fun `Two ChannelUpdatedEvents for same cid in one batch apply the migration only once`() = runTest {
+        val cid = "messaging:channel-id"
+        val mutableGlobalState = MutableGlobalState(currentUser.id).apply {
+            setGroupedUnreadChannels(mapOf("a" to 2, "b" to 0))
+        }
+        val newChannel = randomChannel(
+            id = "channel-id",
+            type = "messaging",
+            extraData = mapOf("group" to "b"),
+        )
+        val handler = Fixture()
+            .withCurrentUser(currentUser)
+            .withMutableGlobalState(mutableGlobalState)
+            .withActiveChannel(
+                channelType = "messaging",
+                channelId = "channel-id",
+                extraData = mapOf("group" to "a"),
+                unreadMessages = 1,
+            )
+            .get(this)
+
+        handler.handleEvents(
+            randomChannelUpdatedEvent(cid = cid, channel = newChannel),
+            randomChannelUpdatedEvent(cid = cid, channel = newChannel),
+        )
+
+        // Without dedup the delta would be applied twice -> {"a" to 0, "b" to 2}.
+        mutableGlobalState.groupedUnreadChannels.value `should be equal to` mapOf("a" to 1, "b" to 1)
+    }
+
+    @Test
+    fun `NotificationRemovedFromChannelEvent before ChannelUpdatedEvent same cid suppresses migration`() = runTest {
+        val cid = "messaging:channel-id"
+        val mutableGlobalState = MutableGlobalState(currentUser.id).apply {
+            setGroupedUnreadChannels(mapOf("a" to 1, "b" to 0))
+        }
+        val newChannel = randomChannel(
+            id = "channel-id",
+            type = "messaging",
+            extraData = mapOf("group" to "b"),
+        )
+        val handler = Fixture()
+            .withCurrentUser(currentUser)
+            .withMutableGlobalState(mutableGlobalState)
+            .withActiveChannel(
+                channelType = "messaging",
+                channelId = "channel-id",
+                extraData = mapOf("group" to "a"),
+                unreadMessages = 1,
+            )
+            .get(this)
+
+        handler.handleEvents(
+            randomNotificationRemovedFromChannelEvent(cid = cid, member = randomMember(user = currentUser)),
+            randomChannelUpdatedEvent(cid = cid, channel = newChannel),
+        )
+
+        // Removed-from-channel marks the cid as destroyed for this batch, so the subsequent
+        // channel.updated delta does not migrate counts.
+        mutableGlobalState.groupedUnreadChannels.value `should be equal to` mapOf("a" to 1, "b" to 0)
+    }
+
+    @Test
+    fun `NotificationMarkReadEvent before ChannelUpdatedEvent same cid does not double-apply delta`() = runTest {
+        val cid = "messaging:channel-id"
+        val mutableGlobalState = MutableGlobalState(currentUser.id).apply {
+            setGroupedUnreadChannels(mapOf("a" to 1, "b" to 0))
+        }
+        val newChannel = randomChannel(
+            id = "channel-id",
+            type = "messaging",
+            extraData = mapOf("group" to "b"),
+        )
+        val handler = Fixture()
+            .withCurrentUser(currentUser)
+            .withMutableGlobalState(mutableGlobalState)
+            .withActiveChannel(
+                channelType = "messaging",
+                channelId = "channel-id",
+                extraData = mapOf("group" to "a"),
+                unreadMessages = 1,
+            )
+            .get(this)
+
+        // HGUC mark_read carries authoritative {a:0, b:0}; channel.updated must NOT then dec a/inc b
+        // on top (the channel is now read).
+        handler.handleEvents(
+            randomNotificationMarkReadEvent(
+                cid = cid,
+                user = currentUser,
+                groupedUnreadChannels = mapOf("a" to 0, "b" to 0),
+            ),
+            randomChannelUpdatedEvent(cid = cid, channel = newChannel),
+        )
+
+        mutableGlobalState.groupedUnreadChannels.value `should be equal to` mapOf("a" to 0, "b" to 0)
+    }
+
+    @Test
+    fun `MarkAllReadEvent before ChannelUpdatedEvent suppresses migration`() = runTest {
+        val cid = "messaging:channel-id"
+        val mutableGlobalState = MutableGlobalState(currentUser.id).apply {
+            setGroupedUnreadChannels(mapOf("a" to 1, "b" to 0))
+        }
+        val newChannel = randomChannel(
+            id = "channel-id",
+            type = "messaging",
+            extraData = mapOf("group" to "b"),
+        )
+        val handler = Fixture()
+            .withCurrentUser(currentUser)
+            .withMutableGlobalState(mutableGlobalState)
+            .withActiveChannel(
+                channelType = "messaging",
+                channelId = "channel-id",
+                extraData = mapOf("group" to "a"),
+                unreadMessages = 1,
+            )
+            .get(this)
+
+        handler.handleEvents(
+            randomMarkAllReadEvent(user = currentUser),
+            randomChannelUpdatedEvent(cid = cid, channel = newChannel),
+        )
+
+        // MarkAllRead conceptually clears unread on all channels; delta no-ops despite stale cache.
+        mutableGlobalState.groupedUnreadChannels.value `should be equal to` mapOf("a" to 1, "b" to 0)
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!-- pr:test -->

### Goal

PR #6516 ported the grouped-channels feature from V6 (#6437) to develop, but a small set of net-new V6 tests in `EventHandlerSequentialTest` were deferred.

Closes [AND-1261](https://linear.app/stream/issue/AND-1261/port-deferred-v6-grouped-channels-tests-to-develop)

### Implementation

- Ported 5 grouped-unread-count test cases verbatim from V6 (commit `bfdc97edcf`) covering `channel.updated` group migration, per-batch dedup, and suppression by `NotificationRemovedFromChannel` / `NotificationMarkRead` / `MarkAllRead` events.

### Testing

- `:stream-chat-android-client:testDebugUnitTest` for `EventHandlerSequentialTest`: 46 tests, 0 failures, all 5 new cases pass.
- Spotless and Detekt pass on the module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for unread-count updates when a channel’s group changes.
  * Verified correct handling when multiple channel updates occur together, including deduplication.
  * Confirmed unread counts are not incorrectly adjusted after earlier remove, mark-read, or mark-all-read events in the same batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->