### PR TITLE
Re-enable the failed-message channel preview e2e test

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/ChannelListPage.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/ChannelListPage.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.compose.pages
 
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.BySelector
 import io.getstream.chat.android.compose.pages.MessageListPage.MessageList.Message
 
 class ChannelListPage {
@@ -47,7 +48,10 @@ class ChannelListPage {
                 val deliveryStatusIsRead = Message.deliveryStatusIsRead
                 val deliveryStatusIsPending = Message.deliveryStatusIsPending
                 val deliveryStatusIsSent = Message.deliveryStatusIsSent
-                val deliveryStatusIsFailed = Message.deliveryStatusIsFailed
+
+                // The channel preview renders the failed state via MessageReadStatusIcon,
+                // unlike the message list, which uses its own failed icon
+                val deliveryStatusIsFailed: BySelector = By.res("Stream_MessageReadStatus_isError")
                 val unreadCountIndicator = By.res("Stream_UnreadCountIndicator")
                 val timestamp = By.res("Stream_Timestamp")
                 val typingIndicator = By.res("Stream_ChannelListTypingIndicator")

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotChannelListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotChannelListAsserts.kt
@@ -44,6 +44,11 @@ fun UserRobot.assertMessageInChannelPreview(text: String, fromCurrentUser: Boole
     return this
 }
 
+fun UserRobot.assertFailedMessageDeliveryStatusInPreview(): UserRobot {
+    assertTrue(Channel.deliveryStatusIsFailed.waitDisplayed())
+    return this
+}
+
 fun UserRobot.assertMessagePreviewTimestamp(isDisplayed: Boolean = true): UserRobot {
     if (isDisplayed) {
         assertTrue(Channel.timestamp.waitDisplayed())

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -320,7 +320,6 @@ class MessageDeliveryStatusTests : StreamTestCase() {
     }
 
     @AllureId("5769")
-    @Ignore("https://linear.app/stream/issue/AND-256")
     @Test
     fun test_errorIndicatorShownInPreview_whenMessageFailedToBeSent() {
         step("GIVEN user opens the channel") {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.tests
 
+import io.getstream.chat.android.compose.robots.assertFailedMessageDeliveryStatusInPreview
 import io.getstream.chat.android.compose.robots.assertMessageDeliveryStatus
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
@@ -334,7 +335,7 @@ class MessageDeliveryStatusTests : StreamTestCase() {
             userRobot.moveToChannelListFromMessageList()
         }
         step("THEN last message delivery status in the channel preview shows failed icon") {
-            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.FAILED)
+            userRobot.assertFailedMessageDeliveryStatusInPreview()
         }
     }
 


### PR DESCRIPTION
### Goal

Re-enable the e2e test `test_errorIndicatorShownInPreview_whenMessageFailedToBeSent`, ignored since January 2025, and fix the selector bug that made it fail. The SDK behavior is correct: the channel preview shows the failed delivery icon for a message with `SyncStatus.FAILED_PERMANENTLY` (confirmed by the CI failure screenshot and UI hierarchy dump, which show the icon rendered with the expected resource id). The test failed because it asserted the wrong tag.

Resolves AND-256

### Implementation

- The channel preview renders the failed state via `MessageReadStatusIcon`, tagged `Stream_MessageReadStatus_isError`. The page object reused the message list's `Stream_MessageFailedIcon` tag, which never exists in the channel list, so the assertion could only pass when a leftover message-list node was still present during the pane transition. The read, pending, and sent tags are shared between the two surfaces, which is why only the failed variant was broken.
- `ChannelListPage.Channel.deliveryStatusIsFailed` now points to `Stream_MessageReadStatus_isError`, and the test asserts it through a new `assertFailedMessageDeliveryStatusInPreview` helper.
- Removed the `@Ignore` from the test. No production code changes.

### 🎨 UI Changes

No UI changes.

### Testing

1. In the app: open a channel, force message sends to fail, send a message, and go back to the channel list. The preview shows the message with the failed delivery icon.
2. The fixed test passed 3 of 3 normal local runs, plus 1 run against a mock patched to delay the failure response by 3 seconds, so the assertion also holds when the failure lands after the navigation back.
