### PR TITLE
e2e: Port the iOS-only tests for slow mode, truncation, scroll, read events, and attachments

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
@@ -95,6 +95,7 @@ open class MessageListPage {
             val unreadMessagesBadge get() = By.res("Stream_UnreadMessagesBadge")
             val typingIndicator get() = By.res("Stream_MessageListTypingIndicator")
             val scrollToBottomButton get() = By.res("Stream_ScrollToBottomButton")
+            val scrollToBottomButtonUnreadCount get() = By.res("Stream_ScrollToBottomButtonUnreadCount")
             val systemMessage get() = By.res("Stream_SystemMessage")
         }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -201,9 +201,14 @@ class UserRobot {
     }
 
     fun quoteMessage(text: String, messageCellIndex: Int = 0): UserRobot {
+        selectReplyFromContextMenu(messageCellIndex)
+        sendMessage(text)
+        return this
+    }
+
+    fun selectReplyFromContextMenu(messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
         ContextMenu.reply.waitToAppear().click()
-        sendMessage(text)
         return this
     }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -319,13 +319,18 @@ class UserRobot {
         return this
     }
 
+    fun tapOnGiphyCommandSuggestion(): UserRobot {
+        Composer.giphyButton.waitToAppear().click()
+        return this
+    }
+
     fun uploadGiphy(useComposerCommand: Boolean = false, send: Boolean = true): UserRobot {
         val giphyMessageText = "G" // any message text will result in sending a giphy
         if (useComposerCommand) {
             openComposerCommands()
             // Selecting the suggestion prefills '/giphy '; typeText replaces the whole input,
             // so the command prefix is set together with the message text.
-            Composer.giphyButton.waitToAppear().click()
+            tapOnGiphyCommandSuggestion()
             typeText("/giphy $giphyMessageText")
             tapOnComposerConfirmButton()
         } else {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -261,6 +261,11 @@ fun UserRobot.assertScrollToBottomButton(isDisplayed: Boolean): UserRobot {
     return this
 }
 
+fun UserRobot.assertMessageCount(count: Int): UserRobot {
+    assertEquals(count, MessageListPage.MessageList.messages.waitForCount(count).size)
+    return this
+}
+
 fun UserRobot.assertThreadIsOpen(): UserRobot {
     assertTrue(ThreadPage.ThreadList.alsoSendToChannelCheckbox.waitDisplayed())
     return this

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -266,6 +266,21 @@ fun UserRobot.assertMessageCount(count: Int): UserRobot {
     return this
 }
 
+fun UserRobot.assertComposerAttachmentsButton(isDisplayed: Boolean = true): UserRobot {
+    assertVisibility(Composer.attachmentsButton, isDisplayed)
+    return this
+}
+
+fun UserRobot.assertScrollToBottomButtonUnreadCount(count: Int): UserRobot {
+    val badge = MessageListPage.MessageList.scrollToBottomButtonUnreadCount
+    if (count > 0) {
+        assertEquals(count.toString(), badge.waitForText(count.toString()))
+    } else {
+        assertFalse(badge.waitToDisappear().isDisplayed())
+    }
+    return this
+}
+
 fun UserRobot.assertThreadIsOpen(): UserRobot {
     assertTrue(ThreadPage.ThreadList.alsoSendToChannelCheckbox.waitDisplayed())
     return this

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/AttachmentsTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/AttachmentsTests.kt
@@ -24,6 +24,9 @@ import io.getstream.chat.android.compose.robots.assertMediaAttachmentInPreview
 import io.getstream.chat.android.compose.robots.assertVideo
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.e2e.test.mockserver.AttachmentType
+import io.getstream.chat.android.e2e.test.uiautomator.device
+import io.getstream.chat.android.e2e.test.uiautomator.disableInternetConnection
+import io.getstream.chat.android.e2e.test.uiautomator.enableInternetConnection
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
 import org.junit.Test
@@ -195,6 +198,28 @@ class AttachmentsTests : StreamTestCase() {
         }
         step("THEN user can see uploaded file") {
             userRobot.assertFile(isDisplayed = true)
+        }
+    }
+
+    @AllureId("5928")
+    @Test
+    fun test_imageUploadRecovers_whenUserComesBackOnline() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user goes offline") {
+            device.disableInternetConnection()
+        }
+        step("WHEN user sends an image while offline") {
+            userRobot
+                .attachFile(type = AttachmentType.IMAGE)
+                .tapOnSendButton()
+        }
+        step("AND user comes back online") {
+            device.enableInternetConnection()
+        }
+        step("THEN the image is uploaded") {
+            userRobot.assertImage(isDisplayed = true)
         }
     }
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
@@ -17,9 +17,12 @@
 package io.getstream.chat.android.compose.tests
 
 import io.getstream.chat.android.compose.robots.assertChannelAvatar
+import io.getstream.chat.android.compose.robots.assertMessageCount
 import io.getstream.chat.android.compose.robots.assertMessageDeliveryStatus
 import io.getstream.chat.android.compose.robots.assertMessageInChannelPreview
 import io.getstream.chat.android.compose.robots.assertMessagePreviewTimestamp
+import io.getstream.chat.android.compose.robots.assertScrollToBottomButton
+import io.getstream.chat.android.compose.robots.assertSystemMessage
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
 import io.getstream.chat.android.e2e.test.uiautomator.device
@@ -272,6 +275,62 @@ class ChannelListTests : StreamTestCase() {
         }
         step("AND the message timestamp is shown") {
             userRobot.assertMessagePreviewTimestamp(isDisplayed = true)
+        }
+    }
+
+    @AllureId("5797")
+    @Test
+    fun test_messageList_and_channelPreview_AreUpdatedWhenChannelTruncatedWithMessage() {
+        val message = "Channel truncated"
+
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 42)
+            userRobot.login().openChannel()
+        }
+        step("WHEN the channel is truncated with a system message") {
+            backendRobot.truncateChannel(withMessage = true)
+        }
+        step("THEN user observes only the system message") {
+            userRobot
+                .assertSystemMessage(message)
+                .assertMessageCount(0)
+                .assertScrollToBottomButton(isDisplayed = false)
+        }
+        step("WHEN user goes back to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        step("THEN the channel preview shows the system message") {
+            userRobot.assertMessageInChannelPreview(message, fromCurrentUser = true)
+        }
+        step("AND the message timestamp is shown") {
+            userRobot.assertMessagePreviewTimestamp(isDisplayed = true)
+        }
+    }
+
+    @AllureId("5827")
+    @Test
+    fun test_messageList_and_channelPreview_AreUpdatedWhenChannelTruncatedWithoutMessage() {
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 42)
+            userRobot.login().openChannel()
+        }
+        step("WHEN the channel is truncated without a system message") {
+            backendRobot.truncateChannel(withMessage = false)
+        }
+        step("THEN user observes an empty message list") {
+            userRobot
+                .assertMessageCount(0)
+                .assertSystemMessage("Channel truncated", isDisplayed = false)
+                .assertScrollToBottomButton(isDisplayed = false)
+        }
+        step("WHEN user goes back to the channel list") {
+            userRobot.tapOnBackButton()
+        }
+        step("THEN the channel preview is empty") {
+            userRobot.assertMessageInChannelPreview("No messages yet")
+        }
+        step("AND the message timestamp is hidden") {
+            userRobot.assertMessagePreviewTimestamp(isDisplayed = false)
         }
     }
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.compose.robots.assertMessageDeliveryStatus
 import io.getstream.chat.android.compose.robots.assertMessageInChannelPreview
 import io.getstream.chat.android.compose.robots.assertMessagePreviewTimestamp
 import io.getstream.chat.android.compose.robots.assertScrollToBottomButton
+import io.getstream.chat.android.compose.robots.assertScrollToBottomButtonUnreadCount
 import io.getstream.chat.android.compose.robots.assertSystemMessage
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
@@ -295,6 +296,7 @@ class ChannelListTests : StreamTestCase() {
                 .assertSystemMessage(message)
                 .assertMessageCount(0)
                 .assertScrollToBottomButton(isDisplayed = false)
+                .assertScrollToBottomButtonUnreadCount(0)
         }
         step("WHEN user goes back to the channel list") {
             userRobot.tapOnBackButton()
@@ -322,6 +324,7 @@ class ChannelListTests : StreamTestCase() {
                 .assertMessageCount(0)
                 .assertSystemMessage("Channel truncated", isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = false)
+                .assertScrollToBottomButtonUnreadCount(0)
         }
         step("WHEN user goes back to the channel list") {
             userRobot.tapOnBackButton()

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.compose.tests
 import io.getstream.chat.android.compose.robots.assertMessageDeliveryStatus
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
+import io.getstream.chat.android.e2e.test.robots.ParticipantRobot
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
 import org.junit.Ignore
@@ -457,6 +458,222 @@ class MessageDeliveryStatusTests : StreamTestCase() {
             userRobot.moveToChannelListFromMessageList()
         }
         step("THEN delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5746")
+    @Ignore("https://linear.app/stream/issue/AND-1310")
+    @Test
+    fun test_readByDecremented_whenParticipantIsRemoved() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND participant reads the message") {
+            participantRobot.readMessage()
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.READ)
+        }
+        step("WHEN participant is removed from the channel") {
+            backendRobot.removeMember(ParticipantRobot.id)
+        }
+        step("THEN user observes a single checkmark below the message") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
+        }
+    }
+
+    @AllureId("5756")
+    @Ignore("https://linear.app/stream/issue/AND-1310")
+    @Test
+    fun test_readByDecrementedInThreadReply_whenParticipantIsRemoved() {
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 1)
+            userRobot.login().openChannel()
+        }
+        step("AND user replies to message in thread") {
+            userRobot.openThread().sendMessage(sampleText)
+        }
+        step("AND participant reads the thread reply") {
+            participantRobot.readMessage()
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.READ)
+        }
+        step("WHEN participant is removed from the channel") {
+            backendRobot.removeMember(ParticipantRobot.id)
+        }
+        step("THEN user observes a single checkmark below the thread reply") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
+        }
+    }
+
+    @AllureId("5759")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHidden_whenMessageIsSentAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("THEN delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5760")
+    @Test
+    fun test_deliveryStatusShowsClocks_whenMessageIsInPendingStateAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends a new message that is gonna freeze") {
+            backendRobot.freezeNewMessages()
+            userRobot.sendMessage("pending message")
+        }
+        step("THEN message delivery status shows clocks") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.PENDING)
+        }
+    }
+
+    @AllureId("5761")
+    @Test
+    fun test_errorIndicatorShown_whenMessageFailedToBeSentAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends a new message that is gonna fail") {
+            backendRobot.failNewMessages()
+            userRobot.sendMessage("failed message")
+        }
+        step("THEN error indicator is shown for the message") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.FAILED)
+        }
+    }
+
+    @AllureId("5762")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHidden_whenMessageReadByParticipantAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("WHEN participant reads the message") {
+            participantRobot.readMessage()
+        }
+        step("THEN delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5763")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHidden_whenNewParticipantAddedAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND participant reads the message") {
+            participantRobot.readMessage()
+        }
+        step("WHEN a new participant is added to the channel") {
+            backendRobot.addMember("leia_organa")
+        }
+        step("THEN delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5764")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHidden_whenParticipantIsRemovedAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND participant reads the message") {
+            participantRobot.readMessage()
+        }
+        step("WHEN participant is removed from the channel") {
+            backendRobot.removeMember(ParticipantRobot.id)
+        }
+        step("THEN delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5765")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHiddenForMessagesInGroup_whenReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("WHEN user sends another message") {
+            userRobot.sendMessage("second message")
+        }
+        step("THEN delivery status is hidden for all messages") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5766")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHidden_whenMessageIsDeletedAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND delivery status is hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+        step("WHEN user deletes the message") {
+            userRobot.deleteMessage()
+        }
+        step("THEN delivery status stays hidden") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
+        }
+    }
+
+    @AllureId("5771")
+    @Ignore("https://linear.app/stream/issue/AND-1309")
+    @Test
+    fun test_deliveryStatusHiddenInPreview_whenMessageIsSentAndReadEventsIsDisabled() {
+        step("GIVEN read events are disabled and user opens the channel") {
+            backendRobot.setReadEvents(enabled = false)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("WHEN user returns to the channel list") {
+            userRobot.moveToChannelListFromMessageList()
+        }
+        step("THEN delivery status is hidden in the channel preview") {
             userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.NIL)
         }
     }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageListTests.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.compose.tests
 
 import io.getstream.chat.android.compose.robots.assertAlsoInTheChannelLabelInChannel
 import io.getstream.chat.android.compose.robots.assertAlsoInTheChannelLabelInThread
+import io.getstream.chat.android.compose.robots.assertComposerAttachmentsButton
 import io.getstream.chat.android.compose.robots.assertComposerCommandsMenu
 import io.getstream.chat.android.compose.robots.assertComposerMentionsMenu
 import io.getstream.chat.android.compose.robots.assertComposerSize
@@ -242,6 +243,26 @@ class MessageListTests : StreamTestCase() {
         }
     }
 
+    @AllureId("5720")
+    @Test
+    fun test_addingCommandHidesAttachmentsButton() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user observes the attachments button") {
+            userRobot.assertComposerAttachmentsButton(isDisplayed = true)
+        }
+        step("WHEN user selects the giphy command from the suggestions") {
+            userRobot
+                .openComposerCommands()
+                .assertComposerCommandsMenu(isDisplayed = true)
+                .tapOnGiphyCommandSuggestion()
+        }
+        step("THEN the attachments button disappears") {
+            userRobot.assertComposerAttachmentsButton(isDisplayed = false)
+        }
+    }
+
     // MARK: Typing indicator
 
     @AllureId("5702")
@@ -432,6 +453,54 @@ class MessageListTests : StreamTestCase() {
         step("THEN message list is scrolled down") {
             userRobot
                 .assertMessage(sampleText)
+                .assertScrollToBottomButton(isDisplayed = false)
+        }
+    }
+
+    @AllureId("5795")
+    @Test
+    fun test_messageListScrollsDown_whenUserTapsOnScrollToBottomButton() {
+        val newMessage = "New message"
+
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 30)
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(newMessage)
+        }
+        step("WHEN user scrolls up") {
+            userRobot.scrollMessageListUp()
+        }
+        step("AND user taps on the scroll to bottom button") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        step("THEN message list is scrolled down") {
+            userRobot
+                .assertMessage(newMessage)
+                .assertScrollToBottomButton(isDisplayed = false)
+        }
+    }
+
+    @AllureId("5831")
+    @Test
+    fun test_reloadsSkippedMessages_whenScrolledToTheBottom() {
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 30)
+            userRobot.login().openChannel()
+        }
+        step("AND user scrolls up") {
+            userRobot.scrollMessageListUp()
+        }
+        step("AND participant sends some messages") {
+            participantRobot.sendMultipleMessages("Some message", count = 16)
+        }
+        step("WHEN user scrolls to the bottom") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        step("THEN skipped messages are reloaded") {
+            userRobot
+                .assertMessage("Some message-16")
                 .assertScrollToBottomButton(isDisplayed = false)
         }
     }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/SlowModeTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/SlowModeTests.kt
@@ -17,9 +17,13 @@
 package io.getstream.chat.android.compose.tests
 
 import io.getstream.chat.android.compose.robots.assertComposerIsDisabledInSlowMode
+import io.getstream.chat.android.compose.robots.assertCooldownIsNotShown
 import io.getstream.chat.android.compose.robots.assertCooldownIsShown
+import io.getstream.chat.android.compose.robots.assertQuotedMessage
+import io.getstream.chat.android.compose.robots.assertThreadIsOpen
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.qameta.allure.kotlin.Allure.step
+import io.qameta.allure.kotlin.AllureId
 import org.junit.Test
 
 class SlowModeTests : StreamTestCase() {
@@ -28,6 +32,8 @@ class SlowModeTests : StreamTestCase() {
 
     private val cooldownDuration = 15
     private val message = "message"
+    private val replyMessage = "reply message"
+    private val editedMessage = "edited message"
 
     @Test
     fun test_cooldownIsShownWhenNewMessageIsSent() {
@@ -60,6 +66,93 @@ class SlowModeTests : StreamTestCase() {
             userRobot
                 .assertCooldownIsShown()
                 .assertComposerIsDisabledInSlowMode()
+        }
+    }
+
+    @AllureId("5788")
+    @Test
+    fun test_slowModeIsActiveAndCooldownIsShown_whenAMessageIsReplied() {
+        step("GIVEN slow mode is enabled on the channel") {
+            backendRobot.setCooldown(enabled = true, duration = cooldownDuration)
+        }
+        step("AND user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND participant sends a new message") {
+            participantRobot.sendMessage(message)
+        }
+        step("WHEN user replies to the message") {
+            userRobot.quoteMessage(replyMessage)
+        }
+        step("THEN slow mode is active and the cooldown is shown") {
+            userRobot.assertCooldownIsShown()
+        }
+        step("AND the reply is sent") {
+            userRobot.assertQuotedMessage(text = replyMessage, quote = message)
+        }
+    }
+
+    @AllureId("5790")
+    @Test
+    fun test_aMessageCantBeReplied_whenSlowModeIsActiveAndCooldownIsShown() {
+        step("GIVEN slow mode is enabled on the channel") {
+            backendRobot.setCooldown(enabled = true, duration = cooldownDuration)
+        }
+        step("AND user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        step("WHEN user selects reply to the message from the context menu") {
+            userRobot.selectReplyFromContextMenu()
+        }
+        step("THEN the cooldown is shown and the composer is locked") {
+            userRobot
+                .assertCooldownIsShown()
+                .assertComposerIsDisabledInSlowMode()
+        }
+    }
+
+    @AllureId("5791")
+    @Test
+    fun test_slowModeContinuesActiveAndCooldownIsShownInThreadMessage_whenSlowModeIsActiveAndCooldownIsShownInChannel() {
+        step("GIVEN slow mode is enabled on the channel") {
+            backendRobot.setCooldown(enabled = true, duration = cooldownDuration)
+        }
+        step("AND user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a new message") {
+            userRobot.sendMessage(message)
+        }
+        step("WHEN user opens the thread on the message") {
+            userRobot.openThread()
+        }
+        step("THEN the cooldown is shown and the composer is locked in the thread") {
+            userRobot
+                .assertThreadIsOpen()
+                .assertCooldownIsShown()
+                .assertComposerIsDisabledInSlowMode()
+        }
+    }
+
+    @AllureId("5794")
+    @Test
+    fun test_slowModeIsNotActiveAndCooldownIsNotShown_whenAMessageIsEdited() {
+        step("GIVEN slow mode is enabled on a channel with a message") {
+            backendRobot
+                .generateChannels(channelsCount = 1, messagesCount = 1)
+                .setCooldown(enabled = true, duration = cooldownDuration)
+        }
+        step("AND user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user edits the message") {
+            userRobot.editMessage(editedMessage)
+        }
+        step("THEN slow mode is not active and the cooldown is not shown") {
+            userRobot.assertCooldownIsNotShown()
         }
     }
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/SlowModeTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/SlowModeTests.kt
@@ -30,7 +30,9 @@ class SlowModeTests : StreamTestCase() {
 
     override fun initTestActivity() = InitTestActivity.UserLogin
 
-    private val cooldownDuration = 15
+    // Long enough that the cooldown cannot expire between the message send and the assert
+    // on a slow CI emulator; no test waits for the cooldown to end.
+    private val cooldownDuration = 60
     private val message = "message"
     private val replyMessage = "reply message"
     private val editedMessage = "edited message"

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ScrollToBottomButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ScrollToBottomButton.kt
@@ -96,7 +96,9 @@ internal fun ScrollToBottomButton(
                     contentColor = ChatTheme.colors.badgeTextOnAccent,
                 ) {
                     Text(
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = StreamTokens.spacing3xs),
+                        modifier = Modifier
+                            .padding(horizontal = 6.dp, vertical = StreamTokens.spacing3xs)
+                            .testTag("Stream_ScrollToBottomButtonUnreadCount"),
                         text = count.toString(),
                         style = ChatTheme.typography.metadataEmphasis,
                     )

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/BackendRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/BackendRobot.kt
@@ -62,6 +62,17 @@ public class BackendRobot(
         return this
     }
 
+    /**
+     * Truncates the currently open channel on the server side. The app under test receives
+     * the `channel.truncated` websocket event.
+     *
+     * @param withMessage When `true`, the truncation also delivers a "Channel truncated" system message.
+     */
+    public fun truncateChannel(withMessage: Boolean): BackendRobot {
+        mockServer.postRequest("truncate_channel?with_message=$withMessage")
+        return this
+    }
+
     public fun revokeToken(duration: Int = 5) {
         waitForMockServerToStart()
         mockServer.postRequest("jwt/revoke_token?duration=$duration")

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/BackendRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/BackendRobot.kt
@@ -73,6 +73,39 @@ public class BackendRobot(
         return this
     }
 
+    /**
+     * Enables or disables read events on every channel. Call before the channel is opened.
+     *
+     * @param enabled Whether the channel config reports `read_events`.
+     */
+    public fun setReadEvents(enabled: Boolean): BackendRobot {
+        waitForMockServerToStart()
+        mockServer.postRequest("config/read_events?value=$enabled")
+        return this
+    }
+
+    /**
+     * Adds a member to the currently open channel on the server side. The app under test
+     * receives the `member.added` and `channel.updated` websocket events.
+     *
+     * @param userId The id of the user to add.
+     */
+    public fun addMember(userId: String): BackendRobot {
+        mockServer.postRequest("add_member?user_id=$userId")
+        return this
+    }
+
+    /**
+     * Removes a member from the currently open channel on the server side. The app under test
+     * receives the `member.removed` and `channel.updated` websocket events.
+     *
+     * @param userId The id of the user to remove.
+     */
+    public fun removeMember(userId: String): BackendRobot {
+        mockServer.postRequest("remove_member?user_id=$userId")
+        return this
+    }
+
     public fun revokeToken(duration: Int = 5) {
         waitForMockServerToStart()
         mockServer.postRequest("jwt/revoke_token?duration=$duration")

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
@@ -64,6 +64,20 @@ public class ParticipantRobot(
         return this
     }
 
+    /**
+     * Sends [count] messages named `"$text-1"` through `"$text-$count"`, spaced 300ms apart.
+     *
+     * @param text The base text of every message; the one-based index is appended after a dash.
+     * @param count How many messages to send.
+     */
+    public fun sendMultipleMessages(text: String, count: Int): ParticipantRobot {
+        repeat(count) { index ->
+            sendMessage("$text-${index + 1}")
+            Thread.sleep(MULTIPLE_MESSAGES_INTERVAL_MILLIS)
+        }
+        return this
+    }
+
     public fun sendMessageInThread(text: String, alsoSendInChannel: Boolean = false): ParticipantRobot {
         mockServer.postRequest(
             "participant/message?thread=true&thread_and_channel=$alsoSendInChannel",
@@ -192,3 +206,5 @@ public class ParticipantRobot(
         return this
     }
 }
+
+private const val MULTIPLE_MESSAGES_INTERVAL_MILLIS = 300L

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
@@ -28,6 +28,7 @@ public class ParticipantRobot(
 
     public companion object {
         public const val name: String = "Count Dooku"
+        public const val id: String = "count_dooku"
     }
 
     public fun startTyping(): ParticipantRobot {


### PR DESCRIPTION
### Goal

Close the iOS e2e parity gap for every topic that needs no new delivery infrastructure: slow mode, channel truncation, message list scroll, read events, and attachment upload recovery. Each ported test binds to its pre-seeded Allure TestOps case id via `@AllureId`, so the case flips from manual to automated and keeps its history. Part of AND-1304; push notifications follow separately because they need a new delivery path in the mock server.

### Implementation

One commit per topic, in the order they were verified:

- **Slow mode** (4 tests, ids 5788, 5790, 5791, 5794). The "message can't be sent" scenarios assert Android's own contract (cooldown indicator shown, composer disabled) because Android disables the composer during cooldown since #6499, while iOS keeps typing enabled. `quoteMessage` is split into `selectReplyFromContextMenu` plus send, since two tests need the reply action alone. The cooldown duration is 60 seconds (iOS uses 15) so it cannot expire between the message send and the assert on a slow CI emulator; no test waits for the cooldown to end.
- **Channel truncation** (2 tests, ids 5797, 5827). iOS truncates through its test app's debug menu; the Android sample has none, so `BackendRobot.truncateChannel` triggers it server-side through a new mock-server route and the app reacts to the `channel.truncated` event. New `assertMessageCount` helper.
- **Message list scroll and commands** (3 tests, ids 5795, 5831, 5720). Adds `ParticipantRobot.sendMultipleMessages` (mirrors iOS: `text-index` suffix, 300ms spacing), a testTag on the scroll-to-bottom unread badge plus its assert helper, and the zero-count backfill on the truncation tests. The command test asserts Android's behavior: the attachments button hides when a command is selected from the suggestions, while on iOS typing `/` already hides the left buttons.
- **Read events and member removal** (11 tests, ids 5746, 5756, 5759-5766, 5771). Adds `BackendRobot.setReadEvents`/`addMember`/`removeMember` (server-side member triggers in the mock server) and `ParticipantRobot.id`. Only 2 land active: the other 9 assert behavior the Compose SDK does not implement yet and are `@Ignore`d against AND-1309 (delivery indicators ignore `read_events`) and AND-1310 (READ does not fall back to SENT when the reading member is removed). Both tickets list their tests; the fix PRs remove the `@Ignore` and the tests are the acceptance check.
- **Attachment upload recovery** (1 test, id 5928). iOS restarts a failed image upload with a dedicated button; the Compose SDK has no restart control, and the offline module uploads the image automatically on reconnect, so the test asserts that recovery under an Android-accurate name.

The truncation and member trigger routes this PR relies on shipped in GetStream/stream-chat-test-mock-server#44 (merged).

Not ported, with reasons verified per case: 5786, 5696, 5913, 5924, 5926 are already covered by existing active Android tests; 5829, 5708, 5929 no longer exist in the iOS suite; 5914 asserts "loaded but off-screen", which Compose's LazyColumn does not expose to UiAutomator (the observable behavior is covered by active test 5912). The full disposition list is on AND-1304.

### Testing

All new active tests pass locally against the mock server, first attempt each:

```
./gradlew :stream-chat-android-compose-sample:connectedE2eDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=io.getstream.chat.android.compose.tests.SlowModeTests
```

Same for `ChannelListTests` (truncation), `MessageListTests` (scroll and command), `MessageDeliveryStatusTests` (the 2 active read-events tests), and `AttachmentsTests#test_imageUploadRecovers_whenUserComesBackOnline`. The suite needs the attachment fixtures on the emulator (`bundle exec fastlane upload_attachments`) and recent modification times on them, so they appear in the picker's first screen.

On CI, the full 6-API-level matrix ran from this branch against the new mock routes ([run](https://github.com/GetStream/stream-chat-android/actions/runs/29345514457)): the truncation and member trigger tests passed on every API level. The only failures were the two slow mode tests on the 3 slower API levels, which is what the 60-second cooldown commit fixes.

No UI changes (the only SDK change is a testTag).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a UI selector/tag for the “scroll to bottom” unread-count badge, enabling more precise message list validations.
  * Improved end-to-end coverage for message list UI: composer attachment button state, scroll-to-bottom behavior, and reloading skipped messages.
  * Improved reliability testing for image upload recovery after connectivity returns.
  * Improved channel preview/message list correctness after truncation (with and without system messages).
  * Strengthened message delivery-status and preview indicators for participant changes and when read events are disabled.
  * Enhanced slow-mode end-to-end validation for replies, thread replies, context-menu actions, and message editing.
  * Improved composer command flow for Giphy suggestion selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
