### PR TITLE
Migrate castPollVote request body to generated CastPollVoteRequest and VoteData models

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -67,7 +67,6 @@ import io.getstream.chat.android.client.api2.model.requests.PartialUpdatePollReq
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateThreadRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
-import io.getstream.chat.android.client.api2.model.requests.PollVoteRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryDraftMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryDraftsRequest
@@ -96,7 +95,6 @@ import io.getstream.chat.android.client.api2.model.requests.UpdateUserGroupReque
 import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.UpsertPushPreferencesRequest
 import io.getstream.chat.android.client.api2.model.requests.UpstreamOptionDto
-import io.getstream.chat.android.client.api2.model.requests.UpstreamVoteDto
 import io.getstream.chat.android.client.api2.model.response.ChannelResponse
 import io.getstream.chat.android.client.api2.model.response.PushPreferencesResponse
 import io.getstream.chat.android.client.api2.model.response.TranslateMessageRequest
@@ -162,6 +160,7 @@ import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.network.models.BlockUsersRequest
+import io.getstream.chat.android.network.models.CastPollVoteRequest
 import io.getstream.chat.android.network.models.CreateDeviceRequest
 import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.MarkReadRequest
@@ -169,6 +168,7 @@ import io.getstream.chat.android.network.models.MarkUnreadRequest
 import io.getstream.chat.android.network.models.MuteChannelRequest
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UpdateChannelPartialRequest
+import io.getstream.chat.android.network.models.VoteData
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
 import io.getstream.result.Result
@@ -1751,7 +1751,7 @@ constructor(
     ): Call<Vote> = castVote(
         messageId = messageId,
         pollId = pollId,
-        vote = UpstreamVoteDto(option_id = optionId),
+        vote = VoteData(optionId = optionId),
     )
 
     override fun castPollAnswer(
@@ -1761,18 +1761,18 @@ constructor(
     ): Call<Vote> = castVote(
         messageId = messageId,
         pollId = pollId,
-        vote = UpstreamVoteDto(answer_text = answer),
+        vote = VoteData(answerText = answer),
     )
 
     private fun castVote(
         messageId: String,
         pollId: String,
-        vote: UpstreamVoteDto,
+        vote: VoteData,
     ): Call<Vote> =
         pollsApi.castPollVote(
             messageId,
             pollId,
-            PollVoteRequest(vote),
+            CastPollVoteRequest(vote),
         ).mapDomain { it.vote.toDomain() }
 
     override fun removePollVote(messageId: String, pollId: String, voteId: String): Call<Vote> =

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/PollsApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/PollsApi.kt
@@ -19,7 +19,6 @@ package io.getstream.chat.android.client.api2.endpoint
 import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api2.model.requests.CreatePollRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdatePollRequest
-import io.getstream.chat.android.client.api2.model.requests.PollVoteRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryPollVotesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryPollsRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdatePollRequest
@@ -30,6 +29,7 @@ import io.getstream.chat.android.client.api2.model.response.PollVoteResponse
 import io.getstream.chat.android.client.api2.model.response.QueryPollVotesResponse
 import io.getstream.chat.android.client.api2.model.response.QueryPollsResponse
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.CastPollVoteRequest
 import io.getstream.chat.android.network.models.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -191,7 +191,7 @@ internal interface PollsApi {
     fun castPollVote(
         @Path("message_id") messageId: String,
         @Path("poll_id") pollId: String,
-        @Body pollVoteRequest: PollVoteRequest,
+        @Body pollVoteRequest: CastPollVoteRequest,
     ): RetrofitCall<PollVoteResponse>
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/PollRequests.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/PollRequests.kt
@@ -96,16 +96,6 @@ internal data class UpstreamOptionDto(
 ) : ExtraDataDto
 
 /**
- * Used for voting on a poll.
- *
- * @property vote the vote object.
- */
-@JsonClass(generateAdapter = true)
-internal data class PollVoteRequest(
-    val vote: UpstreamVoteDto,
-)
-
-/**
  * Used for updating a poll.
  *
  * @property set the fields to set.
@@ -115,15 +105,4 @@ internal data class PollVoteRequest(
 internal data class PartialUpdatePollRequest(
     val set: Map<String, Any> = emptyMap(),
     val unset: List<String> = emptyList(),
-)
-
-/**
- * Used for voting on a poll.
- *
- * @property option_id the text of the answer.
- */
-@JsonClass(generateAdapter = true)
-internal data class UpstreamVoteDto(
-    val option_id: String? = null,
-    val answer_text: String? = null,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/CastPollVoteRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/CastPollVoteRequest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class CastPollVoteRequest(
+    @Json(name = "vote")
+    val vote: VoteData? = null,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/VoteData.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/VoteData.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class VoteData(
+    @Json(name = "answer_text")
+    val answerText: kotlin.String? = null,
+
+    @Json(name = "option_id")
+    val optionId: kotlin.String? = null,
+)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -62,7 +62,6 @@ import io.getstream.chat.android.client.api2.model.requests.PartialUpdatePollReq
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateThreadRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
-import io.getstream.chat.android.client.api2.model.requests.PollVoteRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryGroupedChannelsGroupRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryGroupedChannelsRequest
@@ -82,7 +81,6 @@ import io.getstream.chat.android.client.api2.model.requests.UpdateMemberPartialR
 import io.getstream.chat.android.client.api2.model.requests.UpdateUserGroupRequest
 import io.getstream.chat.android.client.api2.model.requests.UpsertPushPreferencesRequest
 import io.getstream.chat.android.client.api2.model.requests.UpstreamOptionDto
-import io.getstream.chat.android.client.api2.model.requests.UpstreamVoteDto
 import io.getstream.chat.android.client.api2.model.response.AppSettingsResponse
 import io.getstream.chat.android.client.api2.model.response.ChannelResponse
 import io.getstream.chat.android.client.api2.model.response.DraftMessageResponse
@@ -159,6 +157,7 @@ import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.asc
 import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.descByName
 import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.BlockUsersResponse
+import io.getstream.chat.android.network.models.CastPollVoteRequest
 import io.getstream.chat.android.network.models.CreateDeviceRequest
 import io.getstream.chat.android.network.models.HideChannelRequest
 import io.getstream.chat.android.network.models.ListDevicesResponse
@@ -169,6 +168,7 @@ import io.getstream.chat.android.network.models.Response
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UnblockUsersResponse
 import io.getstream.chat.android.network.models.UpdateChannelPartialRequest
+import io.getstream.chat.android.network.models.VoteData
 import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
@@ -2440,7 +2440,7 @@ internal class MoshiChatApiTest {
         val optionId = randomString()
         val result = sut.castPollVote(messageId, pollId, optionId).await()
         // then
-        val expectedVote = PollVoteRequest(UpstreamVoteDto(option_id = optionId))
+        val expectedVote = CastPollVoteRequest(VoteData(optionId = optionId))
         result `should be instance of` expected
         verify(api, times(1)).castPollVote(messageId, pollId, expectedVote)
     }
@@ -2460,7 +2460,7 @@ internal class MoshiChatApiTest {
         val answer = randomString()
         val result = sut.castPollAnswer(messageId, pollId, answer).await()
         // then
-        val expectedAnswer = PollVoteRequest(UpstreamVoteDto(answer_text = answer))
+        val expectedAnswer = CastPollVoteRequest(VoteData(answerText = answer))
         result `should be instance of` expected
         verify(api, times(1)).castPollVote(messageId, pollId, expectedAnswer)
     }


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the `castPollVote` request body (`POST /messages/{id}/polls/{poll_id}/vote`) to the generated `CastPollVoteRequest` + `VoteData` network models. Part of the incremental OpenAPI model migration.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Add generated `internal CastPollVoteRequest` (wraps `vote`) and `VoteData` (`option_id`/`answer_text`) in `network.models`. Remove the hand-written `PollVoteRequest` + `UpstreamVoteDto` from `PollRequests.kt`. Real names, no alias.
- `PollsApi.castPollVote` and the `MoshiChatApi` vote/answer wiring use the generated types. No wire-shape change: still `{"vote":{"option_id":…}}` / `{"vote":{"answer_text":…}}`.

### Testing

- `spotlessApply`, `apiCheck` (no API drift), `detekt`, `lint`, and the full client `testDebugUnitTest` suite pass (the `castPollVote`/`castPollAnswer` tests assert the exact request body).
- Verified on device against the real backend, both vote variants: `{"vote":{"option_id":"…"}}` returns `201`, and `{"vote":{"answer_text":"probe answer"}}` returns `201`; both return a valid `Vote`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll voting request handling for both option votes and text-based answers.
  * Maintained compatibility with the poll voting API while using updated request formatting.

* **Tests**
  * Updated poll voting coverage to verify option and answer submissions with the revised request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->