### PR TITLE
e2e: Disconnect the previous ChatClient when the app re-initializes the SDK

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -23,7 +23,6 @@ import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
 import io.getstream.chat.android.e2e.test.robots.ParticipantRobot
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
-import org.junit.Ignore
 import org.junit.Test
 
 class MessageDeliveryStatusTests : StreamTestCase() {

--- a/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
+++ b/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
@@ -21,43 +21,51 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
+import androidx.lifecycle.lifecycleScope
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.data.PredefinedUserCredentials
 import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.feature.channel.list.ChannelsActivity
 import io.getstream.chat.android.compose.sample.ui.channel.ChannelActivity
+import kotlinx.coroutines.launch
 
 class StartupActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // The harness always launches with BASE_URL; a launch without it comes from a
-        // notification tap, where the already initialized client must stay untouched.
-        val baseUrl = intent.getStringExtra("BASE_URL")
-        if (baseUrl != null) {
-            ChatHelper.initializeSdk(applicationContext, PredefinedUserCredentials.API_KEY, baseUrl)
-            customSettings().isComposerLinkPreviewEnabled = true
-        }
+        lifecycleScope.launch {
+            // The harness always launches with BASE_URL; a launch without it comes from a
+            // notification tap, where the already initialized client must stay untouched.
+            val baseUrl = intent.getStringExtra("BASE_URL")
+            if (baseUrl != null) {
+                // The process survives across retry attempts, so disconnect the client left by
+                // the previous attempt before building a new one.
+                ChatClient.instance().disconnect(flushPersistence = true).await()
+                ChatHelper.initializeSdk(applicationContext, PredefinedUserCredentials.API_KEY, baseUrl)
+                customSettings().isComposerLinkPreviewEnabled = true
+            }
 
-        val initTestActivity = intent.getSerializableExtra("InitTestActivity") as? InitTestActivity
-        if (initTestActivity != null) {
-            startActivity(initTestActivity.createIntent(this@StartupActivity))
-        } else {
-            // Navigating from a push notification, route to the messages screen
-            val channelId = requireNotNull(intent.getStringExtra(KEY_CHANNEL_ID))
-            TaskStackBuilder.create(applicationContext)
-                .addNextIntent(ChannelsActivity.createIntent(applicationContext))
-                .addNextIntent(
-                    ChannelActivity.createIntent(
-                        context = applicationContext,
-                        channelId = channelId,
-                        messageId = intent.getStringExtra(KEY_MESSAGE_ID),
-                        parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
-                    ),
-                )
-                .startActivities()
+            val initTestActivity = intent.getSerializableExtra("InitTestActivity") as? InitTestActivity
+            if (initTestActivity != null) {
+                startActivity(initTestActivity.createIntent(this@StartupActivity))
+            } else {
+                // Navigating from a push notification, route to the messages screen
+                val channelId = requireNotNull(intent.getStringExtra(KEY_CHANNEL_ID))
+                TaskStackBuilder.create(applicationContext)
+                    .addNextIntent(ChannelsActivity.createIntent(applicationContext))
+                    .addNextIntent(
+                        ChannelActivity.createIntent(
+                            context = applicationContext,
+                            channelId = channelId,
+                            messageId = intent.getStringExtra(KEY_MESSAGE_ID),
+                            parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
+                        ),
+                    )
+                    .startActivities()
+            }
+            finish()
         }
-        finish()
     }
 
     companion object {

--- a/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
+++ b/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.sample.ChatHelper
@@ -33,7 +34,9 @@ import kotlinx.coroutines.launch
 class StartupActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
+
         lifecycleScope.launch {
             // The harness always launches with BASE_URL; a launch without it comes from a
             // notification tap, where the already initialized client must stay untouched.


### PR DESCRIPTION
### Goal

In the e2e flavor, every harness launch of `StartupActivity` calls `ChatHelper.initializeSdk`, which builds a new `ChatClient` without disconnecting the previous one. The app process survives across tests and retry attempts, so each launch added one more live client. In the 2026-07-21 nightly failure of `test_offlineMessageInTheMessageList`, attempt 3 had three clients reconnecting and calling `/sync` at the same time, including against the previous attempts' mock servers. The extra clients contend on reconnect, the active client's `/sync` round trip stalls, and `SyncManager` restores channels only after the `/sync` response, so recovery lands outside the assertion window and the test fails all retries.

Resolves AND-1321

### Implementation

In the e2e `StartupActivity`, when the launch carries a `BASE_URL` extra (every harness launch), disconnect the current client with `ChatClient.instance().disconnect(flushPersistence = true).await()` before calling `ChatHelper.initializeSdk`. Since the disconnect is a suspend call, the `onCreate` body now runs inside `lifecycleScope.launch`.

Notes on the paths that stay unchanged:
- The notification-tap launch (no `BASE_URL`) has no suspension point, and `lifecycleScope` uses `Dispatchers.Main.immediate`, so that branch still runs synchronously inside `onCreate`.
- On the first launch in a fresh process no user is connected, so the disconnect returns a logged failure with no side effects.
- I did not reuse `ChatHelper.disconnectUser()` on purpose: it stops `SharedLocationService`, and `SharedLocationService.stop()` cancels its coroutine scope permanently, which would break later attempts in the same process.

### Testing

This changes only the e2e flavor startup path, so the e2e suite is the verification:

1. Run any compose sample e2e test locally (`bundle exec fastlane build_and_run_e2e_test`) and confirm it still passes.
2. To verify the fix itself, run a test twice in the same process (for example, force a failure so `RetryRule` retries) and check logcat: after the second launch there should be a `[disconnect]` log from the previous client, and only one client should reconnect and call `/sync` against the current mock server.
3. The real signal is the nightly e2e run: `test_offlineMessageInTheMessageList` should stop failing on retries with multiple clients alive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup initialization and navigation reliability.
  * Ensured existing chat connections are fully disconnected before reinitializing.
  * Preserved test-specific routing and standard navigation behavior.
  * Improved activity completion handling during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->