### PR TITLE
Migrate OG (enrichUrl) endpoint to the generated GetOGResponse model

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -626,8 +626,9 @@ internal class DomainMapping(
      * Transforms the OG/link-preview [GetOGResponse] to an [Attachment].
      */
     internal fun GetOGResponse.toDomain(): Attachment {
-        // OpenAPI spec doesn't declare file_size/image/mime_type/name; wire ships them at root
-        // and our adapter sweeps them into `custom` (see GENERATOR_ISSUES.md #9).
+        // The spec doesn't declare file_size/image/mime_type/name, but the wire ships them at the
+        // response root; GetOGResponseAdapter gathers undeclared root fields into `custom`, so we
+        // extract them back out here.
         val extras = custom.toMutableMap()
         val fileSize = (extras.remove("file_size") as? Number)?.toInt() ?: 0
         val image = extras.remove("image") as? String

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -79,6 +79,7 @@ import io.getstream.chat.android.models.Answer
 import io.getstream.chat.android.models.App
 import io.getstream.chat.android.models.AppSettings
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.BannedUser
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelInfo
@@ -138,6 +139,9 @@ import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.models.querysort.SortDirection
 import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.DeviceResponse
+import io.getstream.chat.android.network.models.GetOGResponse
+import io.getstream.chat.android.network.models.ImageData
+import io.getstream.chat.android.network.models.Images
 import java.util.Date
 
 @Suppress("TooManyFunctions", "LargeClass")
@@ -619,6 +623,44 @@ internal class DomainMapping(
         )
 
     /**
+     * Transforms the OG/link-preview [GetOGResponse] to an [Attachment].
+     */
+    internal fun GetOGResponse.toDomain(): Attachment {
+        // OpenAPI spec doesn't declare file_size/image/mime_type/name; wire ships them at root
+        // and our adapter sweeps them into `custom` (see GENERATOR_ISSUES.md #9).
+        val extras = custom.toMutableMap()
+        val fileSize = (extras.remove("file_size") as? Number)?.toInt() ?: 0
+        val image = extras.remove("image") as? String
+        val mimeType = extras.remove("mime_type") as? String
+        val name = extras.remove("name") as? String
+        val extraData = mutableMapOf<String, Any>()
+        for ((k, v) in extras) if (v != null) extraData[k] = v
+        // UI reads Giphy data from extraData["giphy"]; the generated DTO splits it out into a
+        // typed `giphy: Images` field, so re-emit it in the legacy nested-map shape.
+        giphy?.let { extraData[AttachmentType.GIPHY] = it.toLegacyMap() }
+        return Attachment(
+            assetUrl = assetUrl,
+            authorName = authorName,
+            authorLink = authorLink,
+            fallback = fallback,
+            fileSize = fileSize,
+            image = image,
+            imageUrl = imageUrl,
+            mimeType = mimeType,
+            name = name,
+            ogUrl = ogScrapeUrl,
+            text = text,
+            thumbUrl = thumbUrl,
+            title = title,
+            titleLink = titleLink,
+            type = type,
+            originalHeight = originalHeight,
+            originalWidth = originalWidth,
+            extraData = extraData,
+        )
+    }
+
+    /**
      * Transforms [BannedUserResponse] to [BannedUser].
      */
     internal fun BannedUserResponse.toDomain(): BannedUser {
@@ -993,3 +1035,21 @@ internal class DomainMapping(
         private const val FIELD_LAST_UPDATED = "last_updated"
     }
 }
+
+private fun Images.toLegacyMap(): Map<String, Map<String, String>> = mapOf(
+    "original" to original.toLegacyMap(),
+    "fixed_height" to fixedHeight.toLegacyMap(),
+    "fixed_height_downsampled" to fixedHeightDownsampled.toLegacyMap(),
+    "fixed_height_still" to fixedHeightStill.toLegacyMap(),
+    "fixed_width" to fixedWidth.toLegacyMap(),
+    "fixed_width_downsampled" to fixedWidthDownsampled.toLegacyMap(),
+    "fixed_width_still" to fixedWidthStill.toLegacyMap(),
+)
+
+private fun ImageData.toLegacyMap(): Map<String, String> = mapOf(
+    "url" to url,
+    "width" to width,
+    "height" to height,
+    "size" to size,
+    "frames" to frames,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.client.parser2.adapters.DownstreamThreadInfoDto
 import io.getstream.chat.android.client.parser2.adapters.DownstreamUserDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.EventAdapterFactory
 import io.getstream.chat.android.client.parser2.adapters.ExactDateAdapter
+import io.getstream.chat.android.client.parser2.adapters.GetOGResponseAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamMemberDataDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamMemberDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamMessageDtoAdapter
@@ -71,6 +72,7 @@ internal class MoshiChatParser(
             .add(UpstreamMessageDtoAdapter)
             .add(DownstreamChannelDtoAdapter)
             .add(AttachmentDtoAdapter)
+            .add(GetOGResponseAdapter)
             .add(DownstreamReactionDtoAdapter)
             .add(UpstreamReactionDtoAdapter)
             .add(DownstreamUserDtoAdapter)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/CustomObjectDtoAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/CustomObjectDtoAdapter.kt
@@ -16,28 +16,35 @@
 
 package io.getstream.chat.android.client.parser2.adapters
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
 
 /**
  * Base class for implementing Moshi adapters that support our API's dynamic
  * JSON models.
  */
-internal open class CustomObjectDtoAdapter<Value : Any>(private val kClass: KClass<Value>) {
-
-    private companion object {
-        private const val EXTRA_DATA = "extraData"
-    }
+internal open class CustomObjectDtoAdapter<Value : Any>(
+    private val kClass: KClass<Value>,
+    private val extraDataPropertyName: String = "extraData",
+) {
 
     /**
-     * Names of the declared properties that are inside the [Value] type being
-     * handled. These will not be copied into extraData when parsing with
-     * [parseWithExtraData].
+     * Wire-format names of the declared properties on [Value]. These will not be copied into
+     * the overflow map when parsing with [parseWithExtraData]. Reads `@Json(name = ...)` first
+     * so camelCase Kotlin properties on generated DTOs map to their snake_case wire names;
+     * falls back to the Kotlin parameter name for hand-written DTOs that omit `@Json`.
      */
     private val memberNames: List<String> by lazy {
-        kClass.members.map { member -> member.name }.minus(EXTRA_DATA)
+        val params = kClass.primaryConstructor?.parameters.orEmpty()
+        params.mapNotNull { param ->
+            val name = param.findAnnotation<Json>()?.name ?: param.name
+            name?.takeIf { it != extraDataPropertyName }
+        }
     }
 
     /**
@@ -61,8 +68,8 @@ internal open class CustomObjectDtoAdapter<Value : Any>(private val kClass: KCla
         val extraData = mutableMapOf<String, Any>()
 
         // Save the value of the literal "extraData" field at the root of the object, if present
-        map[EXTRA_DATA]?.let { explicitExtraData ->
-            extraData[EXTRA_DATA] = explicitExtraData
+        map[extraDataPropertyName]?.let { explicitExtraData ->
+            extraData[extraDataPropertyName] = explicitExtraData
         }
 
         // Save the values of non-member fields as extra data
@@ -73,7 +80,7 @@ internal open class CustomObjectDtoAdapter<Value : Any>(private val kClass: KCla
         }
 
         // Replace original "extraData" with the newly collected values
-        map[EXTRA_DATA] = extraData
+        map[extraDataPropertyName] = extraData
 
         // Parse output value object from the transformed Map
         return valueAdapter.fromJsonValue(map)!!
@@ -100,13 +107,13 @@ internal open class CustomObjectDtoAdapter<Value : Any>(private val kClass: KCla
         val map: MutableMap<String, Any?> = valueAdapter.toJsonValue(value) as MutableMap<String, Any?>
 
         // Grab real "extraData" property's value
-        val extraData = map[EXTRA_DATA] as Map<String, Any?>
+        val extraData = map[extraDataPropertyName] as? Map<String, Any?>
 
         // Remove literal "extraData" field from Map
-        map.remove(EXTRA_DATA)
+        map.remove(extraDataPropertyName)
 
         // Merge all values from "extraData" property back into the Map as top level fields
-        map.putAll(extraData)
+        extraData?.let(map::putAll)
 
         // Write Map to output
         mapAdapter.toJson(jsonWriter, map)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/GetOGResponseAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/GetOGResponseAdapter.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2.adapters
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+import io.getstream.chat.android.network.models.GetOGResponse
+
+internal object GetOGResponseAdapter :
+    CustomObjectDtoAdapter<GetOGResponse>(GetOGResponse::class, extraDataPropertyName = "custom") {
+
+    @FromJson
+    fun fromJson(
+        jsonReader: JsonReader,
+        mapAdapter: JsonAdapter<MutableMap<String, Any>>,
+        responseAdapter: JsonAdapter<GetOGResponse>,
+    ): GetOGResponse? = parseWithExtraData(jsonReader, mapAdapter, responseAdapter)
+
+    @ToJson
+    fun toJson(
+        jsonWriter: JsonWriter,
+        response: GetOGResponse?,
+        mapAdapter: JsonAdapter<MutableMap<String, Any?>>,
+        responseAdapter: JsonAdapter<GetOGResponse>,
+    ) = serializeWithExtraData(jsonWriter, response, mapAdapter, responseAdapter)
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/Action.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/Action.kt
@@ -14,21 +14,35 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AuthenticatedApi
-import io.getstream.chat.android.client.api.QueryParams
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.GetOGResponse
-import retrofit2.http.GET
-import retrofit2.http.Query
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
 
 /**
- * API for open graph data.
+ *
  */
-@AuthenticatedApi
-internal interface OpenGraphApi {
 
-    @GET("/og")
-    fun get(@Query(QueryParams.URL) url: String): RetrofitCall<GetOGResponse>
-}
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class Action(
+    @Json(name = "name")
+    internal val name: String,
+
+    @Json(name = "text")
+    internal val text: String,
+
+    @Json(name = "type")
+    internal val type: String,
+
+    @Json(name = "style")
+    internal val style: String? = null,
+
+    @Json(name = "value")
+    internal val value: String? = null,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/Field.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/Field.kt
@@ -14,21 +14,29 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AuthenticatedApi
-import io.getstream.chat.android.client.api.QueryParams
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.GetOGResponse
-import retrofit2.http.GET
-import retrofit2.http.Query
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
 
 /**
- * API for open graph data.
+ *
  */
-@AuthenticatedApi
-internal interface OpenGraphApi {
 
-    @GET("/og")
-    fun get(@Query(QueryParams.URL) url: String): RetrofitCall<GetOGResponse>
-}
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class Field(
+    @Json(name = "short")
+    internal val short: Boolean,
+
+    @Json(name = "title")
+    internal val title: String,
+
+    @Json(name = "value")
+    internal val value: String,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/GetOGResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/GetOGResponse.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class GetOGResponse(
+    @Json(name = "duration")
+    internal val duration: String,
+
+    @Json(name = "custom")
+    internal val custom: Map<String, Any?> = emptyMap(),
+
+    @Json(name = "asset_url")
+    internal val assetUrl: String? = null,
+
+    @Json(name = "author_icon")
+    internal val authorIcon: String? = null,
+
+    @Json(name = "author_link")
+    internal val authorLink: String? = null,
+
+    @Json(name = "author_name")
+    internal val authorName: String? = null,
+
+    @Json(name = "color")
+    internal val color: String? = null,
+
+    @Json(name = "fallback")
+    internal val fallback: String? = null,
+
+    @Json(name = "footer")
+    internal val footer: String? = null,
+
+    @Json(name = "footer_icon")
+    internal val footerIcon: String? = null,
+
+    @Json(name = "image_url")
+    internal val imageUrl: String? = null,
+
+    @Json(name = "og_scrape_url")
+    internal val ogScrapeUrl: String? = null,
+
+    @Json(name = "original_height")
+    internal val originalHeight: Int? = null,
+
+    @Json(name = "original_width")
+    internal val originalWidth: Int? = null,
+
+    @Json(name = "pretext")
+    internal val pretext: String? = null,
+
+    @Json(name = "text")
+    internal val text: String? = null,
+
+    @Json(name = "thumb_url")
+    internal val thumbUrl: String? = null,
+
+    @Json(name = "title")
+    internal val title: String? = null,
+
+    @Json(name = "title_link")
+    internal val titleLink: String? = null,
+
+    @Json(name = "type")
+    internal val type: String? = null,
+
+    @Json(name = "actions")
+    internal val actions: List<io.getstream.chat.android.network.models.Action>? = emptyList(),
+
+    @Json(name = "fields")
+    internal val fields: List<io.getstream.chat.android.network.models.Field>? = emptyList(),
+
+    @Json(name = "giphy")
+    internal val giphy: io.getstream.chat.android.network.models.Images? = null,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ImageData.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ImageData.kt
@@ -14,21 +14,35 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AuthenticatedApi
-import io.getstream.chat.android.client.api.QueryParams
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.GetOGResponse
-import retrofit2.http.GET
-import retrofit2.http.Query
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
 
 /**
- * API for open graph data.
+ *
  */
-@AuthenticatedApi
-internal interface OpenGraphApi {
 
-    @GET("/og")
-    fun get(@Query(QueryParams.URL) url: String): RetrofitCall<GetOGResponse>
-}
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class ImageData(
+    @Json(name = "frames")
+    internal val frames: String,
+
+    @Json(name = "height")
+    internal val height: String,
+
+    @Json(name = "size")
+    internal val size: String,
+
+    @Json(name = "url")
+    internal val url: String,
+
+    @Json(name = "width")
+    internal val width: String,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/Images.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/Images.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class Images(
+    @Json(name = "fixed_height")
+    internal val fixedHeight: io.getstream.chat.android.network.models.ImageData,
+
+    @Json(name = "fixed_height_downsampled")
+    internal val fixedHeightDownsampled: io.getstream.chat.android.network.models.ImageData,
+
+    @Json(name = "fixed_height_still")
+    internal val fixedHeightStill: io.getstream.chat.android.network.models.ImageData,
+
+    @Json(name = "fixed_width")
+    internal val fixedWidth: io.getstream.chat.android.network.models.ImageData,
+
+    @Json(name = "fixed_width_downsampled")
+    internal val fixedWidthDownsampled: io.getstream.chat.android.network.models.ImageData,
+
+    @Json(name = "fixed_width_still")
+    internal val fixedWidthStill: io.getstream.chat.android.network.models.ImageData,
+
+    @Json(name = "original")
+    internal val original: io.getstream.chat.android.network.models.ImageData,
+)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -161,8 +161,8 @@ import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.des
 import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.CreateDeviceRequest
-import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.GetOGResponse
+import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.ListDevicesResponse
 import io.getstream.chat.android.network.models.MuteChannelRequest
 import io.getstream.chat.android.network.models.Response

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -38,7 +38,6 @@ import io.getstream.chat.android.client.api2.endpoint.UserGroupApi
 import io.getstream.chat.android.client.api2.mapping.DomainMapping
 import io.getstream.chat.android.client.api2.mapping.DtoMapping
 import io.getstream.chat.android.client.api2.mapping.EventMapping
-import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChatPreferencesDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPushPreferenceDto
@@ -163,6 +162,7 @@ import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.CreateDeviceRequest
 import io.getstream.chat.android.network.models.HideChannelRequest
+import io.getstream.chat.android.network.models.GetOGResponse
 import io.getstream.chat.android.network.models.ListDevicesResponse
 import io.getstream.chat.android.network.models.MuteChannelRequest
 import io.getstream.chat.android.network.models.Response
@@ -1842,7 +1842,7 @@ internal class MoshiChatApiTest {
 
     @ParameterizedTest
     @MethodSource("io.getstream.chat.android.client.api2.MoshiChatApiTestArguments#ogInput")
-    fun testOg(call: RetrofitCall<AttachmentDto>, expected: KClass<*>) = runTest {
+    fun testOg(call: RetrofitCall<GetOGResponse>, expected: KClass<*>) = runTest {
         // given
         val api = mock<OpenGraphApi>()
         whenever(api.get(any())).doReturn(call)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
@@ -25,7 +25,6 @@ import io.getstream.chat.android.client.Mother.randomUnreadCountByTeamDto
 import io.getstream.chat.android.client.Mother.randomUnreadDto
 import io.getstream.chat.android.client.Mother.randomUnreadThreadDto
 import io.getstream.chat.android.client.api.FakeResponse
-import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReminderDto
 import io.getstream.chat.android.client.api2.model.dto.HealthEventDto
@@ -77,6 +76,7 @@ import io.getstream.chat.android.models.UnreadCounts
 import io.getstream.chat.android.models.UnreadThread
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.network.models.BlockUsersResponse
+import io.getstream.chat.android.network.models.GetOGResponse
 import io.getstream.chat.android.network.models.ListDevicesResponse
 import io.getstream.chat.android.network.models.Response
 import io.getstream.chat.android.network.models.UnblockUsersResponse
@@ -421,8 +421,8 @@ internal object MoshiChatApiTestArguments {
 
     @JvmStatic
     fun ogInput() = listOf(
-        Arguments.of(RetroSuccess(Mother.randomAttachmentDto()).toRetrofitCall(), Result.Success::class),
-        Arguments.of(RetroError<AttachmentDto>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
+        Arguments.of(RetroSuccess(GetOGResponse(duration = randomString())).toRetrofitCall(), Result.Success::class),
+        Arguments.of(RetroError<GetOGResponse>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
     )
 
     @JvmStatic

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/GetOGResponseAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/GetOGResponseAdapterTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2
+
+import io.getstream.chat.android.network.models.GetOGResponse
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+internal class GetOGResponseAdapterTest {
+
+    private val parser = ParserFactory.createMoshiChatParser()
+
+    @Test
+    fun `Gathers root-level custom fields into the custom map`() {
+        // The OG scrape wire flattens custom ExtraFields at root (file_size/image/mime_type/name
+        // aren't declared in the OpenAPI spec). The adapter sweeps them into `custom`.
+        val json = """
+            {
+                "duration": "12ms",
+                "type": "image",
+                "title": "Example",
+                "og_scrape_url": "https://example.com",
+                "file_size": 1234,
+                "image": "https://example.com/i.png",
+                "mime_type": "image/png",
+                "name": "i.png",
+                "foo": "bar"
+            }
+        """.trimIndent()
+
+        val response = parser.fromJson(json, GetOGResponse::class.java)
+
+        response.duration shouldBeEqualTo "12ms"
+        response.type shouldBeEqualTo "image"
+        response.title shouldBeEqualTo "Example"
+        response.ogScrapeUrl shouldBeEqualTo "https://example.com"
+        response.custom["file_size"] shouldBeEqualTo 1234.0
+        response.custom["image"] shouldBeEqualTo "https://example.com/i.png"
+        response.custom["mime_type"] shouldBeEqualTo "image/png"
+        response.custom["name"] shouldBeEqualTo "i.png"
+        response.custom["foo"] shouldBeEqualTo "bar"
+    }
+
+    @Test
+    fun `Leaves custom empty when the wire has no extra fields`() {
+        val json = """
+            {
+                "duration": "5ms",
+                "type": "video",
+                "title": "No extras"
+            }
+        """.trimIndent()
+
+        val response = parser.fromJson(json, GetOGResponse::class.java)
+
+        response.custom shouldBeEqualTo emptyMap()
+    }
+}


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the OG / link-preview (`enrichUrl`, `GET /og`) endpoint to the generated `GetOGResponse` model. Part of the incremental OpenAPI model migration.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Add generated `internal` models in `network.models`: `GetOGResponse` + its closure (`Action`, `Field`, `Images`, `ImageData`). Patch-free (cross-checked against iOS #4135 and the `openapi-generated` reference branch).
- `OpenGraphApi.get` now returns `RetrofitCall<GetOGResponse>` (was the hand-written `AttachmentDto`); `og()` is unchanged (`mapDomain { it.toDomain() }`).
- Register `GetOGResponseAdapter` (a `CustomObjectDtoAdapter` with `extraDataPropertyName = "custom"`) so undeclared root fields are gathered into `GetOGResponse.custom` on parse, matching how the reference/iOS handle `/og` and how the legacy hand-written `AttachmentDto` (which declared those fields) captured them.
- Enhance the shared `CustomObjectDtoAdapter` to resolve wire field names via `@Json(name = ...)` (falling back to the Kotlin param name), so it works for generated camelCase DTOs as well as the hand-written snake_case ones. Behaviour is unchanged for existing adapters (their snake_case params resolve identically).
- Add `GetOGResponse.toDomain(): Attachment`, ported from the reference branch's proven mapper rather than derived from scratch. Two non-obvious behaviours it preserves:
  - The spec omits `file_size`/`image`/`mime_type`/`name`, but the wire ships them at the response root; the adapter gathers them into `custom`, so they're extracted back out.
  - The typed `giphy: Images` field is re-emitted into `extraData["giphy"]` as the legacy nested-map shape (via ported `Images`/`ImageData.toLegacyMap()` helpers) since the UI reads it there.
- Uses `GetOGResponse` rather than the reference's generated `Attachment` (aliased `AttachmentDto`), because that alias would collide with the still-live hand-written `AttachmentDto` used by the not-yet-migrated message surface. Same wire shape, same ported mapping.

### Testing

- Project-wide `spotlessApply`, `apiDump` (no API drift), `detekt`, and the full client `testDebugUnitTest` suite pass. `GetOGResponseAdapterTest` covers the gather (root fields -> `custom`) and the empty-custom case.
- Verified on device against the live endpoint (image, PDF, giphy URLs): `enrichUrl` returns a correct `Attachment` with all declared fields populated (e.g. a giphy link yields `title`/`text`/`type`/`imageUrl`/`thumbUrl`/`assetUrl`/`ogUrl`), and the raw wire confirmed `/og` returns only declared fields, so `custom`/`extraData` are correctly empty.
- The `custom` gather is defensive/parity: `/og` doesn't emit the `file_size`/`mime_type`/`name` overflow in practice (that belongs to the message-attachment flow), but the legacy code declared those fields, so the adapter guarantees we still capture them rather than silently drop them if the backend ever sends them.
