### PR TITLE
e2e: Re-enable the recovered tests and settle the ignored-test decisions

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -36,7 +36,6 @@ import io.getstream.chat.android.e2e.test.uiautomator.isDisplayed
 import io.getstream.chat.android.e2e.test.uiautomator.longPress
 import io.getstream.chat.android.e2e.test.uiautomator.swipeDown
 import io.getstream.chat.android.e2e.test.uiautomator.swipeUp
-import io.getstream.chat.android.e2e.test.uiautomator.tapOnScreenCenter
 import io.getstream.chat.android.e2e.test.uiautomator.typeText
 import io.getstream.chat.android.e2e.test.uiautomator.wait
 import io.getstream.chat.android.e2e.test.uiautomator.waitToAppear
@@ -407,9 +406,5 @@ class UserRobot {
             Composer.sendButton.waitToAppear().click()
         }
         return this
-    }
-
-    fun tapOnMessageList() {
-        device.tapOnScreenCenter()
     }
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -211,6 +211,13 @@ class UserRobot {
         return this
     }
 
+    fun quoteMessage(text: String, quotedMessageText: String): UserRobot {
+        openContextMenu(quotedMessageText)
+        ContextMenu.reply.waitToAppear().click()
+        sendMessage(text)
+        return this
+    }
+
     fun openThread(messageCellIndex: Int = 0, usingContextMenu: Boolean = true): UserRobot {
         if (usingContextMenu) {
             openContextMenu(messageCellIndex)

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -71,9 +71,7 @@ fun UserRobot.assertMessage(
         assertTrue(textLocator.waitDisplayed())
         assertTrue(Message.timestamp.isDisplayed())
     } else {
-        MessageListPage.MessageList.messages.findObjects().forEach {
-            assertTrue(it.text != text)
-        }
+        assertFalse(Message.text.text(text).waitToDisappear().isDisplayed())
     }
     return this
 }
@@ -150,14 +148,16 @@ fun UserRobot.assertDeletedMessage(text: String? = null, hard: Boolean = false):
     return this
 }
 
-fun UserRobot.assertQuotedMessage(text: String, quote: String = "", isDisplayed: Boolean = true): UserRobot {
+fun UserRobot.assertQuotedMessage(text: String? = null, quote: String = "", isDisplayed: Boolean = true): UserRobot {
     val quotedMessageInList = Message.quotedMessage.hasAncestor(MessageListPage.MessageList.messages)
     if (isDisplayed) {
         assertEquals(quote, quotedMessageInList.waitForText(quote))
     } else {
         assertFalse(quotedMessageInList.waitToDisappear().isDisplayed())
     }
-    assertMessage(text, isDisplayed = isDisplayed)
+    if (text != null) {
+        assertMessage(text, isDisplayed = isDisplayed)
+    }
     return this
 }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -65,13 +65,12 @@ fun UserRobot.assertMessage(
     isDisplayed: Boolean = true,
     isClickable: Boolean = false,
 ): UserRobot {
+    val textLocator = (if (isClickable) Message.clickableText else Message.text).text(text)
     if (isDisplayed) {
-        val textLocator = (if (isClickable) Message.clickableText else Message.text)
-            .text(text)
         assertTrue(textLocator.waitDisplayed())
         assertTrue(Message.timestamp.isDisplayed())
     } else {
-        assertFalse(Message.text.text(text).waitToDisappear().isDisplayed())
+        assertFalse(textLocator.waitToDisappear().isDisplayed())
     }
     return this
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
@@ -32,7 +32,6 @@ import io.getstream.chat.android.e2e.test.uiautomator.enableInternetConnection
 import io.getstream.chat.android.e2e.test.uiautomator.seconds
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
-import org.junit.Ignore
 import org.junit.Test
 
 class ChannelListTests : StreamTestCase() {
@@ -133,7 +132,6 @@ class ChannelListTests : StreamTestCase() {
     }
 
     @AllureId("5796")
-    @Ignore("https://linear.app/stream/issue/AND-218")
     @Test
     fun test_channelPreviewShowsNoMessages_whenChannelIsEmpty() {
         step("WHEN user opens channel list") {
@@ -142,8 +140,8 @@ class ChannelListTests : StreamTestCase() {
         step("AND the channel has no messages") {
             // No actions required as the channel is empty by default
         }
-        step("THEN the channel preview shows No messages") {
-            userRobot.assertMessageInChannelPreview("No messages", fromCurrentUser = false)
+        step("THEN the channel preview shows the empty state") {
+            userRobot.assertMessageInChannelPreview("No messages yet")
         }
         step("AND the message timestamp is hidden") {
             userRobot.assertMessagePreviewTimestamp(isDisplayed = false)
@@ -151,9 +149,8 @@ class ChannelListTests : StreamTestCase() {
     }
 
     @AllureId("5798")
-    @Ignore("https://linear.app/stream/issue/AND-218")
     @Test
-    fun test_channelPreviewShowsNoMessages_whenTheOnlyMessageInChannelIsDeleted() {
+    fun test_channelPreviewShowsMessageDeleted_whenTheOnlyMessageInChannelIsDeleted() {
         step("GIVEN user opens the channel") {
             userRobot.login().openChannel()
         }
@@ -166,11 +163,11 @@ class ChannelListTests : StreamTestCase() {
         step("WHEN user goes back to the channel list") {
             userRobot.tapOnBackButton()
         }
-        step("THEN the channel preview shows No messages") {
-            userRobot.assertMessageInChannelPreview("No messages", fromCurrentUser = false)
+        step("THEN the channel preview shows the deleted message placeholder") {
+            userRobot.assertMessageInChannelPreview("\uFFFD Message deleted", fromCurrentUser = false)
         }
-        step("AND the message timestamp is hidden") {
-            userRobot.assertMessagePreviewTimestamp(isDisplayed = false)
+        step("AND the message timestamp is shown") {
+            userRobot.assertMessagePreviewTimestamp(isDisplayed = true)
         }
     }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/GiphyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/GiphyTests.kt
@@ -27,7 +27,6 @@ import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
-import org.junit.Ignore
 import org.junit.Test
 
 class GiphyTests : StreamTestCase() {
@@ -119,7 +118,6 @@ class GiphyTests : StreamTestCase() {
     }
 
     @AllureId("5787")
-    @Ignore("https://linear.app/stream/issue/AND-218")
     @Test
     fun test_channelListNotModified_whenEphemeralMessageShown() {
         step("GIVEN user opens a channel") {
@@ -132,12 +130,11 @@ class GiphyTests : StreamTestCase() {
             userRobot.tapOnBackButton()
         }
         step("THEN message is not added to the channel list") {
-            userRobot.assertMessageInChannelPreview("No messages", fromCurrentUser = false)
+            userRobot.assertMessageInChannelPreview("No messages yet")
         }
     }
 
     @AllureId("5782")
-    @Ignore("https://linear.app/stream/issue/AND-245")
     @Test
     fun test_deliveryStatusHidden_whenEphemeralMessageShown() {
         step("GIVEN user opens a channel") {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -397,7 +397,6 @@ class MessageDeliveryStatusTests : StreamTestCase() {
     }
 
     @AllureId("5774")
-    @Ignore("https://linear.app/stream/issue/AND-255")
     @Test
     fun test_singleCheckmarkShownForMessageInPreview_whenThreadReplyFailedToBeSent() {
         step("GIVEN user opens the channel") {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageListTests.kt
@@ -223,26 +223,6 @@ class MessageListTests : StreamTestCase() {
         }
     }
 
-    @Ignore("https://linear.app/stream/issue/AND-181")
-    @AllureId("5717")
-    @Test
-    fun test_commandsMenuCloses_whenUserTapsOnMessageList() {
-        step("GIVEN user opens the channel") {
-            userRobot.login().openChannel()
-        }
-        step("AND user opens attachments menu") {
-            userRobot
-                .openComposerCommands()
-                .assertComposerCommandsMenu(isDisplayed = true)
-        }
-        step("WHEN user taps on message list") {
-            userRobot.tapOnMessageList()
-        }
-        step("THEN command suggestions disappear") {
-            userRobot.assertComposerCommandsMenu(isDisplayed = false)
-        }
-    }
-
     @AllureId("5720")
     @Test
     fun test_addingCommandHidesAttachmentsButton() {
@@ -391,7 +371,6 @@ class MessageListTests : StreamTestCase() {
 
     // MARK: Scrolling
 
-    @Ignore("https://linear.app/stream/issue/AND-76")
     @AllureId("5792")
     @Test
     fun test_messageListScrollsDown_whenMessageListIsScrolledUp_andUserSendsNewMessage() {
@@ -906,7 +885,6 @@ class MessageListTests : StreamTestCase() {
     }
 
     @AllureId("6608")
-    @Ignore("https://linear.app/stream/issue/AND-212")
     @Test
     fun test_messageRendersTimestampAgain_whenMessageLastInGroupIsSoftDeleted() {
         step("GIVEN user opens the channel") {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
@@ -238,7 +238,7 @@ class QuotedReplyTests : StreamTestCase() {
             participantRobot.deleteMessage()
         }
         step("THEN deleted message is shown") {
-            userRobot.assertDeletedMessage(quoteReply)
+            userRobot.assertDeletedMessage("1")
         }
         step("AND deleted message is shown in quoted reply bubble") {
             userRobot.assertQuotedMessage(
@@ -286,7 +286,7 @@ class QuotedReplyTests : StreamTestCase() {
             userRobot.deleteMessage(sampleText)
         }
         step("THEN deleted message is shown") {
-            userRobot.assertDeletedMessage(quoteReply)
+            userRobot.assertDeletedMessage(sampleText)
         }
         step("AND deleted message is shown in quoted reply bubble") {
             userRobot.assertQuotedMessage(
@@ -363,6 +363,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5892")
+    @Ignore("https://linear.app/stream/issue/AND-960")
     @Test
     fun test_quotedReplyNotInList_whenUserAddsQuotedReply_InThread() {
         step("GIVEN user opens the channel") {
@@ -658,7 +659,7 @@ class QuotedReplyTests : StreamTestCase() {
         step("THEN deleted message is shown") {
             userRobot
                 .assertDeletedMessage(quoteReply)
-                .assertQuotedMessage(text = sampleText, isDisplayed = false)
+                .assertQuotedMessage(isDisplayed = false)
         }
     }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
@@ -96,7 +96,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5684")
-    @Ignore("https://linear.app/stream/issue/AND-76")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenUserAddsQuotedReply() {
         step("GIVEN user opens the channel") {
@@ -150,7 +150,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5865")
-    @Ignore("https://linear.app/stream/issue/AND-266")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_File() {
         step("GIVEN user opens the channel") {
@@ -176,7 +176,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5866")
-    @Ignore("https://linear.app/stream/issue/AND-266")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Giphy() {
         step("GIVEN user opens the channel") {
@@ -364,7 +364,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5892")
-    @Ignore("https://linear.app/stream/issue/AND-76")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenUserAddsQuotedReply_InThread() {
         step("GIVEN user opens the channel") {
@@ -393,7 +393,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5893")
-    @Ignore("https://linear.app/stream/issue/AND-960")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Message_InThread() {
         step("GIVEN user opens the channel") {
@@ -425,7 +425,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5894")
-    @Ignore("https://linear.app/stream/issue/AND-266")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_File_InThread() {
         step("GIVEN user opens the channel") {
@@ -457,7 +457,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5895")
-    @Ignore("https://linear.app/stream/issue/AND-266")
+    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Giphy_InThread() {
         step("GIVEN user opens the channel") {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.compose.tests
 
 import io.getstream.chat.android.compose.robots.assertDeletedMessage
+import io.getstream.chat.android.compose.robots.assertFile
 import io.getstream.chat.android.compose.robots.assertGiphyImage
 import io.getstream.chat.android.compose.robots.assertInvalidCommandMessage
 import io.getstream.chat.android.compose.robots.assertMessage
@@ -40,6 +41,7 @@ class QuotedReplyTests : StreamTestCase() {
     private val sampleText = "Test message"
     private var quoteReply = "Alright"
     private val messagesCount = 30
+    private val firstMessage = "1"
 
     @AllureId("5923")
     @Test
@@ -96,7 +98,6 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5684")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenUserAddsQuotedReply() {
         step("GIVEN user opens the channel") {
@@ -105,12 +106,12 @@ class QuotedReplyTests : StreamTestCase() {
         }
         step("WHEN user adds a quoted reply to message") {
             userRobot
-                .scrollMessageListUp(times = 3)
-                .quoteMessage(quoteReply, messageCellIndex = messagesCount - 1)
+                .scrollMessageListUp(times = 8)
+                .quoteMessage(quoteReply, quotedMessageText = firstMessage)
         }
         step("THEN user observes the quote reply in message list") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = true)
+                .assertQuotedMessage(text = quoteReply, quote = firstMessage, isDisplayed = true)
                 .assertScrollToBottomButton(isDisplayed = false)
         }
         step("WHEN user taps on a quoted message") {
@@ -118,7 +119,7 @@ class QuotedReplyTests : StreamTestCase() {
         }
         step("THEN user is scrolled up to the quote") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = false)
+                .assertQuotedMessage(text = quoteReply, quote = firstMessage, isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = true)
         }
     }
@@ -126,7 +127,6 @@ class QuotedReplyTests : StreamTestCase() {
     @AllureId("5685")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Message() {
-        val firstMessage = 1.toString()
         step("GIVEN user opens the channel") {
             backendRobot.generateChannels(channelsCount = 1, messagesCount = messagesCount)
             userRobot.login().openChannel()
@@ -150,7 +150,6 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5865")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_File() {
         step("GIVEN user opens the channel") {
@@ -162,7 +161,8 @@ class QuotedReplyTests : StreamTestCase() {
         }
         step("THEN user observes the quote reply in message list") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = true)
+                .assertFile(isDisplayed = true)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = true)
                 .assertScrollToBottomButton(isDisplayed = false)
         }
         step("WHEN user taps on a quoted message") {
@@ -170,13 +170,12 @@ class QuotedReplyTests : StreamTestCase() {
         }
         step("THEN user is scrolled up to the quote") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = false)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = true)
         }
     }
 
     @AllureId("5866")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Giphy() {
         step("GIVEN user opens the channel") {
@@ -189,7 +188,7 @@ class QuotedReplyTests : StreamTestCase() {
         step("THEN user observes the quote reply in message list") {
             userRobot
                 .assertGiphyImage(isDisplayed = true)
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = true)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = true)
                 .assertScrollToBottomButton(isDisplayed = false)
         }
         step("WHEN user taps on a quoted message") {
@@ -198,7 +197,7 @@ class QuotedReplyTests : StreamTestCase() {
         step("THEN user is scrolled up to the quote") {
             userRobot
                 .assertGiphyImage(isDisplayed = false)
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = false)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = true)
         }
     }
@@ -364,7 +363,6 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5892")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
     @Test
     fun test_quotedReplyNotInList_whenUserAddsQuotedReply_InThread() {
         step("GIVEN user opens the channel") {
@@ -374,12 +372,12 @@ class QuotedReplyTests : StreamTestCase() {
         step("WHEN user adds a quoted reply to message in thread") {
             userRobot
                 .openThread()
-                .scrollMessageListUp(times = 3)
-                .quoteMessage(quoteReply, messageCellIndex = messagesCount - 1)
+                .scrollMessageListUp(times = 8)
+                .quoteMessage(quoteReply, quotedMessageText = firstMessage)
         }
         step("THEN user observes the quote reply in thread") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = true)
+                .assertQuotedMessage(text = quoteReply, quote = firstMessage, isDisplayed = true)
                 .assertScrollToBottomButton(isDisplayed = false)
         }
         step("WHEN user taps on a quoted message") {
@@ -387,13 +385,13 @@ class QuotedReplyTests : StreamTestCase() {
         }
         step("THEN user is scrolled up to the quote") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = messagesCount.toString(), isDisplayed = false)
+                .assertQuotedMessage(text = quoteReply, quote = firstMessage, isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = true)
         }
     }
 
     @AllureId("5893")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
+    @Ignore("https://linear.app/stream/issue/AND-960")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Message_InThread() {
         step("GIVEN user opens the channel") {
@@ -425,7 +423,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5894")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
+    @Ignore("https://linear.app/stream/issue/AND-960")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_File_InThread() {
         step("GIVEN user opens the channel") {
@@ -443,7 +441,8 @@ class QuotedReplyTests : StreamTestCase() {
         step("THEN user observes the quote reply in thread") {
             userRobot
                 .openThread()
-                .assertQuotedMessage(text = quoteReply, quote = sampleText, isDisplayed = true)
+                .assertFile(isDisplayed = true)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = true)
                 .assertScrollToBottomButton(isDisplayed = false)
         }
         step("WHEN user taps on a quoted message") {
@@ -451,13 +450,13 @@ class QuotedReplyTests : StreamTestCase() {
         }
         step("THEN user is scrolled up to the quote") {
             userRobot
-                .assertQuotedMessage(text = quoteReply, quote = sampleText, isDisplayed = false)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = true)
         }
     }
 
     @AllureId("5895")
-    @Ignore("https://linear.app/stream/issue/AND-1312")
+    @Ignore("https://linear.app/stream/issue/AND-960")
     @Test
     fun test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Giphy_InThread() {
         step("GIVEN user opens the channel") {
@@ -476,7 +475,7 @@ class QuotedReplyTests : StreamTestCase() {
             userRobot
                 .openThread()
                 .assertGiphyImage(isDisplayed = true)
-                .assertQuotedMessage(text = quoteReply, quote = sampleText, isDisplayed = true)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = true)
                 .assertScrollToBottomButton(isDisplayed = false)
         }
         step("WHEN user taps on a quoted message") {
@@ -485,7 +484,7 @@ class QuotedReplyTests : StreamTestCase() {
         step("THEN user is scrolled up to the quote") {
             userRobot
                 .assertGiphyImage(isDisplayed = false)
-                .assertQuotedMessage(text = quoteReply, quote = sampleText, isDisplayed = false)
+                .assertQuotedMessage(quote = firstMessage, isDisplayed = false)
                 .assertScrollToBottomButton(isDisplayed = true)
         }
     }


### PR DESCRIPTION
### Goal

Settle the fate of the remaining ignored e2e tests, based on the per-test verification recorded on AND-1304. Eleven tests come back to the active suite, and the ones that stay ignored now point at real, open tickets instead of canceled ones. Part of AND-1304.

### Implementation

- **6 tests re-enabled as they were**: their canceled bug tickets described behavior that is correct on current develop (verified by running each test locally on the fixed harness). Two of them only needed the current empty-state copy (`No messages yet`, no sender prefix).
- **1 test re-enabled with a rewritten assertion**: the channel preview deliberately shows `Message deleted` when the only message is deleted (documented intent in `getLastMessageIncludingDeleted`, and iOS shows the same placeholder), so `test_channelPreviewShowsNoMessages_whenTheOnlyMessageInChannelIsDeleted` became `test_channelPreviewShowsMessageDeleted_...` and expects the placeholder.
- **4 quoted-reply tests fixed and re-enabled**: their failures were port bugs in the tests, not product bugs. The expected quoted text said `30` where the mock quotes the oldest message (`1`, matching the active sibling test and iOS), and the attachment variants asserted reply text that their robot calls never send (iOS asserts only the quote plus the attachment). The user variants now quote deterministically by message text after scrolling to the top, instead of by an index that Compose's LazyColumn cannot reach.
- **1 test deleted**: `test_commandsMenuCloses_whenUserTapsOnMessageList` asserted old-composer behavior; the redesigned suggestion list is driven by the input content and iOS has no counterpart. Its orphaned robot helper went with it.
- **3 tests parked on reopened AND-960**: tapping a quote in a thread does not jump to the quoted reply unless its cell was previously composed; reproduced deterministically with artifacts. The fix PR for AND-960 re-enables them.
- Harness: one more stale-read fix (`assertMessage`'s absence branch now checks at the selector level), `assertQuotedMessage`'s `text` parameter is optional to mirror the iOS helper shape, and a `quoteMessage(text, quotedMessageText)` overload for by-text quoting.

Ticket trail: AND-256, AND-272, and AND-960 are reopened with their tests as the acceptance check; the other linked tickets stay canceled with closing comments.

### Testing

Every re-enabled test passed locally against the mock server on the first attempt, verified per batch while making the changes (retry data on the device checked to rule out pass-on-retry). Reproduce with:

```
./gradlew :stream-chat-android-compose-sample:connectedE2eDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=io.getstream.chat.android.compose.tests.QuotedReplyTests
```

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end validation for quoted replies, deleted messages, empty channels, ephemeral messages, and message delivery states.
  * Updated channel previews to display “No messages yet” for empty channels and a deleted-message indicator when applicable.

* **Tests**
  * Re-enabled coverage for scrolling, quoted replies, delivery status, and ephemeral-message scenarios.
  * Added support for composing replies to specifically selected quoted messages.
  * Removed an obsolete message-list interaction test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->