### PR TITLE
e2e: Ignore the flaky thread quote jump test with the scrolling setup

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
@@ -31,6 +31,7 @@ import io.getstream.chat.android.e2e.test.mockserver.AttachmentType
 import io.getstream.chat.android.e2e.test.uiautomator.appContext
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
+import org.junit.Ignore
 import org.junit.Test
 import io.getstream.chat.android.ui.common.R as UiCommonR
 
@@ -362,6 +363,7 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5892")
+    @Ignore("https://linear.app/stream/issue/AND-1332")
     @Test
     fun test_quotedReplyNotInList_whenUserAddsQuotedReply_InThread() {
         step("GIVEN user opens the channel") {


### PR DESCRIPTION
### Goal

`test_quotedReplyNotInList_whenUserAddsQuotedReply_InThread` (AllureId 5892) was re-enabled by #6589 and turned out unstable: it failed the e2e batch on two unrelated PRs (#6588, #6587) after the merge, and it reproduces locally at roughly 2 of 5 runs. This ignores that one test again so open PRs are unblocked, until it is stabilized.

Resolves nothing by itself; the stabilization work is tracked in AND-1332.

### Implementation

Adds `@Ignore` with the AND-1332 reference on the single flaky test. The failures are in the test setup, before the jump behavior under test: a `waitToAppear` timeout finding the target message after a fixed number of scroll-ups (CI), and a `StaleObjectException` clicking the channel (local). The three participant variants of the same scenario have deterministic setups, do not fail, and stay enabled, so the jump fix keeps e2e coverage.

### Testing

Test-only change. `spotlessCheck` and the e2e androidTest compilation pass. The remaining `QuotedReplyTests` continue to run on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled a quoted-reply end-to-end test while a known issue is being addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->