### PR TITLE
Migrate searchMessages request body to the generated SearchPayload model

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -1449,13 +1449,13 @@ constructor(
         next: String?,
         sort: QuerySorter<Message>?,
     ): Call<SearchMessagesResult> {
-        val newRequest = io.getstream.chat.android.client.api2.model.requests.SearchMessagesRequest(
-            filter_conditions = channelFilter.toMap(),
-            message_filter_conditions = messageFilter.toMap(),
+        val newRequest = io.getstream.chat.android.network.models.SearchPayload(
+            filterConditions = channelFilter.toMap(),
+            messageFilterConditions = messageFilter.toMap(),
             offset = offset,
             limit = limit,
             next = next,
-            sort = sort?.toDto(),
+            sort = sort?.toSortParams(),
         )
         return generalApi.searchMessages(newRequest)
             .mapDomain { response ->

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/GeneralApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/GeneralApi.kt
@@ -21,12 +21,12 @@ import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.dto.UnreadDto
 import io.getstream.chat.android.client.api2.model.requests.QueryMembersRequest
-import io.getstream.chat.android.client.api2.model.requests.SearchMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.SyncHistoryRequest
 import io.getstream.chat.android.client.api2.model.response.QueryMembersResponse
 import io.getstream.chat.android.client.api2.model.response.SearchMessagesResponse
 import io.getstream.chat.android.client.api2.model.response.SyncHistoryResponse
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.SearchPayload
 import okhttp3.ResponseBody
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -47,7 +47,7 @@ internal interface GeneralApi {
 
     @GET("/search")
     fun searchMessages(
-        @UrlQueryPayload @Query("payload") payload: SearchMessagesRequest,
+        @UrlQueryPayload @Query("payload") payload: SearchPayload,
     ): RetrofitCall<SearchMessagesResponse>
 
     @GET("/members")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/MessageOptions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/MessageOptions.kt
@@ -14,16 +14,25 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class SearchMessagesRequest(
-    val filter_conditions: Map<*, *>,
-    val message_filter_conditions: Map<*, *>,
-    val offset: Int?,
-    val limit: Int?,
-    val next: String?,
-    val sort: List<Map<String, Any>>?,
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class MessageOptions(
+    @Json(name = "include_thread_participants")
+    internal val includeThreadParticipants: Boolean? = null,
+
+    @Json(name = "member_custom_include")
+    internal val memberCustomInclude: List<String>? = emptyList(),
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/SearchPayload.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/SearchPayload.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class SearchPayload(
+    @Json(name = "filter_conditions")
+    internal val filterConditions: Map<String, Any?> = emptyMap(),
+
+    @Json(name = "force_default_search")
+    internal val forceDefaultSearch: Boolean? = null,
+
+    @Json(name = "force_sql_v2_backend")
+    internal val forceSqlV2Backend: Boolean? = null,
+
+    @Json(name = "limit")
+    internal val limit: Int? = null,
+
+    @Json(name = "next")
+    internal val next: String? = null,
+
+    @Json(name = "offset")
+    internal val offset: Int? = null,
+
+    @Json(name = "query")
+    internal val query: String? = null,
+
+    @Json(name = "sort")
+    internal val sort: List<io.getstream.chat.android.network.models.SortParamRequest>? = emptyList(),
+
+    @Json(name = "message_filter_conditions")
+    internal val messageFilterConditions: Map<String, Any?>? = emptyMap(),
+
+    @Json(name = "message_options")
+    internal val messageOptions: io.getstream.chat.android.network.models.MessageOptions? = null,
+)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -1896,13 +1896,13 @@ internal class MoshiChatApiTest {
         val next = randomString()
         val result = sut.searchMessages(channelFilter, messageFilter, offset, limit, next, sort).await()
         // then
-        val expectedPayload = io.getstream.chat.android.client.api2.model.requests.SearchMessagesRequest(
-            filter_conditions = channelFilter.toMap(),
-            message_filter_conditions = messageFilter.toMap(),
+        val expectedPayload = io.getstream.chat.android.network.models.SearchPayload(
+            filterConditions = channelFilter.toMap(),
+            messageFilterConditions = messageFilter.toMap(),
             offset = offset,
             limit = limit,
             next = next,
-            sort = sort.toDto(),
+            sort = sort.toSortParams(),
         )
         result `should be instance of` expected
         verify(api, times(1)).searchMessages(expectedPayload)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/SearchPayloadAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/SearchPayloadAdapterTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2
+
+import io.getstream.chat.android.client.parser2.testdata.SearchPayloadTestData
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class SearchPayloadAdapterTest {
+    private val parser = ParserFactory.createMoshiChatParser()
+
+    @Test
+    fun `Serialize SearchPayload with all fields`() {
+        val json = parser.toJson(SearchPayloadTestData.searchPayload)
+        Assertions.assertEquals(SearchPayloadTestData.searchPayloadJson, json)
+    }
+
+    @Test
+    fun `Serialize SearchPayload with default fields`() {
+        val json = parser.toJson(SearchPayloadTestData.searchPayloadWithDefaults)
+        Assertions.assertEquals(SearchPayloadTestData.searchPayloadJsonWithDefaults, json)
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/SearchPayloadTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/SearchPayloadTestData.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2.testdata
+
+import io.getstream.chat.android.network.models.MessageOptions
+import io.getstream.chat.android.network.models.SearchPayload
+import io.getstream.chat.android.network.models.SortParamRequest
+import org.intellij.lang.annotations.Language
+
+internal object SearchPayloadTestData {
+
+    @Language("JSON")
+    val searchPayloadJson =
+        """{
+          "filter_conditions": {
+            "type": "messaging"
+          },
+          "force_default_search": true,
+          "force_sql_v2_backend": false,
+          "limit": 30,
+          "next": "next-token",
+          "offset": 0,
+          "query": "hello",
+          "sort": [
+            {
+              "direction": -1,
+              "field": "created_at",
+              "type": "message"
+            }
+          ],
+          "message_filter_conditions": {
+            "text": "hello"
+          },
+          "message_options": {
+            "include_thread_participants": true,
+            "member_custom_include": [
+              "role"
+            ]
+          }
+        }""".withoutWhitespace()
+
+    val searchPayload = SearchPayload(
+        filterConditions = mapOf("type" to "messaging"),
+        forceDefaultSearch = true,
+        forceSqlV2Backend = false,
+        limit = 30,
+        next = "next-token",
+        offset = 0,
+        query = "hello",
+        sort = listOf(
+            SortParamRequest(
+                direction = -1,
+                field = "created_at",
+                type = "message",
+            ),
+        ),
+        messageFilterConditions = mapOf("text" to "hello"),
+        messageOptions = MessageOptions(
+            includeThreadParticipants = true,
+            memberCustomInclude = listOf("role"),
+        ),
+    )
+
+    @Language("JSON")
+    val searchPayloadJsonWithDefaults =
+        """{
+          "filter_conditions": {},
+          "sort": [],
+          "message_filter_conditions": {}
+        }""".withoutWhitespace()
+
+    val searchPayloadWithDefaults = SearchPayload()
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/SearchPayloadTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/SearchPayloadTestData.kt
@@ -38,8 +38,7 @@ internal object SearchPayloadTestData {
           "sort": [
             {
               "direction": -1,
-              "field": "created_at",
-              "type": "message"
+              "field": "created_at"
             }
           ],
           "message_filter_conditions": {
@@ -65,7 +64,6 @@ internal object SearchPayloadTestData {
             SortParamRequest(
                 direction = -1,
                 field = "created_at",
-                type = "message",
             ),
         ),
         messageFilterConditions = mapOf("text" to "hello"),


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the `searchMessages` request body to the generated `SearchPayload` model.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- `searchMessages` request -> generated `SearchPayload` (+ vendored `MessageOptions`, referenced by it); `sort` via `toSortParams()`. Mapper ported from the reference branch.
- `GeneralApi.searchMessages` `@UrlQueryPayload` param retyped to `SearchPayload`.
- Removed the hand-written `SearchMessagesRequest` DTO. Response side (`SearchMessagesResponse`) is unchanged.
- `SearchPayload` is a superset of the old DTO: it adds only optional `query`/`force_default_search`/`force_sql_v2_backend`/`message_options`, all default-null, so they are omitted from the wire — no shape change.

### Testing

- Updated the `MoshiChatApiTest` payload assertion to `SearchPayload`.
- `spotlessApply`, `apiDump` (no public-API change), `detekt`, and the full client `testDebugUnitTest` suite pass.
- Device probe (compose-sample) confirmed the live wire body: `{"filter_conditions":...,"message_filter_conditions":{"text":{"$autocomplete":"a"}},"sort":[{"direction":-1,"field":"created_at"}],"offset":0,"limit":5}` — the optional fields were omitted, backend returned 200 with results parsed into `SearchMessagesResult`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message search request handling to use the correct payload format.
  * Preserved support for search filters, sorting, pagination, and message-specific options.
  * Improved compatibility with the messaging API while maintaining existing search behavior.

* **Tests**
  * Updated message search coverage to validate the revised request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->