### PR TITLE
compose: Raise Paparazzi test worker heap to avoid OutOfMemoryError

### DIFF
--- a/stream-chat-android-compose/build.gradle.kts
+++ b/stream-chat-android-compose/build.gradle.kts
@@ -55,6 +55,12 @@ baselineProfile {
     }
 }
 
+// Paparazzi renders and compresses every snapshot in the forked test worker, which defaults to a
+// 512 MB heap. Raise it so recordPaparazziDebug / verifyPaparazziDebug do not run out of memory.
+tasks.withType<Test>().configureEach {
+    maxHeapSize = "4g"
+}
+
 tasks.withType<KotlinCompile> {
     compilerOptions.freeCompilerArgs.addAll(
         listOf(


### PR DESCRIPTION
### Goal

`./gradlew :stream-chat-android-compose:recordPaparazziDebug` fails with `java.lang.OutOfMemoryError: Java heap space`. The same can happen on `verifyPaparazziDebug`.

Paparazzi tests do not run in the Gradle daemon. They run in a forked unit test worker JVM, and that worker's heap is sized separately from the daemon. The compose module never sets a heap for the `Test` task, so the worker falls back to a 512 MB max heap. Passing `-Dorg.gradle.jvmargs=-Xmx...` on the command line does not help, because that only sizes the daemon, not the worker.

The compose snapshot suite has grown (more tests and larger renders). `recordPaparazziDebug` renders and compresses every snapshot in that worker, and the peak usage now exceeds 512 MB, so it runs out of memory during PNG compression.

Resolves AND-1299

### Implementation

Set `maxHeapSize = "4g"` on the compose module `Test` tasks:

```kotlin
tasks.withType<Test>().configureEach {
    maxHeapSize = "4g"
}
```

This is scoped to the compose module only, since it is the only module using the Paparazzi plugin and no other module has shown this issue.

### Testing

1. On `develop`, run `./gradlew :stream-chat-android-compose:recordPaparazziDebug`. It fails with `OutOfMemoryError` in `ApngWriter.compress`.
2. On this branch, run the same command. It completes without the memory error.

To confirm the worker heap without a full record run, you can check the effective value:
- Before the change, the forked `testDebugUnitTest` worker reports a 512 MB max heap.
- After the change, it reports 4096 MB.
