### PR TITLE
e2e: Wait for the message delivery before the participant reads it

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/MessageDeliveryStatusTests.kt
@@ -199,6 +199,9 @@ class MessageDeliveryStatusTests : StreamTestCase() {
         step("WHEN user replies to message in thread") {
             userRobot.openThread().sendMessage(sampleText)
         }
+        step("AND the thread reply is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
+        }
         step("AND participant reads the user's thread reply") {
             participantRobot.readMessage()
         }
@@ -347,6 +350,9 @@ class MessageDeliveryStatusTests : StreamTestCase() {
         step("AND user sends a new message") {
             userRobot.sendMessage(sampleText)
         }
+        step("AND the message is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
+        }
         step("WHEN user returns to the channel list") {
             userRobot.moveToChannelListFromMessageList()
         }
@@ -469,6 +475,9 @@ class MessageDeliveryStatusTests : StreamTestCase() {
         step("AND user sends a new message") {
             userRobot.sendMessage(sampleText)
         }
+        step("AND the message is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
+        }
         step("AND participant reads the message") {
             participantRobot.readMessage()
             userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.READ)
@@ -490,6 +499,9 @@ class MessageDeliveryStatusTests : StreamTestCase() {
         }
         step("AND user replies to message in thread") {
             userRobot.openThread().sendMessage(sampleText)
+        }
+        step("AND the thread reply is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
         }
         step("AND participant reads the thread reply") {
             participantRobot.readMessage()


### PR DESCRIPTION
### Goal

Fix a send-read race in four read receipt tests. The send is asynchronous after the composer tap, so on a slow emulator the participant's read request can reach the mock server before the message it should mark as read. The message then stays unread and the double checkmark never shows.

This must merge before GetStream/stream-chat-test-mock-server#53: the mock server's new sub-second timestamps expose the race (second-precision dates used to hide the wrong order as a tie). Against the current mock the change is also green, so this PR can merge on its own.

Related: AND-1329

### Implementation

The four tests whose READ assertions depend on the read happening after the send now wait for the delivery status between the two, the same fix #6591 applied to the participant pin.

Three other tests also call `participantRobot.readMessage()` right after a send, but they run with read events disabled and assert that no delivery indicator shows, which holds under either order, so they stay unchanged.

### Testing

- Ran the four tests locally against the mock server PR branch (API 35 emulator, per-test data isolation): all pass, the previously flaky `test_readByDecremented_whenParticipantIsRemoved` three times in a row.
- Full nightly matrix on this branch against the mock server branch: https://github.com/GetStream/stream-chat-android/actions/runs/30434731061

Test-only change, no public API impact.
