### PR TITLE
CI Test: Run e2e cron tests on Android 16 and 17

### DIFF
--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -43,6 +43,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - android_api_level: 37
+          - android_api_level: 36
           - android_api_level: 35
           - android_api_level: 34
           - android_api_level: 33


### PR DESCRIPTION
### Goal
Closes #AND-1315
Run E2E tests on Android 16 and Android 17

### Implementation

Run E2E tests on Android 16 and Android 17

### 🎨 UI Changes

None

### Testing

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded nightly end-to-end testing to include Android API levels 36 and 37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->