### PR TITLE
Migrate channel config request bodies to generated models

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -59,12 +59,10 @@ import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagUserRequest
 import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
-import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.InviteMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkDeliveredRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkUnreadRequest
-import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdatePollRequest
@@ -91,7 +89,6 @@ import io.getstream.chat.android.client.api2.model.requests.SendEventRequest
 import io.getstream.chat.android.client.api2.model.requests.SendMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.SyncHistoryRequest
 import io.getstream.chat.android.client.api2.model.requests.TruncateChannelRequest
-import io.getstream.chat.android.client.api2.model.requests.UpdateChannelPartialRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
@@ -168,7 +165,10 @@ import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.CreateDeviceRequest
+import io.getstream.chat.android.network.models.HideChannelRequest
+import io.getstream.chat.android.network.models.MuteChannelRequest
 import io.getstream.chat.android.network.models.UnblockUsersRequest
+import io.getstream.chat.android.network.models.UpdateChannelPartialRequest
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
 import io.getstream.result.Result
@@ -732,7 +732,7 @@ constructor(
     ): Call<Unit> {
         return moderationApi.muteChannel(
             body = MuteChannelRequest(
-                channel_cid = "$channelType:$channelId",
+                channelCids = listOf("$channelType:$channelId"),
                 expiration = expiration,
             ),
         ).toUnitCall()
@@ -744,7 +744,7 @@ constructor(
     ): Call<Unit> {
         return moderationApi.unmuteChannel(
             body = MuteChannelRequest(
-                channel_cid = "$channelType:$channelId",
+                channelCids = listOf("$channelType:$channelId"),
                 expiration = null,
             ),
         ).toUnitCall()
@@ -1075,7 +1075,7 @@ constructor(
         return channelApi.updateChannelPartial(
             channelType = channelType,
             channelId = channelId,
-            body = UpdateChannelPartialRequest(set, unset),
+            body = UpdateChannelPartialRequest(set = set, unset = unset),
         ).map(this::flattenChannel)
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ChannelApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ChannelApi.kt
@@ -21,7 +21,6 @@ import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
-import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.InviteMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkDeliveredRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
@@ -34,7 +33,6 @@ import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.RemoveMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.SendEventRequest
 import io.getstream.chat.android.client.api2.model.requests.TruncateChannelRequest
-import io.getstream.chat.android.client.api2.model.requests.UpdateChannelPartialRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateMemberPartialRequest
@@ -45,7 +43,9 @@ import io.getstream.chat.android.client.api2.model.response.MessagesResponse
 import io.getstream.chat.android.client.api2.model.response.QueryChannelsResponse
 import io.getstream.chat.android.client.api2.model.response.QueryGroupedChannelsResponse
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.Response
+import io.getstream.chat.android.network.models.UpdateChannelPartialRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ModerationApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ModerationApi.kt
@@ -20,13 +20,13 @@ import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagRequest
-import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.response.FlagResponse
 import io.getstream.chat.android.client.api2.model.response.MuteUserResponse
 import io.getstream.chat.android.client.api2.model.response.QueryBannedUsersResponse
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.MuteChannelRequest
 import io.getstream.chat.android.network.models.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/HideChannelRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/HideChannelRequest.kt
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class UpdateChannelPartialRequest(
-    val set: Map<String, Any>,
-    val unset: List<String>,
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class HideChannelRequest(
+    @Json(name = "clear_history")
+    internal val clearHistory: Boolean? = null,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/MuteChannelRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/MuteChannelRequest.kt
@@ -14,12 +14,26 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
 internal data class MuteChannelRequest(
-    val channel_cid: String,
-    val expiration: Int?,
+    @Json(name = "expiration")
+    internal val expiration: Int? = null,
+
+    @Json(name = "channel_cids")
+    internal val channelCids: List<String>? = emptyList(),
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateChannelPartialRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateChannelPartialRequest.kt
@@ -14,11 +14,26 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class HideChannelRequest(
-    val clear_history: Boolean,
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class UpdateChannelPartialRequest(
+    @Json(name = "unset")
+    internal val unset: List<String>? = emptyList(),
+
+    @Json(name = "set")
+    internal val set: Map<String, Any?>? = emptyMap(),
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -55,11 +55,9 @@ import io.getstream.chat.android.client.api2.model.requests.DeliveredMessageDto
 import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagUserRequest
 import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
-import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkDeliveredRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkUnreadRequest
-import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdatePollRequest
@@ -79,7 +77,6 @@ import io.getstream.chat.android.client.api2.model.requests.ReminderRequest
 import io.getstream.chat.android.client.api2.model.requests.RemoveUserGroupMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.SendActionRequest
 import io.getstream.chat.android.client.api2.model.requests.SendEventRequest
-import io.getstream.chat.android.client.api2.model.requests.UpdateChannelPartialRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateMemberPartialRequest
@@ -165,10 +162,13 @@ import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.des
 import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.CreateDeviceRequest
+import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.ListDevicesResponse
+import io.getstream.chat.android.network.models.MuteChannelRequest
 import io.getstream.chat.android.network.models.Response
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UnblockUsersResponse
+import io.getstream.chat.android.network.models.UpdateChannelPartialRequest
 import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
@@ -674,7 +674,7 @@ internal class MoshiChatApiTest {
         val result = sut.muteChannel(channelType, channelId, expiration).await()
         // then
         val expectedRequest = MuteChannelRequest(
-            channel_cid = "$channelType:$channelId",
+            channelCids = listOf("$channelType:$channelId"),
             expiration = expiration,
         )
         result `should be instance of` expected
@@ -696,7 +696,7 @@ internal class MoshiChatApiTest {
         val result = sut.unmuteChannel(channelType, channelId).await()
         // then
         val expectedRequest = MuteChannelRequest(
-            channel_cid = "$channelType:$channelId",
+            channelCids = listOf("$channelType:$channelId"),
             expiration = null,
         )
         result `should be instance of` expected


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the channel-config request bodies (`hideChannel`, `muteChannel`/`unmuteChannel`, `updateChannelPartial`) to generated models. Part of the incremental OpenAPI model migration.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Add generated `internal HideChannelRequest`, `MuteChannelRequest`, `UpdateChannelPartialRequest` in `network.models`; delete the hand-written ones. Repoint `ChannelApi`, `ModerationApi`, `MoshiChatApi`, and tests.
- `MuteChannelRequest`: the field is now `channelCids: List<String>` (was `channel_cid: String`); both `muteChannel` and `unmuteChannel` pass `listOf("$type:$id")`. Wire payload verified unchanged in behaviour on device.
- `UpdateChannelPartialRequest`: generated field order is `(unset, set)`, so the call site now uses named args `(set = set, unset = unset)`.
- `HideChannelRequest`: `clearHistory` is now `Boolean?` (was `Boolean`); the call passes it positionally, no logic change.

### Testing

- Project-wide `spotlessApply`, `apiDump` (no API drift), `detekt`, and `testDebugUnitTest` all pass.
- Verified on device: `hideChannel`/`showChannel` -> `200`, `muteChannel`/`unmuteChannel` -> `200`, and `updateChannelPartial` -> `200` with a custom-field (`extraData`) round-trip confirmed (sentinel set then unset).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated channel moderation requests to use the latest supported format, improving mute and unmute behavior.
  * Adjusted partial channel update handling to work reliably with the current request structure.
  * Improved channel hide request serialization for better compatibility with backend expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->