### PR TITLE
Update the quoted message preview in threads when the quoted message is deleted or edited

### DIFF
--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.MarkAllReadEvent
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MemberRemovedEvent
+import io.getstream.chat.android.client.events.MessageDeletedEvent
 import io.getstream.chat.android.client.events.MessageDeliveredEvent
 import io.getstream.chat.android.client.events.MessageReadEvent
 import io.getstream.chat.android.client.events.MessageUpdatedEvent
@@ -501,6 +502,30 @@ public fun randomMessageUpdateEvent(
     channelType = channelType,
     channelId = channelId,
     message = message,
+)
+
+public fun randomMessageDeletedEvent(
+    createdAt: Date = Date(),
+    user: User = randomUser(),
+    cid: String = randomCID(),
+    channelType: String = randomString(),
+    channelId: String = randomString(),
+    message: Message = randomMessage(),
+    hardDelete: Boolean = randomBoolean(),
+    deletedForMe: Boolean = false,
+    channelMessageCount: Int? = positiveRandomInt(),
+): MessageDeletedEvent = MessageDeletedEvent(
+    type = EventType.MESSAGE_DELETED,
+    createdAt = createdAt,
+    rawCreatedAt = streamFormatter.format(createdAt),
+    user = user,
+    cid = cid,
+    channelType = channelType,
+    channelId = channelId,
+    message = message,
+    hardDelete = hardDelete,
+    deletedForMe = deletedForMe,
+    channelMessageCount = channelMessageCount,
 )
 
 public fun randomChannelUpdatedEvent(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadLogic.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.events.AnswerCastedEvent
 import io.getstream.chat.android.client.events.HasMessage
 import io.getstream.chat.android.client.events.HasPoll
 import io.getstream.chat.android.client.events.HasReminder
+import io.getstream.chat.android.client.events.MessageDeletedEvent
 import io.getstream.chat.android.client.events.MessageUpdatedEvent
 import io.getstream.chat.android.client.events.PollClosedEvent
 import io.getstream.chat.android.client.events.PollDeletedEvent
@@ -121,6 +122,17 @@ internal class ThreadLogic(
                 }
             }
         upsertMessages(messages)
+        events.zip(messages).forEach { (event, message) ->
+            when (event) {
+                is MessageUpdatedEvent -> threadStateLogic.updateQuotedMessageReferences(message)
+                is MessageDeletedEvent -> if (event.hardDelete) {
+                    threadStateLogic.deleteQuotedMessageReferences(message.id)
+                } else {
+                    threadStateLogic.updateQuotedMessageReferences(message)
+                }
+                else -> Unit
+            }
+        }
     }
 
     internal fun handleReminderEvents(events: List<HasReminder>) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogic.kt
@@ -64,6 +64,32 @@ internal class ThreadStateLogic(private val mutableState: ThreadMutableState) {
         )
     }
 
+    /**
+     * Updates each thread message that quotes the given message with its new content.
+     *
+     * @param quotedMessage The message whose quoting messages should be updated.
+     */
+    fun updateQuotedMessageReferences(quotedMessage: Message) {
+        updateQuotingMessages(quotedMessage.id) { it.copy(replyTo = quotedMessage) }
+    }
+
+    /**
+     * Clears the quoted message reference from each thread message quoting the given message.
+     *
+     * @param quotedMessageId The ID of the quoted message to remove references for.
+     */
+    fun deleteQuotedMessageReferences(quotedMessageId: String) {
+        updateQuotingMessages(quotedMessageId) { it.copy(replyTo = null) }
+    }
+
+    private fun updateQuotingMessages(quotedMessageId: String, update: (Message) -> Message) {
+        val quotingMessages = mutableState.rawMessage.value.values
+            .filter { it.replyTo?.id == quotedMessageId || it.replyMessageId == quotedMessageId }
+        if (quotingMessages.isNotEmpty()) {
+            mutableState.upsertMessages(quotingMessages.map(update))
+        }
+    }
+
     private fun isMessageNewerThanCurrent(currentMessage: Message?, newMessage: Message): Boolean {
         return if (newMessage.syncStatus == SyncStatus.COMPLETED) {
             (currentMessage?.lastUpdateTime() ?: NEVER.time) <= newMessage.lastUpdateTime()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadLogicTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadLogicTest.kt
@@ -20,7 +20,9 @@ import io.getstream.chat.android.client.events.HasReminder
 import io.getstream.chat.android.client.extensions.internal.toMessageReminderInfo
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.thread.internal.ThreadMutableState
 import io.getstream.chat.android.client.test.randomAnswerCastedEvent
+import io.getstream.chat.android.client.test.randomMessageDeletedEvent
 import io.getstream.chat.android.client.test.randomMessageUpdateEvent
+import io.getstream.chat.android.client.test.randomNewMessageEvent
 import io.getstream.chat.android.client.test.randomNotificationReminderDueEvent
 import io.getstream.chat.android.client.test.randomPollClosedEvent
 import io.getstream.chat.android.client.test.randomPollDeletedEvent
@@ -387,6 +389,72 @@ internal class ThreadLogicTest {
             poll = eventPoll,
         )
         verify(threadStateLogic, times(1)).upsertMessages(listOf(expectedMessage))
+    }
+
+    @Test
+    fun `Given MessageUpdatedEvent When handleMessageEvents is called Should update quoted message references`() {
+        // given
+        val updatedMessage = randomMessage(replyMessageId = null, poll = null, ownReactions = emptyList())
+        val event = randomMessageUpdateEvent(message = updatedMessage)
+
+        whenever(threadMutableState.rawMessage).doReturn(MutableStateFlow(emptyMap()))
+        whenever(threadMutableState.messages).doReturn(MutableStateFlow(emptyList()))
+
+        // when
+        threadLogic.handleMessageEvents(listOf(event))
+
+        // then
+        val expectedMessage = updatedMessage.copy(replyTo = null)
+        verify(threadStateLogic, times(1)).updateQuotedMessageReferences(expectedMessage)
+        verify(threadStateLogic, never()).deleteQuotedMessageReferences(any())
+    }
+
+    @Test
+    fun `Given soft delete MessageDeletedEvent When handleMessageEvents is called Should update quoted message references`() {
+        // given
+        val deletedMessage = randomMessage(ownReactions = emptyList())
+        val event = randomMessageDeletedEvent(message = deletedMessage, hardDelete = false)
+
+        whenever(threadMutableState.rawMessage).doReturn(MutableStateFlow(emptyMap()))
+
+        // when
+        threadLogic.handleMessageEvents(listOf(event))
+
+        // then
+        verify(threadStateLogic, times(1)).updateQuotedMessageReferences(deletedMessage)
+        verify(threadStateLogic, never()).deleteQuotedMessageReferences(any())
+    }
+
+    @Test
+    fun `Given hard delete MessageDeletedEvent When handleMessageEvents is called Should delete quoted message references`() {
+        // given
+        val deletedMessage = randomMessage(ownReactions = emptyList())
+        val event = randomMessageDeletedEvent(message = deletedMessage, hardDelete = true)
+
+        whenever(threadMutableState.rawMessage).doReturn(MutableStateFlow(emptyMap()))
+
+        // when
+        threadLogic.handleMessageEvents(listOf(event))
+
+        // then
+        verify(threadStateLogic, times(1)).deleteQuotedMessageReferences(deletedMessage.id)
+        verify(threadStateLogic, never()).updateQuotedMessageReferences(any())
+    }
+
+    @Test
+    fun `Given NewMessageEvent When handleMessageEvents is called Should not touch quoted message references`() {
+        // given
+        val message = randomMessage()
+        val event = randomNewMessageEvent(message = message)
+
+        whenever(threadMutableState.rawMessage).doReturn(MutableStateFlow(emptyMap()))
+
+        // when
+        threadLogic.handleMessageEvents(listOf(event))
+
+        // then
+        verify(threadStateLogic, never()).updateQuotedMessageReferences(any())
+        verify(threadStateLogic, never()).deleteQuotedMessageReferences(any())
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogicTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogicTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.state.plugin.logic.channel.thread.internal
+
+import io.getstream.chat.android.client.internal.state.plugin.state.channel.thread.internal.ThreadMutableState
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomString
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+internal class ThreadStateLogicTest {
+
+    private val parentId = randomString()
+
+    @Test
+    fun `updateQuotedMessageReferences should update messages quoting via replyTo`() = runTest {
+        // given
+        val (mutableState, threadStateLogic) = threadStateLogic(backgroundScope)
+        val quotedMessage = quotedMessage()
+        val quotingMessage = quotingMessage(replyTo = quotedMessage, replyMessageId = null)
+        threadStateLogic.upsertMessages(listOf(quotedMessage, quotingMessage))
+        // when
+        val deletedQuotedMessage = quotedMessage.copy(deletedAt = Date())
+        threadStateLogic.updateQuotedMessageReferences(deletedQuotedMessage)
+        // then
+        assertEquals(deletedQuotedMessage, mutableState.rawMessage.value[quotingMessage.id]?.replyTo)
+    }
+
+    @Test
+    fun `updateQuotedMessageReferences should update messages quoting via replyMessageId`() = runTest {
+        // given
+        val (mutableState, threadStateLogic) = threadStateLogic(backgroundScope)
+        val quotedMessage = quotedMessage()
+        val quotingMessage = quotingMessage(replyTo = null, replyMessageId = quotedMessage.id)
+        threadStateLogic.upsertMessages(listOf(quotedMessage, quotingMessage))
+        // when
+        val updatedQuotedMessage = quotedMessage.copy(text = "Updated text")
+        threadStateLogic.updateQuotedMessageReferences(updatedQuotedMessage)
+        // then
+        assertEquals(updatedQuotedMessage, mutableState.rawMessage.value[quotingMessage.id]?.replyTo)
+    }
+
+    @Test
+    fun `updateQuotedMessageReferences should not touch messages that do not quote the message`() = runTest {
+        // given
+        val (mutableState, threadStateLogic) = threadStateLogic(backgroundScope)
+        val quotedMessage = quotedMessage()
+        val otherMessage = quotingMessage(replyTo = null, replyMessageId = null)
+        threadStateLogic.upsertMessages(listOf(quotedMessage, otherMessage))
+        // when
+        threadStateLogic.updateQuotedMessageReferences(quotedMessage.copy(text = "Updated text"))
+        // then
+        assertEquals(otherMessage, mutableState.rawMessage.value[otherMessage.id])
+    }
+
+    @Test
+    fun `deleteQuotedMessageReferences should clear replyTo of quoting messages`() = runTest {
+        // given
+        val (mutableState, threadStateLogic) = threadStateLogic(backgroundScope)
+        val quotedMessage = quotedMessage()
+        val quotingMessage = quotingMessage(replyTo = quotedMessage, replyMessageId = quotedMessage.id)
+        threadStateLogic.upsertMessages(listOf(quotedMessage, quotingMessage))
+        // when
+        threadStateLogic.deleteQuotedMessageReferences(quotedMessage.id)
+        // then
+        assertNull(mutableState.rawMessage.value[quotingMessage.id]?.replyTo)
+    }
+
+    private fun threadStateLogic(scope: CoroutineScope): Pair<ThreadMutableState, ThreadStateLogic> {
+        val mutableState = ThreadMutableState(parentId, scope)
+        return mutableState to ThreadStateLogic(mutableState)
+    }
+
+    private fun quotedMessage(): Message = randomMessage(
+        id = parentId,
+        parentId = null,
+        replyTo = null,
+        replyMessageId = null,
+        deletedAt = null,
+        deletedForMe = false,
+    )
+
+    private fun quotingMessage(replyTo: Message?, replyMessageId: String?): Message = randomMessage(
+        parentId = parentId,
+        replyTo = replyTo,
+        replyMessageId = replyMessageId,
+        deletedAt = null,
+        deletedForMe = false,
+    )
+}

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
@@ -664,7 +664,6 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("6791")
-    @Ignore("https://linear.app/stream/issue/AND-272")
     @Test
     fun test_originalQuoteIsDeletedByUser_deletedMessageIsShown_InThread() {
         step("GIVEN user opens the channel") {


### PR DESCRIPTION
### Goal

When a message quoted by a thread reply is deleted or edited, the quoted preview inside the thread is not updated. The channel message list already handles this case, but the thread message list keeps showing the old content. This change applies the same update to the thread state.

Resolves AND-272

### Implementation

The channel path refreshes quote previews when the `message.updated` / `message.deleted` WebSocket event arrives: `ChannelEventHandlerImpl` calls `ChannelStateImpl.updateQuotedMessageReferences`, which rewrites the `replyTo` of every quoting message. The thread path (`EventHandlerSequential.updateThreadState` -> `ThreadLogic.handleMessageEvents`) only upserted the changed message itself, so quoting thread replies kept a stale `replyTo`.

- `ThreadStateLogic`: new `updateQuotedMessageReferences(quotedMessage)` and `deleteQuotedMessageReferences(quotedMessageId)`. They scan the in-memory thread messages for `replyTo?.id` / `replyMessageId` matches instead of maintaining a `quotedMessagesMap` like the channel state does, since the thread list is small and fully in memory.
- `ThreadLogic.handleMessageEvents`: after the existing upsert, `MessageUpdatedEvent` and soft `MessageDeletedEvent` refresh the `replyTo` of quoting messages with the enriched message, and a hard delete clears the `replyTo`. This mirrors the channel event handler contract. `ThreadLogic` is shared by the new and legacy channel logic modes, so both are covered.
- Removed the `@Ignore` from `test_originalQuoteIsDeletedByUser_deletedMessageIsShown_InThread`, as required by the ticket.
- Added a `randomMessageDeletedEvent` builder to the shared test fixtures.

One intentional difference from the channel counterpart: attachment URLs of the old `replyTo` are not preserved when rewriting it. Thread state upserts never preserve attachment URLs today, so this follows the existing thread module behavior.

This also aligns with the iOS SDK, where the quote is a database relationship: quoting messages always render the current content of the quoted message, and a hard delete nullifies the reference.

### Testing

Covered by new unit tests (`ThreadLogicTest`, `ThreadStateLogicTest`) and by the re-enabled e2e test `QuotedReplyTests#test_originalQuoteIsDeletedByUser_deletedMessageIsShown_InThread`. The e2e test passes locally with this change and fails without it (verified by running both builds against the mock server).

Manual steps:
1. Open a channel and start a thread on one of its messages.
2. Inside the thread, quote the root message (long press > Reply) and send the reply.
3. Delete the original quoted message.
4. Expected: the quoted bubble inside the thread reply shows "Message deleted". Before this change it kept the old text.
5. Editing works the same way: edit the quoted message and the quoted bubble shows the updated text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread consistency when quoted messages are edited or deleted.
  * Updated quoted replies appropriately for soft deletions and removed references for permanent deletions.
  * Ensured quoted-message updates are reflected across thread messages.

* **Tests**
  * Added coverage for quoted-message updates and deletions.
  * Enabled end-to-end coverage for displaying deleted quoted messages in threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->