### PR TITLE
Update the message read status when the reading member is removed from the channel

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
@@ -105,6 +105,7 @@ public fun Channel.updateLastMessage(
 
 /**
  * Removes member from the [Channel.members] and aligns [Channel.memberCount].
+ * Also removes the member's read state from [Channel.read], as a removed member no longer counts as a reader.
  *
  * @param memberUserId User id of the removed member.
  */
@@ -112,6 +113,7 @@ public fun Channel.updateLastMessage(
 public fun Channel.removeMember(memberUserId: String?): Channel = copy(
     members = members.filterNot { it.user.id == memberUserId },
     memberCount = memberCount - (1.takeIf { members.any { it.user.id == memberUserId } } ?: 0),
+    read = read.filterNot { it.user.id == memberUserId },
 )
 
 /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImpl.kt
@@ -271,6 +271,8 @@ internal class ChannelEventHandlerImpl(
 
             is MemberRemovedEvent -> {
                 state.removeMember(event)
+                // A removed member no longer counts as a reader of the channel
+                state.removeRead(event.member.getUserId())
                 // Remove the channel.membership if the current user is removed from the channel
                 if (event.member.getUserId() == getCurrentUserId()) {
                     state.deleteMembership()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelEventHandlerLegacyImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelEventHandlerLegacyImpl.kt
@@ -185,6 +185,8 @@ internal class ChannelEventHandlerLegacyImpl(
 
             is MemberRemovedEvent -> {
                 stateLogic.deleteMember(event.member)
+                // A removed member no longer counts as a reader of the channel
+                stateLogic.deleteRead(event.member.getUserId())
                 // Remove the channel.membership if the current user is removed from the channel
                 if (event.member.getUserId() == getCurrentUserId()) {
                     stateLogic.removeMembership()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelStateLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelStateLogic.kt
@@ -266,6 +266,15 @@ internal class ChannelStateLogic(
     }
 
     /**
+     * Deletes the read state of the given user, so they no longer count as a reader of the channel.
+     *
+     * @param userId The id of the user whose read state should be deleted.
+     */
+    fun deleteRead(userId: String) {
+        mutableState.deleteRead(userId)
+    }
+
+    /**
      * Updates the list of typing users.
      * The method is responsible for adding/removing typing users, sorting the list and updating both
      * [ChannelState] and [MutableGlobalState].

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImpl.kt
@@ -1166,6 +1166,15 @@ internal class ChannelStateImpl(
     }
 
     /**
+     * Removes the read state of the given user, so they no longer count as a reader of the channel.
+     *
+     * @param userId The id of the user whose read state should be removed.
+     */
+    fun removeRead(userId: UserId) {
+        _reads.update { current -> current - userId }
+    }
+
+    /**
      * Updates the delivered status for a user's read state.
      *
      * @param read The [ChannelUserRead] containing the delivered status to update.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
@@ -563,6 +563,17 @@ internal class ChannelStateLegacyImpl(
     }
 
     /**
+     * Deletes the read state of the given user, so they no longer count as a reader of the channel.
+     *
+     * @param userId The id of the user whose read state should be deleted.
+     */
+    fun deleteRead(userId: String) {
+        _rawReads?.apply {
+            value = value - userId
+        }
+    }
+
+    /**
      * Upsert the delivered status for a specific user's read.
      */
     fun upsertDelivered(read: ChannelUserRead) {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ChannelExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ChannelExtensionsTests.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.Location
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.randomChannel
+import io.getstream.chat.android.randomChannelUserRead
 import io.getstream.chat.android.randomLocation
 import io.getstream.chat.android.randomMember
 import io.getstream.chat.android.randomMembers
@@ -349,6 +350,27 @@ internal class ChannelExtensionsTests {
         result.memberCount shouldBeEqualTo 1
         result.members shouldContain memberToKeep
         result.members shouldNotContain memberToRemove
+    }
+
+    @Test
+    fun `removeMember should remove the member's read state`() {
+        // given
+        val memberToRemove = randomMember(user = randomUser(id = "user-to-remove"))
+        val memberToKeep = randomMember(user = randomUser(id = "user-to-keep"))
+        val readToRemove = randomChannelUserRead(user = memberToRemove.user)
+        val readToKeep = randomChannelUserRead(user = memberToKeep.user)
+        val channel = randomChannel(
+            members = listOf(memberToRemove, memberToKeep),
+            memberCount = 2,
+            read = listOf(readToRemove, readToKeep),
+        )
+
+        // when
+        val result = channel.removeMember("user-to-remove")
+
+        // then
+        result.read shouldContain readToKeep
+        result.read shouldNotContain readToRemove
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImplTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImplTest.kt
@@ -703,17 +703,19 @@ internal class ChannelEventHandlerImplTest {
         handler.handle(event)
 
         verify(state).removeMember(event)
+        verify(state).removeRead(member.getUserId())
         verify(state).deleteMembership()
     }
 
     @Test
-    fun `When MemberRemovedEvent for other user is handled, Then only member is deleted`() {
+    fun `When MemberRemovedEvent for other user is handled, Then member and its read state are deleted`() {
         val member = randomMember(user = randomUser(id = randomString()))
         val event = randomMemberRemovedEvent(cid = cid, member = member)
 
         handler.handle(event)
 
         verify(state).removeMember(event)
+        verify(state).removeRead(member.getUserId())
         verify(state, never()).deleteMembership()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelEventHandlerLegacyImplTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelEventHandlerLegacyImplTest.kt
@@ -450,17 +450,19 @@ internal class ChannelEventHandlerLegacyImplTest {
         handler.handle(event)
 
         verify(stateLogic).deleteMember(member)
+        verify(stateLogic).deleteRead(member.getUserId())
         verify(stateLogic).removeMembership()
     }
 
     @Test
-    fun `When MemberRemovedEvent for other user is handled, Then only member is deleted`() {
+    fun `When MemberRemovedEvent for other user is handled, Then member and its read state are deleted`() {
         val member = randomMember(user = randomUser(id = randomString()))
         val event = randomMemberRemovedEvent(cid = cid, member = member)
 
         handler.handle(event)
 
         verify(stateLogic).deleteMember(member)
+        verify(stateLogic).deleteRead(member.getUserId())
         verify(stateLogic, never()).removeMembership()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImplReadReceiptsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImplReadReceiptsTest.kt
@@ -658,6 +658,40 @@ internal class ChannelStateImplReadReceiptsTest : ChannelStateImplTestBase() {
 
     // endregion
 
+    @Nested
+    inner class RemoveRead {
+
+        @Test
+        fun `removeRead should remove read state for the given user`() = runTest {
+            // given
+            val user1 = randomUser(id = "user_1")
+            val user2 = randomUser(id = "user_2")
+            channelState.updateReads(
+                listOf(
+                    createRead(user1, unreadMessages = 0, lastRead = Date(1000)),
+                    createRead(user2, unreadMessages = 0, lastRead = Date(2000)),
+                ),
+            )
+            // when
+            channelState.removeRead("user_1")
+            // then
+            val reads = channelState.reads.value
+            assertEquals(1, reads.size)
+            assertEquals("user_2", reads.first().user.id)
+        }
+
+        @Test
+        fun `removeRead should do nothing when the user has no read state`() = runTest {
+            // given
+            val user = randomUser(id = "user_1")
+            channelState.updateRead(createRead(user, unreadMessages = 0, lastRead = Date(1000)))
+            // when
+            channelState.removeRead("unknown_user")
+            // then
+            assertEquals(1, channelState.reads.value.size)
+        }
+    }
+
     // region ReadsStateFlow
 
     @Nested

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImplTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImplTest.kt
@@ -786,6 +786,33 @@ internal class ChannelStateLegacyImplTest {
         assertEquals(delivered, userRead)
     }
 
+    @Test
+    fun `deleteRead should remove read state for the given user`() = runTest {
+        val user = randomUser()
+        val otherUser = randomUser()
+        channelState.upsertReads(
+            listOf(
+                randomChannelUserRead(user),
+                randomChannelUserRead(otherUser),
+            ),
+        )
+
+        channelState.deleteRead(user.id)
+
+        assertNull(channelState.reads.value.find { it.user.id == user.id })
+        assertNotNull(channelState.reads.value.find { it.user.id == otherUser.id })
+    }
+
+    @Test
+    fun `deleteRead should do nothing when the user has no read state`() = runTest {
+        val user = randomUser()
+        channelState.upsertReads(listOf(randomChannelUserRead(user)))
+
+        channelState.deleteRead(randomString())
+
+        assertEquals(1, channelState.reads.value.size)
+    }
+
     private fun ChannelStateLegacyImpl.assertPinnedMessagesSizeEqualsTo(size: Int) {
         require(pinnedMessages.value.size == size) {
             "pinnedMessages should have $size items, but was ${pinnedMessages.value.size}"

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -462,7 +462,6 @@ class MessageDeliveryStatusTests : StreamTestCase() {
     }
 
     @AllureId("5746")
-    @Ignore("https://linear.app/stream/issue/AND-1310")
     @Test
     fun test_readByDecremented_whenParticipantIsRemoved() {
         step("GIVEN user opens the channel") {
@@ -484,7 +483,6 @@ class MessageDeliveryStatusTests : StreamTestCase() {
     }
 
     @AllureId("5756")
-    @Ignore("https://linear.app/stream/issue/AND-1310")
     @Test
     fun test_readByDecrementedInThreadReply_whenParticipantIsRemoved() {
         step("GIVEN user opens the channel") {


### PR DESCRIPTION
### Goal

When the only member who read a message is removed from the channel, the message delivery status should fall back from READ (double checkmark) to SENT (single checkmark), because no remaining member has read it. Currently the status stays READ after the `member.removed` event: the member is removed from the state, but their read entry is kept, so both the Compose and XML message lists keep showing the double checkmark. The iOS SDK already behaves correctly by deleting the removed member's read state.

Resolves AND-1310

### Implementation

On `member.removed`, the removed member's `ChannelUserRead` is now deleted together with the member, in all three places that hold it:

- In-memory state: `ChannelEventHandlerImpl` calls the new `ChannelStateImpl.removeRead(userId)`.
- Legacy state: `ChannelEventHandlerLegacyImpl` calls the new `ChannelStateLogic.deleteRead(userId)`, which delegates to `ChannelStateLegacyImpl`.
- Offline storage: the `Channel.removeMember` extension (used by `EventHandlerSequential` to persist the event) now also filters the removed user's entry out of `Channel.read`, so a cold start does not restore the stale READ status.

The scope is `member.removed` only, matching the iOS SDK. `notification.removed_from_channel` and `notification.invite_rejected` are unchanged.

Since `MessageListController` computes the read status from `ChannelState.reads`, the fix applies to both the Compose and XML UI kits.

The two e2e tests ported in #6572 are no longer ignored and act as the acceptance check:
- `test_readByDecremented_whenParticipantIsRemoved`
- `test_readByDecrementedInThreadReply_whenParticipantIsRemoved`

### Testing

Manual steps:
1. Log in with user A and open a channel that also has member B.
2. Send a message as user A.
3. Read the message as user B. User A sees a double checkmark below the message.
4. Remove user B from the channel (for example, from the channel info screen or via a server-side call).
5. The indicator below the message falls back to a single checkmark.

The same steps apply to a thread reply (step 2: reply in a thread instead).

Automated coverage:
- New unit tests for `ChannelStateImpl.removeRead`, `ChannelStateLegacyImpl.deleteRead`, both event handlers, and the `Channel.removeMember` extension. `:stream-chat-android-client:testDebugUnitTest` passes.
- The two previously ignored e2e tests listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed users’ read-state entries when they leave or are removed from a channel.
  - Prevented removed members from continuing to appear as channel readers.
  - Preserved read states for remaining channel members.

- **Tests**
  - Added coverage for member removal and read-state cleanup.
  - Re-enabled end-to-end tests for message and thread read-status updates after member removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->