### PR TITLE
compose: Anchor the audio recording hint above the composer in threads

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -2035,15 +2035,17 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/Compos
 	public final fun getLambda$-1267828661$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1344661276$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1483541199$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-17156589$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-173232017$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1908203637$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$1180759242$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1309976052$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1434062186$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$278788378$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$309759556$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$419456890$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$667073716$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$851409439$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$974985920$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/MessageComposerKt {
@@ -2092,10 +2094,8 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/intern
 	public fun <init> ()V
 	public final fun getLambda$-585591518$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$146509517$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1828592956$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$266592135$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$79147160$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$921498771$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$AudioRecordingContentKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.SnackbarData
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -54,6 +55,8 @@ import io.getstream.chat.android.compose.ui.messages.composer.internal.suggestio
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ComposerConfig
 import io.getstream.chat.android.compose.ui.theme.LocalChatUiConfig
+import io.getstream.chat.android.compose.ui.theme.MessageComposerAudioRecordingHintParams
+import io.getstream.chat.android.compose.ui.theme.MessageComposerAudioRecordingPermissionRationaleParams
 import io.getstream.chat.android.compose.ui.theme.MessageComposerInputParams
 import io.getstream.chat.android.compose.ui.theme.MessageComposerLeadingContentParams
 import io.getstream.chat.android.compose.ui.theme.MessageComposerParams
@@ -228,6 +231,22 @@ internal val LocalMessageComposerSnackbarHostState =
     staticCompositionLocalOf<SnackbarHostState?> { null }
 
 /**
+ * Hands the audio recording hint's [SnackbarHostState] from the composer to the mic button, so the
+ * hint popup is rendered by the composer (anchored above it) while the mic button drives showing and
+ * dismissing it. This keeps the hint anchored to the composer's top rather than the mic button,
+ * which sits lower when the composer is taller (e.g. the "Also send in Channel" row in a thread).
+ */
+internal val LocalMessageComposerRecordingHintHostState =
+    staticCompositionLocalOf<SnackbarHostState?> { null }
+
+/**
+ * Hands the audio recording permission rationale's [SnackbarHostState] from the composer to the mic
+ * button, for the same reason as [LocalMessageComposerRecordingHintHostState].
+ */
+internal val LocalMessageComposerRecordingRationaleHostState =
+    staticCompositionLocalOf<SnackbarHostState?> { null }
+
+/**
  * Clean version of the [MessageComposer] that doesn't rely on ViewModels, so the user can provide a
  * manual way to handle and represent data and various operations.
  *
@@ -311,6 +330,10 @@ public fun MessageComposer(
     }
     val commandSuggestions = messageComposerState.commandSuggestions
     val snackbarHostState = LocalMessageComposerSnackbarHostState.current ?: remember { SnackbarHostState() }
+    val recordingHintHostState =
+        LocalMessageComposerRecordingHintHostState.current ?: remember { SnackbarHostState() }
+    val recordingRationaleHostState =
+        LocalMessageComposerRecordingRationaleHostState.current ?: remember { SnackbarHostState() }
 
     MessageInputValidationError(
         validationErrors = validationErrors,
@@ -339,46 +362,93 @@ public fun MessageComposer(
             }
         }
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = StreamTokens.spacingMd,
-                    end = StreamTokens.spacingMd,
-                    top = if (ChatTheme.config.composer.floatingStyleEnabled) {
-                        0.dp
-                    } else {
-                        StreamTokens.spacingMd
-                    },
-                    bottom = StreamTokens.spacingMd,
-                ),
-            verticalAlignment = Bottom,
+        CompositionLocalProvider(
+            LocalMessageComposerRecordingHintHostState provides recordingHintHostState,
+            LocalMessageComposerRecordingRationaleHostState provides recordingRationaleHostState,
         ) {
-            ChatTheme.componentFactory.MessageComposerLeadingContent(
-                params = MessageComposerLeadingContentParams(
-                    state = messageComposerState,
-                    isAttachmentPickerVisible = isAttachmentPickerVisible,
-                    onAttachmentsClick = onAttachmentsClick,
-                    onAttachmentsClickLabel = attachmentsActionLabel,
-                ),
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = StreamTokens.spacingMd,
+                        end = StreamTokens.spacingMd,
+                        top = if (ChatTheme.config.composer.floatingStyleEnabled) {
+                            0.dp
+                        } else {
+                            StreamTokens.spacingMd
+                        },
+                        bottom = StreamTokens.spacingMd,
+                    ),
+                verticalAlignment = Bottom,
+            ) {
+                ChatTheme.componentFactory.MessageComposerLeadingContent(
+                    params = MessageComposerLeadingContentParams(
+                        state = messageComposerState,
+                        isAttachmentPickerVisible = isAttachmentPickerVisible,
+                        onAttachmentsClick = onAttachmentsClick,
+                        onAttachmentsClickLabel = attachmentsActionLabel,
+                    ),
+                )
 
-            input(messageComposerState)
+                input(messageComposerState)
 
-            ChatTheme.componentFactory.MessageComposerTrailingContent(
-                params = MessageComposerTrailingContentParams(
-                    state = messageComposerState,
-                ),
-            )
+                ChatTheme.componentFactory.MessageComposerTrailingContent(
+                    params = MessageComposerTrailingContentParams(
+                        state = messageComposerState,
+                    ),
+                )
 
-            if (snackbarHostState.currentSnackbarData != null) {
-                SnackbarPopup(hostState = snackbarHostState) { snackbarData ->
-                    ChatTheme.componentFactory.MessageComposerSnackbar(
-                        params = MessageComposerSnackbarParams(data = snackbarData),
-                    )
-                }
+                // Snackbars are children of the composer row so they anchor above the composer.
+                MessageComposerSnackbars(
+                    snackbarHostState = snackbarHostState,
+                    recordingHintHostState = recordingHintHostState,
+                    recordingRationaleHostState = recordingRationaleHostState,
+                )
             }
         }
+    }
+}
+
+/**
+ * The snackbars shown above the composer: the event-driven composer snackbar, the audio recording
+ * hint, and the audio recording permission rationale. All are rendered inside the composer row so
+ * they anchor above the composer; the two recording ones are driven by the mic button via their
+ * composition locals.
+ */
+@Composable
+private fun MessageComposerSnackbars(
+    snackbarHostState: SnackbarHostState,
+    recordingHintHostState: SnackbarHostState,
+    recordingRationaleHostState: SnackbarHostState,
+) {
+    ComposerSnackbar(snackbarHostState) { snackbarData ->
+        ChatTheme.componentFactory.MessageComposerSnackbar(
+            params = MessageComposerSnackbarParams(data = snackbarData),
+        )
+    }
+    ComposerSnackbar(recordingHintHostState) { snackbarData ->
+        ChatTheme.componentFactory.MessageComposerAudioRecordingHint(
+            params = MessageComposerAudioRecordingHintParams(snackbarData),
+        )
+    }
+    ComposerSnackbar(recordingRationaleHostState) { snackbarData ->
+        ChatTheme.componentFactory.MessageComposerAudioRecordingPermissionRationale(
+            params = MessageComposerAudioRecordingPermissionRationaleParams(snackbarData),
+        )
+    }
+}
+
+/**
+ * A composer snackbar rendered only while [hostState] has data, so the popup measures its real size
+ * and anchors above the composer instead of appearing at a zero-size spot.
+ */
+@Composable
+private fun ComposerSnackbar(
+    hostState: SnackbarHostState,
+    snackbar: @Composable (SnackbarData) -> Unit,
+) {
+    if (hostState.currentSnackbarData != null) {
+        SnackbarPopup(hostState = hostState, snackbar = snackbar)
     }
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingButton.kt
@@ -70,14 +70,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.messages.composer.LocalMessageComposerRecordingHintHostState
 import io.getstream.chat.android.compose.ui.messages.composer.actions.AudioRecordingActions
 import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageComposerAudioRecordingFloatingLockIconParams
-import io.getstream.chat.android.compose.ui.theme.MessageComposerAudioRecordingHintParams
-import io.getstream.chat.android.compose.ui.theme.MessageComposerAudioRecordingPermissionRationaleParams
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
-import io.getstream.chat.android.compose.ui.util.SnackbarPopup
 import io.getstream.chat.android.compose.ui.util.applyIf
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.state.messages.composer.RecordingState
@@ -360,38 +358,8 @@ private fun MicButtonGestureArea(
             MicButtonVisual(interactionSource = interactionSource)
         }
     }
-
-    RecordingSnackbars(
-        hintHostState = hint.snackbarHostState,
-        rationaleHostState = permissionState.rationaleSnackbarHostState,
-    )
-}
-
-@Composable
-private fun RecordingSnackbars(
-    hintHostState: SnackbarHostState,
-    rationaleHostState: SnackbarHostState,
-) {
-    if (hintHostState.currentSnackbarData != null) {
-        SnackbarPopup(
-            hostState = hintHostState,
-            snackbar = {
-                ChatTheme.componentFactory.MessageComposerAudioRecordingHint(
-                    params = MessageComposerAudioRecordingHintParams(it),
-                )
-            },
-        )
-    }
-    if (rationaleHostState.currentSnackbarData != null) {
-        SnackbarPopup(
-            hostState = rationaleHostState,
-            snackbar = {
-                ChatTheme.componentFactory.MessageComposerAudioRecordingPermissionRationale(
-                    params = MessageComposerAudioRecordingPermissionRationaleParams(it),
-                )
-            },
-        )
-    }
+    // The recording hint and permission rationale popups are rendered by the composer (anchored
+    // above it); the mic button only drives them via the hoisted hosts.
 }
 
 /** Emits press/release interactions on [interactionSource] while [isPressed] is true. */
@@ -467,7 +435,8 @@ private class RecordingHintState(
 
 @Composable
 private fun rememberRecordingHint(): RecordingHintState {
-    val snackbarHostState = remember { SnackbarHostState() }
+    // Use the host provided by the composer so the hint popup is anchored above the composer.
+    val snackbarHostState = LocalMessageComposerRecordingHintHostState.current ?: remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val sendOnComplete = ChatTheme.config.composer.audioRecordingSendOnComplete
     val message = stringResource(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingPermission.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingPermission.kt
@@ -35,6 +35,7 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import io.getstream.chat.android.compose.ui.components.SimpleDialog
+import io.getstream.chat.android.compose.ui.messages.composer.LocalMessageComposerRecordingRationaleHostState
 import io.getstream.chat.android.ui.common.utils.openSystemSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -55,7 +56,6 @@ internal fun rememberAudioRecordingPermission(): AudioRecordingPermission {
                 statusProvider = { PermissionStatus.Granted },
                 launchPermissionRequest = {},
                 showRationale = {},
-                rationaleSnackbarHostState = SnackbarHostState(),
             )
         }
     }
@@ -81,7 +81,6 @@ internal fun rememberAudioRecordingPermission(): AudioRecordingPermission {
             statusProvider = { state.status },
             launchPermissionRequest = { state.launchPermissionRequest() },
             showRationale = { rationaleState.show() },
-            rationaleSnackbarHostState = rationaleState.snackbarHostState,
         )
     }
 }
@@ -91,7 +90,6 @@ internal class AudioRecordingPermission(
     private val statusProvider: () -> PermissionStatus,
     val launchPermissionRequest: () -> Unit,
     val showRationale: () -> Unit,
-    val rationaleSnackbarHostState: SnackbarHostState,
 ) {
     /** Current permission status, read fresh on every access. */
     val status: PermissionStatus get() = statusProvider()
@@ -138,7 +136,8 @@ private class PermissionRationaleState(
 
 @Composable
 private fun rememberPermissionRationale(): PermissionRationaleState {
-    val snackbarHostState = remember { SnackbarHostState() }
+    // Use the host provided by the composer so the rationale popup is anchored above the composer.
+    val snackbarHostState = LocalMessageComposerRecordingRationaleHostState.current ?: remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val message = stringResource(UiCommonR.string.stream_ui_message_composer_permission_audio_record_message)

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/messages/composer/MessageComposerScreenTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/messages/composer/MessageComposerScreenTest.kt
@@ -17,6 +17,10 @@
 package io.getstream.chat.android.compose.ui.messages.composer
 
 import androidx.annotation.UiThread
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasText
@@ -140,6 +144,48 @@ internal class MessageComposerScreenTest : MockedChatClientTest {
 
         composeTestRule.onNodeWithTag(ComposerInputTestTag).assertIsEnabled()
         composeTestRule.onNodeWithTag("Stream_ComposerAttachmentsButton").assertIsEnabled()
+    }
+
+    @Test
+    @UiThread
+    fun `audio recording hint is rendered by the composer`() {
+        whenever(mockViewModel.messageComposerState) doReturn MutableStateFlow(MessageComposerState())
+        val hintHost = SnackbarHostState()
+        val hintMessage = "Hold to record. Release to save."
+
+        composeTestRule.setContent {
+            ChatTheme {
+                CompositionLocalProvider(LocalMessageComposerRecordingHintHostState provides hintHost) {
+                    MessageComposer(viewModel = mockViewModel)
+                }
+                LaunchedEffect(Unit) { hintHost.showSnackbar(hintMessage, duration = SnackbarDuration.Indefinite) }
+            }
+        }
+
+        // The composer, not the mic button, renders the hint from the provided host, so it anchors
+        // above the composer.
+        composeTestRule.onNodeWithText(hintMessage).assertExists()
+    }
+
+    @Test
+    @UiThread
+    fun `audio recording permission rationale is rendered by the composer`() {
+        whenever(mockViewModel.messageComposerState) doReturn MutableStateFlow(MessageComposerState())
+        val rationaleHost = SnackbarHostState()
+        val rationaleMessage = "Microphone permission is required."
+
+        composeTestRule.setContent {
+            ChatTheme {
+                CompositionLocalProvider(LocalMessageComposerRecordingRationaleHostState provides rationaleHost) {
+                    MessageComposer(viewModel = mockViewModel)
+                }
+                LaunchedEffect(Unit) {
+                    rationaleHost.showSnackbar(rationaleMessage, duration = SnackbarDuration.Indefinite)
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText(rationaleMessage).assertExists()
     }
 
     @Test


### PR DESCRIPTION
### Goal

When recording a voice message inside a thread, the recording hint ("Hold to record. Release to save.") and the microphone permission rationale appeared over the composer content instead of above the composer. In a thread the composer is taller (it shows the parent message and the "Also send in Channel" row), so the hint popup, which was anchored to the microphone button, landed too low and overlapped the composer.

Resolves AND-1292

### Implementation

The recording hint and the permission rationale are now rendered by the composer itself, using snackbar hosts provided through composition locals, so they anchor above the composer regardless of the composer height. This mirrors how the validation-error snackbar is already rendered by the composer.

- `MessageComposer` creates the two hosts, provides them via `LocalMessageComposerRecordingHintHostState` and `LocalMessageComposerRecordingRationaleHostState`, and renders all three composer snackbars (validation error, recording hint, permission rationale) in one place.
- `AudioRecordingButton` reads the hint host from the local instead of creating its own host and rendering the snackbar itself.
- `AudioRecordingPermission` reads the rationale host from the local.

### 🎨 UI Changes

#### Docked style

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="before_thread_recording_hint_docked" src="https://github.com/user-attachments/assets/ae3eaa45-316a-4740-bc5f-f376669613f1" /> | <img width="1080" height="2400" alt="after_thread_recording_hint_docked" src="https://github.com/user-attachments/assets/75cf12fb-68c2-4227-b9b6-c408232e71d7" /> |

#### Floating style

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="before_thread_recording_hint" src="https://github.com/user-attachments/assets/91068f37-417d-4733-8ffa-9f6e999b4a5f" /> | <img width="1080" height="2400" alt="after_thread_recording_hint" src="https://github.com/user-attachments/assets/fa0adcbc-8c47-480d-9f6b-ee80e914c093" /> |

### Testing

1. Open a thread (reply to a message) so the composer shows the parent message and the "Also send in Channel" row.
2. Tap and release the microphone button quickly (a tap, not a hold). The recording hint should appear directly above the composer, not overlapping it.
3. Revoke the microphone permission for the app, then tap the microphone button. The permission rationale snackbar should also appear above the composer.
4. Repeat both steps in a normal (non-thread) channel to confirm the position is unchanged there.

Unit tests: added `audio recording hint is rendered by the composer` and `audio recording permission rationale is rendered by the composer` to `MessageComposerScreenTest`, verifying the composer renders content from the provided hosts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two composer snackbar messages for audio recording: a recording hint and a microphone permission rationale.
  * These messages are now displayed above the message composer, alongside existing composer alerts.

* **Bug Fixes**
  * Improved snackbar placement so audio recording prompts appear in the composer area consistently.
  * Updated recording permission handling to keep the rationale prompt working as expected.

* **Tests**
  * Added UI coverage for both new audio recording snackbar messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->