### PR TITLE
e2e: Wait for the WebSocket disconnect before the participant sends a message

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageListTests.kt
@@ -301,6 +301,9 @@ class MessageListTests : StreamTestCase() {
         step("AND user goes to background") {
             device.goToBackground()
         }
+        step("AND user's WebSocket connection is closed") {
+            backendRobot.waitForWebSocketDisconnection()
+        }
         step("WHEN participant sends a new message") {
             participantRobot.sendMessage(sampleText)
         }
@@ -355,6 +358,9 @@ class MessageListTests : StreamTestCase() {
         }
         step("AND user goes to the background") {
             device.goToBackground()
+        }
+        step("AND user's WebSocket connection is closed") {
+            backendRobot.waitForWebSocketDisconnection()
         }
         step("WHEN participant sends a new message") {
             participantRobot.sendMessage(sampleText)

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/BackendRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/BackendRobot.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.e2e.test.robots
 
 import io.getstream.chat.android.e2e.test.mockserver.MockServer
 import junit.framework.TestCase.fail
+import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -129,6 +130,25 @@ public class BackendRobot(
     public fun breakTokenGeneration(duration: Int = 5) {
         waitForMockServerToStart()
         mockServer.postRequest("jwt/break_token_generation?duration=$duration")
+    }
+
+    /**
+     * Waits until the app under test closes its WebSocket connection to the mock server.
+     * The SDK keeps the socket open for a short period after the app goes to background,
+     * so call this before triggering server-side events that must not be delivered live.
+     *
+     * @param timeoutMillis How long to wait for the disconnect before failing the test.
+     */
+    public fun waitForWebSocketDisconnection(timeoutMillis: Long = 10_000) {
+        val startTime = System.currentTimeMillis()
+        while (System.currentTimeMillis() - startTime < timeoutMillis) {
+            val status = mockServer.getRequest("ws/status")?.string()
+            if (status != null && !JSONObject(status).getBoolean("connected")) {
+                return
+            }
+            Thread.sleep(500)
+        }
+        fail("WebSocket was not disconnected within $timeoutMillis ms")
     }
 
     private fun waitForMockServerToStart() {


### PR DESCRIPTION
### Goal

`test_offlineMessageInTheMessageList` has a flake mode where the participant's message is delivered live while the test is taking the app offline. The SDK keeps the WebSocket open for a short period after the app goes to background (the socket is only closed when the delayed lifecycle stop reaches `ChatSocketStateService.onStop()`), and `svc data disable` does not close established sockets immediately. So the `message.new` event can arrive over the still-open socket, the message is stored locally and shown while offline, and the assert "user does not observe a new message from participant" fails.

This change removes the race by waiting until the client socket is actually disconnected before the participant sends the message.

Depends on https://github.com/GetStream/stream-chat-test-mock-server/pull/49, which must merge first because the e2e CI clones the mock server `main` branch.

Resolves AND-1325

### Implementation

- New `BackendRobot.waitForWebSocketDisconnection()` in `stream-chat-android-e2e-test` polls the mock server's new `GET /ws/status` endpoint until the server reports the socket as closed.
- `test_offlineMessageInTheMessageList` and `test_offlineRecoveryWithinSession` call it after backgrounding the app, before the participant sends. Ordering is now decided on the server: once it reports `connected: false`, its socket handle is `nil`, so the participant message is only stored and gets delivered on reconnect.
- `test_offlineRecoveryWithinSession` is included because it has the same race. It passes either way today, but without the wait the message can be delivered live before the socket closes, so the test can pass without exercising the recovery path it is meant to cover.

No UI changes.

### Testing

1. Check out the mock server PR branch and start the driver: `bundle exec ruby driver.rb`.
2. Build and install the e2e APKs: `./gradlew :stream-chat-android-compose-sample:assembleE2eDebug :stream-chat-android-compose-sample:assembleE2eDebugAndroidTest`, then `adb install -r` both.
3. Run the two tests, for example: `adb shell am instrument -w -e class 'io.getstream.chat.android.compose.tests.MessageListTests#test_offlineMessageInTheMessageList' io.getstream.chat.android.compose.sample.e2etest.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner`.
4. In the mock server per-test log (`logs/test_offlineMessageInTheMessageList_*.log`), verify the order: `GET /ws/status` returns `connected: false`, then `POST /participant/message`, then the message is delivered after reconnect through `/sync` and the channel query.

Both tests pass locally with this flow. `spotlessCheck` and `detekt` pass on the touched modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved offline-mode test reliability by waiting for the WebSocket connection to close before simulating connectivity changes and app recovery.
  * Added timeout handling to detect unsuccessful disconnections during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->