### PR TITLE
Revert "CI Test: Run e2e cron tests on Android 16 and 17"

### DIFF
--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -43,8 +43,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - android_api_level: 37
-          - android_api_level: 36
           - android_api_level: 35
           - android_api_level: 34
           - android_api_level: 33


### PR DESCRIPTION
Reverts GetStream/stream-chat-android#6575 until we manage to make that work properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the nightly Android end-to-end test matrix by removing API levels 36 and 37.
  * Existing test coverage for the remaining configured Android API levels is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->