### PR TITLE
Migrate queryReactions request body to the generated QueryReactionsRequest model

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -77,7 +77,6 @@ import io.getstream.chat.android.client.api2.model.requests.QueryGroupedChannels
 import io.getstream.chat.android.client.api2.model.requests.QueryGroupedChannelsRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryPollVotesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryPollsRequest
-import io.getstream.chat.android.client.api2.model.requests.QueryReactionsRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryRemindersRequest
 import io.getstream.chat.android.client.api2.model.requests.ReactionRequest
 import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
@@ -167,6 +166,8 @@ import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.CreateDeviceRequest
 import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.MuteChannelRequest
+import io.getstream.chat.android.network.models.QueryReactionsRequest
+import io.getstream.chat.android.network.models.SortParamRequest
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UpdateChannelPartialRequest
 import io.getstream.log.taggedLogger
@@ -431,7 +432,7 @@ constructor(
             filter = filter?.toMap(),
             limit = limit,
             next = next,
-            sort = sort?.toDto(),
+            sort = sort?.toSortParams(),
         )
         return messageApi.queryReactions(messageId, body).mapDomain {
             QueryReactionsResult(
@@ -2009,3 +2010,11 @@ constructor(
     private fun <T : Any, R : Any> RetrofitCall<T>.flatMapDomain(transform: DomainMapping.(T) -> Call<R>): Call<R> =
         flatMap { domainMapping.transform(it) }
 }
+
+internal fun QuerySorter<*>.toSortParams(): List<SortParamRequest> =
+    toDto().map {
+        SortParamRequest(
+            field = it[QuerySorter.KEY_FIELD_NAME] as? String,
+            direction = (it[QuerySorter.KEY_DIRECTION] as? Number)?.toInt(),
+        )
+    }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/MessageApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/MessageApi.kt
@@ -20,7 +20,6 @@ import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryDraftMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryDraftsRequest
-import io.getstream.chat.android.client.api2.model.requests.QueryReactionsRequest
 import io.getstream.chat.android.client.api2.model.requests.ReactionRequest
 import io.getstream.chat.android.client.api2.model.requests.SendActionRequest
 import io.getstream.chat.android.client.api2.model.requests.SendMessageRequest
@@ -34,6 +33,7 @@ import io.getstream.chat.android.client.api2.model.response.ReactionResponse
 import io.getstream.chat.android.client.api2.model.response.ReactionsResponse
 import io.getstream.chat.android.client.api2.model.response.TranslateMessageRequest
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.QueryReactionsRequest
 import io.getstream.chat.android.network.models.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/QueryReactionsRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/QueryReactionsRequest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+import kotlin.collections.List
+import kotlin.collections.Map
+
+/**
+ *
+ */
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class QueryReactionsRequest(
+    @Json(name = "limit")
+    val limit: kotlin.Int? = null,
+
+    @Json(name = "next")
+    val next: kotlin.String? = null,
+
+    @Json(name = "prev")
+    val prev: kotlin.String? = null,
+
+    @Json(name = "sort")
+    val sort: kotlin.collections.List<SortParamRequest>? = emptyList(),
+
+    @Json(name = "filter")
+    val filter: kotlin.collections.Map<kotlin.String, Any?>? = emptyMap(),
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/SortParamRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/SortParamRequest.kt
@@ -14,22 +14,29 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
 
 /**
- * Request for querying reactions on a message.
  *
- * @property filter The filter criteria.
- * @property limit The maximum number of reactions to return.
- * @property next The pagination token for fetching the next set of results.
- * @property sort The sorting criteria to apply.
  */
-@JsonClass(generateAdapter = true)
-internal data class QueryReactionsRequest(
-    val filter: Map<*, *>? = null,
-    val limit: Int? = null,
-    val next: String? = null,
-    val sort: List<Map<String, Any>>? = null,
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class SortParamRequest(
+    @Json(name = "direction")
+    val direction: kotlin.Int? = null,
+
+    @Json(name = "field")
+    val field: kotlin.String? = null,
+
+    @Json(name = "type")
+    val type: kotlin.String? = null,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -70,7 +70,6 @@ import io.getstream.chat.android.client.api2.model.requests.QueryGroupedChannels
 import io.getstream.chat.android.client.api2.model.requests.QueryGroupedChannelsRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryPollVotesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryPollsRequest
-import io.getstream.chat.android.client.api2.model.requests.QueryReactionsRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryRemindersRequest
 import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.ReminderRequest
@@ -165,6 +164,7 @@ import io.getstream.chat.android.network.models.CreateDeviceRequest
 import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.ListDevicesResponse
 import io.getstream.chat.android.network.models.MuteChannelRequest
+import io.getstream.chat.android.network.models.QueryReactionsRequest
 import io.getstream.chat.android.network.models.Response
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UnblockUsersResponse
@@ -461,7 +461,7 @@ internal class MoshiChatApiTest {
             filter = filter.toMap(),
             limit = limit,
             next = next,
-            sort = sort.toDto(),
+            sort = sort.toSortParams(),
         )
         result `should be instance of` expected
         verify(api, times(1)).queryReactions(messageId, expectedRequest)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/QueryReactionsRequestAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/QueryReactionsRequestAdapterTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2
+
+import io.getstream.chat.android.client.parser2.testdata.QueryReactionsRequestTestData
+import io.getstream.chat.android.network.models.QueryReactionsRequest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class QueryReactionsRequestAdapterTest {
+    private val parser = ParserFactory.createMoshiChatParser()
+
+    @Test
+    fun `Serialize QueryReactionsRequest with all fields`() {
+        val json = parser.toJson(QueryReactionsRequestTestData.queryReactionsRequest)
+        Assertions.assertEquals(QueryReactionsRequestTestData.queryReactionsRequestJson, json)
+    }
+
+    @Test
+    fun `Serialize QueryReactionsRequest with default fields`() {
+        val json = parser.toJson(QueryReactionsRequestTestData.queryReactionsRequestWithDefaults)
+        Assertions.assertEquals(QueryReactionsRequestTestData.queryReactionsRequestJsonWithDefaults, json)
+    }
+
+    @Test
+    fun `Deserialize QueryReactionsRequest with all fields`() {
+        val request = parser.fromJson(
+            QueryReactionsRequestTestData.queryReactionsRequestJson,
+            QueryReactionsRequest::class.java,
+        )
+        Assertions.assertEquals(QueryReactionsRequestTestData.queryReactionsRequest, request)
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/QueryReactionsRequestTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/QueryReactionsRequestTestData.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2.testdata
+
+import io.getstream.chat.android.network.models.QueryReactionsRequest
+import io.getstream.chat.android.network.models.SortParamRequest
+import org.intellij.lang.annotations.Language
+
+internal object QueryReactionsRequestTestData {
+
+    @Language("JSON")
+    val queryReactionsRequestJson =
+        """{
+          "limit": 10,
+          "next": "next-token",
+          "prev": "prev-token",
+          "sort": [
+            {
+              "direction": -1,
+              "field": "created_at",
+              "type": "reaction"
+            }
+          ],
+          "filter": {
+            "type": "like"
+          }
+        }""".withoutWhitespace()
+
+    val queryReactionsRequest = QueryReactionsRequest(
+        limit = 10,
+        next = "next-token",
+        prev = "prev-token",
+        sort = listOf(
+            SortParamRequest(
+                direction = -1,
+                field = "created_at",
+                type = "reaction",
+            ),
+        ),
+        filter = mapOf(
+            "type" to "like",
+        ),
+    )
+
+    @Language("JSON")
+    val queryReactionsRequestJsonWithDefaults =
+        """{
+          "sort": [],
+          "filter": {}
+        }""".withoutWhitespace()
+
+    val queryReactionsRequestWithDefaults = QueryReactionsRequest()
+}


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the `queryReactions` request body (`POST /messages/{id}/reactions`) to the generated `QueryReactionsRequest` network model. Introduces the shared `SortParamRequest` model + a `QuerySorter -> List<SortParamRequest>` helper that the remaining query-payload migrations will reuse. Part of the incremental OpenAPI model migration.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Add generated `internal QueryReactionsRequest` + `SortParamRequest` in `network.models` (patch-free). Delete the hand-written `api2.model.requests.QueryReactionsRequest`. Real names, no alias.
- The generated `sort` field is now `List<SortParamRequest>` (was `List<Map<String, Any>>`). Add a top-level `internal fun QuerySorter<*>.toSortParams(): List<SortParamRequest>` (ported from the reference) mapping each sort entry to `SortParamRequest(field, direction)`, and change the `queryReactions` call site from `sort = sort?.toDto()` to `sort = sort?.toSortParams()`. `filter?.toMap()` (Map<String, Any>) fits the generated `Map<String, Any?>` field. No wire-shape change.

### Testing

- `spotlessApply`, `apiCheck` (no API drift), `detekt`, and the full client `testDebugUnitTest` suite pass.
- Verified on device: `queryReactions` with a `created_at desc` sort serializes on the wire as `{"limit":10,"sort":[{"direction":-1,"field":"created_at"}]}` and returns `201`. The `sort` array confirms the new `SortParamRequest` serialization via `toSortParams()` (the migration's changed surface; the response type is unchanged by this slice).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reaction query handling, including better support for pagination, sorting, and filtering in reaction-related requests.
  * Updated reaction request serialization to match the latest network format.

* **Bug Fixes**
  * Fixed inconsistencies in how reaction query sort values are sent, helping requests work more reliably.

* **Tests**
  * Added coverage for reaction request JSON serialization and deserialization, including default and fully populated cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->