### PR TITLE
Fix pending message not showing quoted message

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -774,7 +774,7 @@ public class MessageComposerController(
         val currentUserId = chatClient.getCurrentUser()?.id
         val trimmedMessage = message.trim()
         val activeMessage = activeAction?.message ?: Message()
-        val replyMessageId = (activeAction as? Reply)?.message?.id
+        val replyMessage = (activeAction as? Reply)?.message
         val mentions = filterMentions(selectedMentions, trimmedMessage)
 
         return if (isInEditMode && !activeMessage.isModerationError(currentUserId)) {
@@ -788,7 +788,8 @@ public class MessageComposerController(
                 cid = channelCid,
                 text = trimmedMessage,
                 parentId = parentMessageId,
-                replyMessageId = replyMessageId,
+                replyMessageId = replyMessage?.id,
+                replyTo = replyMessage,
                 attachments = attachments.toMutableList(),
                 mentionedUsersIds = mentions,
             )


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Backport of #6222 to `v6`. On v6 (reported on 6.41.1), sending a reply shows no quoted-message header while the message is in the pending state; the header only appears once the server confirms it, causing a flicker.

Closes [AND-1363](https://linear.app/stream/issue/AND-1363/backport-6222-to-v6-pending-reply-message-not-showing-quoted-message)

### Implementation

- `MessageComposerController.buildNewMessage()` now sets `replyTo` (the quoted `Message`) on the pending message in addition to `replyMessageId`, so the reply header renders immediately. Straight cherry-pick of #6222, already on `develop`/v7.

### Testing

- `:stream-chat-android-ui-common:testDebugUnitTest --tests "*MessageComposerController*"` passes.
