### PR TITLE
ci: Trigger required checks on merge_group for merge queue

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,7 +13,7 @@ on:
         default: main
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,6 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
+  merge_group:
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,11 @@
 name: Pull request CI checks
 
-on: [ pull_request ]
+on:
+  pull_request:
+  merge_group:
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Goal

Closes [AND-1335](https://linear.app/stream/issue/AND-1335/enable-github-merge-queue-for-the-android-chat-repo)

Prepare the CI to support GitHub's merge queue. When a PR is added to a merge queue, GitHub fires a `merge_group` event (not `pull_request`) against a temporary queue branch. Any required status check must run on that event or the queued PR hangs indefinitely waiting for a check that never reports.

All 7 checks currently required on `develop` are produced by two workflows:
- `pr-checks.yml` → `base-android-ci / Build`, `/ Run actionlint`, `/ Run static checks`, `/ Run unit tests`
- `e2e-test.yml` → `Test compose (0)`, `(1)`, `(2)`

### Implementation

- Added a `merge_group:` trigger to `pr-checks.yml` and `e2e-test.yml` so the required checks report on merge-queue runs.
- Fixed `pr-checks.yml` concurrency key: `github.head_ref` is empty on `merge_group` events, which would collapse all queued entries into one group and cancel each other. Falls back to `github.ref` (unique per queue entry). `e2e-test.yml` already keyed on `github.ref`, so it was left as-is.

### Testing

`actionlint` passes on both files. Full validation requires the merge queue to be enabled on `develop` (a repo-settings change made after this merges); a throwaway PR should then be run through the queue to confirm all 7 checks report on the `merge_group` run.

> [!NOTE]
> `e2e-test.yml` sets `GITHUB_PR_NUM: github.event.pull_request.number`, which is empty under `merge_group`. Verified this is safe — every consumer in the `stream_actions` plugin degrades gracefully: `is_check_required` treats an empty PR number as "always run" (so E2E still executes), `allure_create_launch` falls back to naming the launch from the commit message, and `current_branch` falls back to `git_branch`. No path fails the build; the only effect is cosmetic in Allure TestOps (launch named from the commit message instead of the PR title, no PR-label tags). No follow-up guard needed.

### Rollout

Merge-queue trigger must be present on `develop` **before** the queue is enabled (merge_group workflows run from the base branch's file). Sequence: merge this PR normally → enable "Require merge queue" on the `develop` branch protection rule (keep the same 7 required checks) → validate with a test PR.

### ☑️Contributor Checklist
- [ ] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the Linear issue it resolves


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated checks to run for merge queue events.
  * Improved workflow concurrency handling to prevent conflicts when merge queue events lack a pull request branch reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->