### PR TITLE
e2e: Make the remaining UserRobot clicks stale-safe

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.compose.pages
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.BySelector
 import io.getstream.chat.android.e2e.test.mockserver.ReactionType
+import java.util.regex.Pattern
 
 open class MessageListPage {
 
@@ -56,6 +57,10 @@ open class MessageListPage {
             val sendButton get() = By.res("Stream_ComposerSendButton")
             val cooldownIndicator get() = By.res("Stream_ComposerCooldownIndicator")
             val saveButton get() = By.res("Stream_ComposerSaveButton")
+
+            // The composer trailing button is the send button normally and the save button in
+            // command mode; one selector covers taps that accept either.
+            val confirmButton get() = By.res(Pattern.compile("Stream_Composer(Send|Save)Button"))
             val recordAudioButton get() = By.res("Stream_ComposerRecordAudioButton")
             val commandSuggestionList get() = By.res("Stream_CommandSuggestionList")
             val commandSuggestionListTitle get() = By.res("Stream_CommandSuggestionListTitle")

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -137,19 +137,8 @@ class UserRobot {
      * send button; with the sample's configuration both build the same message.
      */
     private fun tapOnComposerConfirmButton(): UserRobot {
-        val endTime = System.currentTimeMillis() + defaultTimeout
-        while (System.currentTimeMillis() < endTime) {
-            Composer.sendButton.findObjects().firstOrNull()?.let {
-                it.click()
-                return this
-            }
-            Composer.saveButton.findObjects().firstOrNull()?.let {
-                it.click()
-                return this
-            }
-            Thread.sleep(50)
-        }
-        error("Neither the send nor the save composer button appeared within ${defaultTimeout}ms")
+        Composer.confirmButton.waitToAppearAndClick()
+        return this
     }
 
     fun tapOnLinkPreviewCancelButton(): UserRobot {
@@ -193,19 +182,19 @@ class UserRobot {
 
     fun copyMessage(messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
-        ContextMenu.copy.waitToAppear().click()
+        ContextMenu.copy.waitToAppearAndClick()
         return this
     }
 
     fun pinMessage(messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
-        ContextMenu.pin.waitToAppear().click()
+        ContextMenu.pin.waitToAppearAndClick()
         return this
     }
 
     fun unpinMessage(messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
-        ContextMenu.unpin.waitToAppear().click()
+        ContextMenu.unpin.waitToAppearAndClick()
         return this
     }
 
@@ -221,7 +210,7 @@ class UserRobot {
     }
 
     fun tapOnMessageReaction(): UserRobot {
-        Message.Reactions.reactions.waitToAppear().click()
+        Message.Reactions.reactions.waitToAppearAndClick()
         return this
     }
 
@@ -231,8 +220,8 @@ class UserRobot {
      */
     fun toggleReactionUsingExtendedPicker(type: ReactionType, messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
-        ContextMenu.showMoreReactions.waitToAppear().click()
-        ContextMenu.ReactionsView.reaction(type).waitToAppear().click()
+        ContextMenu.showMoreReactions.waitToAppearAndClick()
+        ContextMenu.ReactionsView.reaction(type).waitToAppearAndClick()
         return this
     }
 
@@ -275,11 +264,6 @@ class UserRobot {
         return this
     }
 
-    fun tapOnMessage(messageCellIndex: Int = 0): UserRobot {
-        MessageList.messages.waitToAppearBottomUp(withIndex = messageCellIndex).click()
-        return this
-    }
-
     fun tapOnQuotedMessage(messageCellIndex: Int = 0): UserRobot {
         // A tap that lands while the list is still moving is cancelled by the touch slop and
         // never reaches the click handler, so verify the jump moved the quote out of the
@@ -300,12 +284,12 @@ class UserRobot {
     }
 
     fun tapOnScrollToFirstUnreadButton(): UserRobot {
-        MessageList.scrollToFirstUnreadButton.waitToAppear().click()
+        MessageList.scrollToFirstUnreadButton.waitToAppearAndClick()
         return this
     }
 
     fun dismissUnreadIndicator(): UserRobot {
-        MessageList.scrollToFirstUnreadDismissIcon.waitToAppear().click()
+        MessageList.scrollToFirstUnreadDismissIcon.waitToAppearAndClick()
         return this
     }
 
@@ -387,12 +371,12 @@ class UserRobot {
     }
 
     fun tapOnMoreSwipeAction(): UserRobot {
-        ChannelListPage.ChannelList.SwipeActions.more.waitToAppear().click()
+        ChannelListPage.ChannelList.SwipeActions.more.waitToAppearAndClick()
         return this
     }
 
     fun tapOnViewChannelInfo(): UserRobot {
-        ChannelListPage.ChannelMenu.viewInfo.waitToAppear().click()
+        ChannelListPage.ChannelMenu.viewInfo.waitToAppearAndClick()
         return this
     }
 


### PR DESCRIPTION
### Goal

The last nightly run failed on API 35 because `GiphyTests.test_userObservesAnimatedGiphy_afterAddingGiphyThroughComposerMenu` failed all 3 retry attempts with `StaleObjectException`: https://github.com/GetStream/stream-chat-android/actions/runs/30414531872. The click landed on a composer button node that went stale between the find and the click.

#6588 introduced the stale-safe `waitToAppearAndClick`, but some `UserRobot` actions still click a found `UiObject2` directly, so any of them can fail the same way when Compose recomposes at tap time. This PR routes every remaining click through the stale-safe helper.

Resolves AND-1344

### Implementation

- `tapOnComposerConfirmButton` now taps one combined selector, `By.res(Pattern.compile("Stream_Composer(Send|Save)Button"))`, through `waitToAppearAndClick`, replacing the custom loop that polled the send and save buttons and clicked without stale protection. On timeout the error message now comes from `waitToAppear` instead of the custom text; the exception type is unchanged.
- The 10 `waitToAppear().click()` call sites convert to `waitToAppearAndClick()`: copy, pin, unpin, message reaction, extended reactions picker (2 taps), scroll-to-first-unread button and its dismiss icon, channel swipe "more", and view channel info.
- `tapOnMessage` is removed: it was the last unprotected click, and it has no callers.

### Testing

Ran locally against the mock server (`main`) on an API 35 emulator with direct instrumentation:

- `GiphyTests`: 10/10 passed in 106s, including the test that failed the nightly.
- `ReactionsTests`, `PinnedMessagesTests`, `ChannelActionsTests`, `MessageActionsTests` (the classes that exercise the converted click sites): 21/21 passed in 257s.

No retries were needed in either run. To reproduce, build `assembleE2eDebug` and `assembleE2eDebugAndroidTest` of `stream-chat-android-compose-sample`, start the mock server (`bundle exec fastlane start_mock_server`), install both APKs, and run the classes above with `adb shell am instrument`.

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated coverage for message composition, including both sending messages and saving commands.
  - Increased reliability of UI interactions for pinning, reactions, unread indicators, and channel information.
  - Standardized interaction handling to reduce flaky end-to-end test behavior in the Compose sample app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->