### PR TITLE
Forward sort type from custom sorters in toSortParams

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -2045,5 +2045,9 @@ internal fun QuerySorter<*>.toSortParams(): List<SortParamRequest> =
         SortParamRequest(
             field = it[QuerySorter.KEY_FIELD_NAME] as? String,
             direction = (it[QuerySorter.KEY_DIRECTION] as? Number)?.toInt(),
+            // Built-in sorters don't emit a type; forward it when a custom sorter does.
+            type = it[KEY_SORT_TYPE] as? String,
         )
     }
+
+private const val KEY_SORT_TYPE = "type"

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -2046,8 +2046,6 @@ internal fun QuerySorter<*>.toSortParams(): List<SortParamRequest> =
             field = it[QuerySorter.KEY_FIELD_NAME] as? String,
             direction = (it[QuerySorter.KEY_DIRECTION] as? Number)?.toInt(),
             // Built-in sorters don't emit a type; forward it when a custom sorter does.
-            type = it[KEY_SORT_TYPE] as? String,
+            type = it[QuerySorter.KEY_TYPE] as? String,
         )
     }
-
-private const val KEY_SORT_TYPE = "type"

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/ToSortParamsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/ToSortParamsTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api2
+
+import io.getstream.chat.android.models.querysort.ComparableFieldProvider
+import io.getstream.chat.android.models.querysort.QuerySortByField
+import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.models.querysort.internal.SortSpecification
+import io.getstream.chat.android.network.models.SortParamRequest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class ToSortParamsTest {
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    fun `maps sorter to sort params`(sorter: QuerySorter<*>, expected: List<SortParamRequest>) {
+        Assertions.assertEquals(expected, sorter.toSortParams())
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun arguments(): List<Arguments> = listOf(
+            // Custom sorter emitting a type: field, direction and type are all forwarded.
+            Arguments.of(
+                FakeSorter(mapOf("field" to "created_at", "direction" to -1, "type" to "number")),
+                listOf(SortParamRequest(field = "created_at", direction = -1, type = "number")),
+            ),
+            // Custom sorter without a type: type stays null.
+            Arguments.of(
+                FakeSorter(mapOf("field" to "created_at", "direction" to 1)),
+                listOf(SortParamRequest(field = "created_at", direction = 1, type = null)),
+            ),
+            // Built-in sorter: only field and direction, no type.
+            Arguments.of(
+                QuerySortByField.descByName<Item>("created_at"),
+                listOf(SortParamRequest(field = "created_at", direction = -1, type = null)),
+            ),
+        )
+    }
+
+    private class FakeSorter(private val dto: Map<String, Any>) : QuerySorter<Any> {
+        override var sortSpecifications: List<SortSpecification<Any>> = emptyList()
+        override val comparator: Comparator<in Any> = Comparator { _, _ -> 0 }
+        override fun toDto(): List<Map<String, Any>> = listOf(dto)
+    }
+
+    private data class Item(val createdAt: Int) : ComparableFieldProvider {
+        override fun getComparableField(fieldName: String): Comparable<*>? = when (fieldName) {
+            "created_at" -> createdAt
+            else -> null
+        }
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/ToSortParamsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/ToSortParamsTest.kt
@@ -40,12 +40,23 @@ internal class ToSortParamsTest {
         fun arguments(): List<Arguments> = listOf(
             // Custom sorter emitting a type: field, direction and type are all forwarded.
             Arguments.of(
-                FakeSorter(mapOf("field" to "created_at", "direction" to -1, "type" to "number")),
+                FakeSorter(
+                    mapOf(
+                        QuerySorter.KEY_FIELD_NAME to "created_at",
+                        QuerySorter.KEY_DIRECTION to -1,
+                        QuerySorter.KEY_TYPE to "number",
+                    ),
+                ),
                 listOf(SortParamRequest(field = "created_at", direction = -1, type = "number")),
             ),
             // Custom sorter without a type: type stays null.
             Arguments.of(
-                FakeSorter(mapOf("field" to "created_at", "direction" to 1)),
+                FakeSorter(
+                    mapOf(
+                        QuerySorter.KEY_FIELD_NAME to "created_at",
+                        QuerySorter.KEY_DIRECTION to 1,
+                    ),
+                ),
                 listOf(SortParamRequest(field = "created_at", direction = 1, type = null)),
             ),
             // Built-in sorter: only field and direction, no type.

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -2778,6 +2778,7 @@ public abstract interface class io/getstream/chat/android/models/querysort/Query
 	public static final field EQUAL_ON_COMPARISON I
 	public static final field KEY_DIRECTION Ljava/lang/String;
 	public static final field KEY_FIELD_NAME Ljava/lang/String;
+	public static final field KEY_TYPE Ljava/lang/String;
 	public static final field LESS_ON_COMPARISON I
 	public static final field MORE_ON_COMPARISON I
 	public abstract fun getComparator ()Ljava/util/Comparator;
@@ -2790,6 +2791,7 @@ public final class io/getstream/chat/android/models/querysort/QuerySorter$Compan
 	public static final field EQUAL_ON_COMPARISON I
 	public static final field KEY_DIRECTION Ljava/lang/String;
 	public static final field KEY_FIELD_NAME Ljava/lang/String;
+	public static final field KEY_TYPE Ljava/lang/String;
 	public static final field LESS_ON_COMPARISON I
 	public static final field MORE_ON_COMPARISON I
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySorter.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySorter.kt
@@ -42,6 +42,7 @@ public interface QuerySorter<T : Any> {
     public companion object {
         public const val KEY_DIRECTION: String = "direction"
         public const val KEY_FIELD_NAME: String = "field"
+        public const val KEY_TYPE: String = "type"
         public const val MORE_ON_COMPARISON: Int = 1
         public const val EQUAL_ON_COMPARISON: Int = 0
         public const val LESS_ON_COMPARISON: Int = -1


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

`QuerySorter.toSortParams()` mapped only `field`/`direction` into the generated `SortParamRequest`, silently dropping the `type` the backend reads for number/boolean sort semantics. Forward it so a custom `QuerySorter` whose `toDto()` emits a `type` keeps it on the wire. Built-in sorters never emit `type`, so their output is unchanged.

Closes [AND-1354](https://linear.app/stream/issue/AND-1354/tosortparams-never-fills-sortparamrequesttype-on-sort-request-bodies)

### Implementation

- `toSortParams()` now also reads the `type` key from each `toDto()` map into `SortParamRequest.type` (null when absent).

### Testing

- New parameterized `ToSortParamsTest`: custom sorter with `type` forwards it, custom sorter without `type` leaves it null, built-in `descByName` maps to `field`/`direction` only.
- `spotlessCheck`, `detekt`, `apiDump` (no API change), and the full client `testDebugUnitTest` suite pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom sorting now correctly forwards an optional sort type when querying data.
* **Tests**
  * Added coverage for custom sorters with and without a type, as well as built-in field sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->