### PR TITLE
e2e: Cover the unread messages flows backed by the mock server read state

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/ChannelListPage.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/ChannelListPage.kt
@@ -59,7 +59,6 @@ class ChannelListPage {
                 // The channel preview renders the failed state via MessageReadStatusIcon,
                 // unlike the message list, which uses its own failed icon
                 val deliveryStatusIsFailed: BySelector = By.res("Stream_MessageReadStatus_isError")
-                val unreadCountIndicator = By.res("Stream_UnreadCountIndicator")
                 val timestamp = By.res("Stream_Timestamp")
                 val typingIndicator = By.res("Stream_ChannelListTypingIndicator")
                 val mutedIcon = By.res("Stream_ChannelMutedIcon")

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -186,8 +186,8 @@ class UserRobot {
         return this
     }
 
-    fun markMessageAsUnread(messageCellIndex: Int = 0): UserRobot {
-        openContextMenu(messageCellIndex)
+    fun markMessageAsUnread(text: String): UserRobot {
+        openContextMenu(text)
         ContextMenu.markAsUnread.waitToAppear().click()
         return this
     }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -186,6 +186,12 @@ class UserRobot {
         return this
     }
 
+    fun markMessageAsUnread(messageCellIndex: Int = 0): UserRobot {
+        openContextMenu(messageCellIndex)
+        ContextMenu.markAsUnread.waitToAppear().click()
+        return this
+    }
+
     fun pinMessage(messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
         ContextMenu.pin.waitToAppearAndClick()

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -188,7 +188,7 @@ class UserRobot {
 
     fun markMessageAsUnread(text: String): UserRobot {
         openContextMenu(text)
-        ContextMenu.markAsUnread.waitToAppear().click()
+        ContextMenu.markAsUnread.waitToAppearAndClick()
         return this
     }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotChannelListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotChannelListAsserts.kt
@@ -28,10 +28,23 @@ import io.getstream.chat.android.e2e.test.uiautomator.waitToDisappear
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import io.getstream.chat.android.compose.R as ComposeR
 import io.getstream.chat.android.ui.common.R as UiCommonR
 
 fun UserRobot.assertChannelAvatar(): UserRobot {
     assertTrue(Channel.avatar.isDisplayed())
+    return this
+}
+
+fun UserRobot.assertChannelUnreadCount(count: Int): UserRobot {
+    // The badge exposes only a content description; its text is cleared from the
+    // semantics tree by clearAndSetSemantics in UnreadCountIndicator.
+    val expectedDescription = appContext.resources.getQuantityString(
+        ComposeR.plurals.stream_compose_channel_item_unread,
+        count,
+        count,
+    )
+    assertTrue(By.desc(expectedDescription).waitDisplayed())
     return this
 }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/UnreadMessagesTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/UnreadMessagesTests.kt
@@ -107,7 +107,7 @@ class UnreadMessagesTests : StreamTestCase() {
             userRobot.assertMessage("New-$unreadCount")
         }
         step("WHEN user marks the first participant message as unread") {
-            userRobot.markMessageAsUnread(messageCellIndex = 1)
+            userRobot.markMessageAsUnread("New-1")
         }
         step("THEN the unread separator is shown with the unread count") {
             userRobot.assertUnreadSeparator(unreadCount = unreadCount)

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/UnreadMessagesTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/UnreadMessagesTests.kt
@@ -18,9 +18,11 @@ package io.getstream.chat.android.compose.tests
 
 import io.getstream.chat.android.compose.robots.assertChannelUnreadCount
 import io.getstream.chat.android.compose.robots.assertMessage
+import io.getstream.chat.android.compose.robots.assertMessageDeliveryStatus
 import io.getstream.chat.android.compose.robots.assertScrollToFirstUnreadButton
 import io.getstream.chat.android.compose.robots.assertUnreadSeparator
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
+import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
 import org.junit.Test
@@ -36,6 +38,9 @@ class UnreadMessagesTests : StreamTestCase() {
         val unreadCount = 2
         step("GIVEN user opens the channel and sends the message") {
             userRobot.login().openChannel().sendMessage(sampleText)
+        }
+        step("AND the message is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
         }
         step("AND user moves back to the channel list") {
             userRobot.moveToChannelListFromMessageList()
@@ -60,6 +65,9 @@ class UnreadMessagesTests : StreamTestCase() {
         val unreadCount = 25
         step("GIVEN user opens the channel and sends the message") {
             userRobot.login().openChannel().sendMessage(sampleText)
+        }
+        step("AND the message is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
         }
         step("AND user moves back to the channel list") {
             userRobot.moveToChannelListFromMessageList()
@@ -91,6 +99,9 @@ class UnreadMessagesTests : StreamTestCase() {
         step("GIVEN user opens the channel and sends the message") {
             userRobot.login().openChannel().sendMessage(sampleText)
         }
+        step("AND the message is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
+        }
         step("AND participant sends messages") {
             participantRobot.sendMultipleMessages(text = "New", count = unreadCount)
             userRobot.assertMessage("New-$unreadCount")
@@ -112,6 +123,9 @@ class UnreadMessagesTests : StreamTestCase() {
         val unreadCount = 25
         step("GIVEN user opens the channel and sends the message") {
             userRobot.login().openChannel().sendMessage(sampleText)
+        }
+        step("AND the message is delivered") {
+            userRobot.assertMessageDeliveryStatus(MessageDeliveryStatus.SENT)
         }
         step("AND user moves back to the channel list") {
             userRobot.moveToChannelListFromMessageList()

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/UnreadMessagesTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/UnreadMessagesTests.kt
@@ -16,12 +16,13 @@
 
 package io.getstream.chat.android.compose.tests
 
+import io.getstream.chat.android.compose.robots.assertChannelUnreadCount
+import io.getstream.chat.android.compose.robots.assertMessage
 import io.getstream.chat.android.compose.robots.assertScrollToFirstUnreadButton
 import io.getstream.chat.android.compose.robots.assertUnreadSeparator
 import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
-import org.junit.Ignore
 import org.junit.Test
 
 class UnreadMessagesTests : StreamTestCase() {
@@ -30,7 +31,6 @@ class UnreadMessagesTests : StreamTestCase() {
     private val sampleText = "Test"
 
     @AllureId("11453")
-    @Ignore("https://linear.app/stream/issue/AND-1329")
     @Test
     fun test_unreadSeparatorIsShown_whenParticipantSendsMessagesWhileUserIsAway() {
         val unreadCount = 2
@@ -43,6 +43,9 @@ class UnreadMessagesTests : StreamTestCase() {
         step("WHEN participant sends new messages") {
             participantRobot.sendMultipleMessages(text = "New", count = unreadCount)
         }
+        step("AND the channel preview shows the unread count") {
+            userRobot.assertChannelUnreadCount(unreadCount)
+        }
         step("AND user reopens the channel") {
             userRobot.openChannel()
         }
@@ -52,7 +55,6 @@ class UnreadMessagesTests : StreamTestCase() {
     }
 
     @AllureId("11454")
-    @Ignore("https://linear.app/stream/issue/AND-1329")
     @Test
     fun test_userScrollsToFirstUnreadMessage() {
         val unreadCount = 25
@@ -64,6 +66,9 @@ class UnreadMessagesTests : StreamTestCase() {
         }
         step("AND participant sends new messages") {
             participantRobot.sendMultipleMessages(text = "New", count = unreadCount)
+        }
+        step("AND the channel preview shows the unread count") {
+            userRobot.assertChannelUnreadCount(unreadCount)
         }
         step("WHEN user reopens the channel") {
             userRobot.openChannel()
@@ -79,8 +84,29 @@ class UnreadMessagesTests : StreamTestCase() {
         }
     }
 
+    @AllureId("6073")
+    @Test
+    fun test_userMarksMessageAsUnread() {
+        val unreadCount = 2
+        step("GIVEN user opens the channel and sends the message") {
+            userRobot.login().openChannel().sendMessage(sampleText)
+        }
+        step("AND participant sends messages") {
+            participantRobot.sendMultipleMessages(text = "New", count = unreadCount)
+            userRobot.assertMessage("New-$unreadCount")
+        }
+        step("WHEN user marks the first participant message as unread") {
+            userRobot.markMessageAsUnread(messageCellIndex = 1)
+        }
+        step("THEN the unread separator is shown with the unread count") {
+            userRobot.assertUnreadSeparator(unreadCount = unreadCount)
+        }
+        step("AND the channel preview shows the unread count") {
+            userRobot.moveToChannelListFromMessageList().assertChannelUnreadCount(unreadCount)
+        }
+    }
+
     @AllureId("11455")
-    @Ignore("https://linear.app/stream/issue/AND-1329")
     @Test
     fun test_userDismissesTheUnreadIndicator() {
         val unreadCount = 25

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -147,7 +147,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -236,7 +235,7 @@ public class MessageListController(
      * via [messageListState], which mirrors this value.
      */
     public val unreadLabelState: MutableStateFlow<UnreadLabel?> = MutableStateFlow(null)
-    private val showUnreadButtonState = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
+    private val showUnreadButtonState = MutableStateFlow(true)
     private var lastProcessedReadMessageId: String? = null
     private val originalTranslationsStore by lazy { MessageOriginalTranslationsStore.forChannel(cid) }
 
@@ -597,34 +596,51 @@ public class MessageListController(
      * logic of determining unread message state, including edge cases for own messages,
      * mark as unread functionality, and offline/pending message scenarios.
      */
-    @Suppress("MagicNumber")
     private fun observeUnreadLabelState() {
         combine(
-            showUnreadButtonState.onStart { emit(true) },
+            showUnreadButtonState,
             channelState.filterNotNull(),
             channelState.filterNotNull().flatMapLatest { it.read },
         ) { shouldShowButton, channel, read ->
-            read
-                ?.takeIf { !isStartedForThread }
-                ?.takeIf { it.lastReadMessageId != null && lastProcessedReadMessageId != it.lastReadMessageId }
-                ?.let { channelUserRead ->
-                    lastProcessedReadMessageId = channelUserRead.lastReadMessageId
-
-                    // Delegate to the calculator for the complex unread label logic
-                    val unreadLabel = unreadLabelCalculator.calculateUnreadLabel(
-                        channelUserRead = channelUserRead,
-                        messages = channel.messages.value,
-                        currentUserId = clientState.user.value?.id,
-                        shouldShowButton = shouldShowButton,
-                    )
-
-                    // Only update the label if the calculator produced a non-null result. This makes the label sticky:
-                    // once shown, it persists until the user leaves the channel.
-                    if (unreadLabel != null) {
-                        unreadLabelState.value = unreadLabel
-                    }
-                }
+            computeUnreadLabel(
+                channelUserRead = read,
+                channel = channel,
+                shouldShowButton = shouldShowButton,
+            )
         }.launchIn(scope)
+    }
+
+    /**
+     * Recalculates the unread label from the given read state and updates [unreadLabelState].
+     *
+     * The label is recalculated whenever [ChannelUserRead.lastReadMessageId] changes, and the
+     * result is "sticky": a null calculation never overwrites a non-null label, so the separator
+     * persists when the user auto-reads messages by scrolling, while mark-as-unread events
+     * (which move [ChannelUserRead.lastReadMessageId] backward) still produce a new label.
+     */
+    private fun computeUnreadLabel(
+        channelUserRead: ChannelUserRead?,
+        channel: ChannelState,
+        shouldShowButton: Boolean,
+    ) {
+        channelUserRead
+            ?.takeIf { !isStartedForThread }
+            ?.takeIf { it.lastReadMessageId != null && lastProcessedReadMessageId != it.lastReadMessageId }
+            ?.let { read ->
+                lastProcessedReadMessageId = read.lastReadMessageId
+
+                // Delegate to the calculator for the complex unread label logic
+                val unreadLabel = unreadLabelCalculator.calculateUnreadLabel(
+                    channelUserRead = read,
+                    messages = channel.messages.value,
+                    currentUserId = clientState.user.value?.id,
+                    shouldShowButton = shouldShowButton,
+                )
+
+                if (unreadLabel != null) {
+                    unreadLabelState.value = unreadLabel
+                }
+            }
     }
 
     /**
@@ -638,7 +654,7 @@ public class MessageListController(
      */
     public fun disableUnreadLabelButton() {
         val currentLabel = unreadLabelState.value ?: return
-        showUnreadButtonState.tryEmit(false)
+        showUnreadButtonState.value = false
         unreadLabelState.value = currentLabel.copy(buttonVisibility = false)
     }
 
@@ -1761,6 +1777,17 @@ public class MessageListController(
         if (isInThread) {
             markThreadAsRead()
         } else {
+            // Compute the unread label before marking read. Marking the channel read zeroes the
+            // read state optimistically, and observeUnreadLabelState collects a conflating flow,
+            // so on a busy main thread it can observe only the zeroed state and never produce
+            // the label.
+            channelState.value?.let { channel ->
+                computeUnreadLabel(
+                    channelUserRead = channel.read.value,
+                    channel = channel,
+                    shouldShowButton = showUnreadButtonState.value,
+                )
+            }
             markChannelAsRead()
         }
     }
@@ -1844,7 +1871,7 @@ public class MessageListController(
                         ErrorEvent.MarkUnreadError(it)
                     }
                 } else {
-                    showUnreadButtonState.tryEmit(false)
+                    showUnreadButtonState.value = false
                 }
             }
         }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -627,8 +627,6 @@ public class MessageListController(
             ?.takeIf { !isStartedForThread }
             ?.takeIf { it.lastReadMessageId != null && lastProcessedReadMessageId != it.lastReadMessageId }
             ?.let { read ->
-                lastProcessedReadMessageId = read.lastReadMessageId
-
                 // Delegate to the calculator for the complex unread label logic
                 val unreadLabel = unreadLabelCalculator.calculateUnreadLabel(
                     channelUserRead = read,
@@ -638,6 +636,10 @@ public class MessageListController(
                 )
 
                 if (unreadLabel != null) {
+                    // Marking the read state as processed only on a produced label keeps the
+                    // recalculation open while the reason for a null result is transient, for
+                    // example a message list that has not loaded yet.
+                    lastProcessedReadMessageId = read.lastReadMessageId
                     unreadLabelState.value = unreadLabel
                 }
             }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -784,6 +784,57 @@ internal class MessageListControllerTests {
         }
 
     @Test
+    fun `Keep unread label, when marking read zeroes the read state`() =
+        runTest {
+            val chatClient: ChatClient = mock()
+            val lastReadMessage = randomMessage(id = "last_read_message_id", deletedAt = null, deletedForMe = false)
+            val messages = listOf(
+                lastReadMessage,
+                randomMessage(
+                    id = "first_unread_message_id",
+                    user = user2,
+                    syncStatus = SyncStatus.COMPLETED,
+                    deletedAt = null,
+                    deletedForMe = false,
+                ),
+            )
+            val channelRead = MutableStateFlow(
+                randomChannelUserRead(
+                    user = user1,
+                    lastReadMessageId = lastReadMessage.id,
+                    unreadMessages = 1,
+                ),
+            )
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser(user1)
+                .givenChannelQuery()
+                .givenChannelState(
+                    messagesState = MutableStateFlow(messages),
+                    read = channelRead,
+                )
+                .get()
+
+            // The state plugin zeroes the read state optimistically when marking read;
+            // the label must already be computed when the mark-read call goes out.
+            var labelWhenMarkingRead: MessageListController.UnreadLabel? = null
+            whenever(chatClient.markRead(any(), any())) doAnswer {
+                labelWhenMarkingRead = controller.unreadLabelState.value
+                channelRead.value = channelRead.value.copy(
+                    unreadMessages = 0,
+                    lastRead = Date(),
+                    lastReceivedEventDate = Date(),
+                )
+                Unit.asCall()
+            }
+            controller.markLastMessageRead()
+            delay(1000)
+
+            verify(chatClient, times(1)).markRead(any(), any())
+            labelWhenMarkingRead.`should not be null`().unreadCount `should be equal to` 1
+            controller.unreadLabelState.value.`should not be null`().unreadCount `should be equal to` 1
+        }
+
+    @Test
     fun `Show unread label, when message is marked as unread`() =
         runTest {
             val user = randomUser()

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -784,6 +784,49 @@ internal class MessageListControllerTests {
         }
 
     @Test
+    fun `Show unread label, when the read state arrives before the messages are loaded`() =
+        runTest {
+            val chatClient: ChatClient = mock()
+            val messagesState = MutableStateFlow(emptyList<Message>())
+            val channelRead = MutableStateFlow(
+                randomChannelUserRead(
+                    user = user1,
+                    lastReadMessageId = "last_read_message_id",
+                    unreadMessages = 2,
+                ),
+            )
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser(user1)
+                .givenChannelQuery()
+                .givenMarkRead()
+                .givenChannelState(
+                    messagesState = messagesState,
+                    read = channelRead,
+                )
+                .get()
+            // The read state is processed while the message list is still empty,
+            // so no label can be calculated yet.
+            delay(1000)
+            controller.unreadLabelState.value `should be equal to` null
+
+            messagesState.value = listOf(
+                randomMessage(id = "last_read_message_id", user = user1, deletedAt = null, deletedForMe = false),
+                randomMessage(id = "unread_1", user = user2, deletedAt = null, deletedForMe = false),
+                randomMessage(
+                    id = "unread_2",
+                    user = user2,
+                    syncStatus = SyncStatus.COMPLETED,
+                    deletedAt = null,
+                    deletedForMe = false,
+                ),
+            )
+            controller.markLastMessageRead()
+            delay(1000)
+
+            controller.unreadLabelState.value.`should not be null`().unreadCount `should be equal to` 2
+        }
+
+    @Test
     fun `Keep unread label, when marking read zeroes the read state`() =
         runTest {
             val chatClient: ChatClient = mock()


### PR DESCRIPTION
### Goal

Cover the unread messages flows now that the mock server maintains per-user read state: the unread separator, the jump-to-unread button and its dismissal, and the mark-as-unread message action.

The new tests exposed two real client-side defects in the unread label pipeline, fixed here as well. First, on channel open the automatic mark-read zeroes the read state optimistically, and the label pipeline collects a conflating flow, so on a slow device it could observe only the zeroed state. Second, the pipeline marked a read state as processed before calculating, so a first emission arriving while the message list was still empty produced no label and permanently blocked recalculation for that read state. Either way the unread separator sometimes never rendered.

Built on the read state that GetStream/stream-chat-test-mock-server#53 added to the mock server (merged).

Related: AND-1329

### Implementation

- `MessageListController` now computes the unread label from the current read state right before triggering the mark-read call. The controller owns both sides of the race, so this makes the order deterministic. The label calculation is extracted into `computeUnreadLabel`, shared by the existing flow observation and the new capture, and `showUnreadButtonState` becomes a `StateFlow` so the capture can read its current value. No public API change; the XML message list shares the same controller, so both UIs are covered.
- `lastProcessedReadMessageId` is recorded only when the calculator produces a label, so a transient null result (for example, the message list has not loaded yet) no longer blocks recalculation. The capture before mark-read is the natural recovery point: mark-read only fires when the last message is visible, so the messages are always loaded there.
- `UnreadMessagesTests`: the three tests `@Ignore`d in #6591 (Allure 11453-11455) run again, and a new `test_userMarksMessageAsUnread` (Allure 6073) covers the mark-as-unread context menu action end to end, asserting the unread separator and the channel list badge.
- All four tests wait for the user's message delivery before the participant acts, and the two count-asserting tests also wait for the channel list badge to settle before reopening the channel, so the assertions never race the message order or the event processing.
- New `assertChannelUnreadCount`: the badge exposes only a content description (`clearAndSetSemantics` in `UnreadCountIndicator` removes the child text and tag from the semantics tree), so the assertion matches the `stream_compose_channel_item_unread` plural. The stale `Stream_UnreadCountIndicator` selector is removed.

### Testing

- Two new unit tests in `MessageListControllerTests`: one pins the ordering contract (when the mark-read call goes out, the label is already computed, and it keeps its count after the read state is zeroed), and one reproduces the empty-list poisoning deterministically (read state arrives before the messages, then the messages load and the label must appear; it fails against the old code). All 903 ui-common unit tests pass, plus detekt and apiCheck.
- Ran the four e2e tests locally against the mock server PR branch (API 35 emulator, per-test data isolation): 6/6 including repeats.
- A conflation race cannot be reproduced under a serial test scheduler, so the empirical evidence is the full nightly matrix, where the label race reproduced in every earlier run (roughly one of the four tests per run): https://github.com/GetStream/stream-chat-android/actions/runs/30550107723 is the run with the complete fix against the merged mock main.



