### PR TITLE
Migrate user request bodies (partialUpdateUser, getGuestUser, updateUsers) to generated models

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -69,7 +69,6 @@ import io.getstream.chat.android.client.api2.model.requests.UpdateChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateMessageRequest
-import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.UpsertPushPreferencesRequest
 import io.getstream.chat.android.client.api2.model.response.ChannelResponse
 import io.getstream.chat.android.client.api2.model.response.PushPreferencesResponse
@@ -177,6 +176,7 @@ import io.getstream.chat.android.network.models.UpdateUserGroupRequest
 import io.getstream.chat.android.network.models.UpdateUserGroupResponse
 import io.getstream.chat.android.network.models.UpdateUserPartialRequest
 import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
+import io.getstream.chat.android.network.models.UpdateUsersRequest
 import io.getstream.chat.android.network.models.UserGroupResponse
 import io.getstream.chat.android.network.models.UserRequest
 import io.getstream.chat.android.network.models.VoteData
@@ -1387,7 +1387,7 @@ constructor(
         return userApi.updateUsers(
             connectionId = connectionId,
             body = with(dtoMapping) {
-                UpdateUsersRequest(users.associateBy({ it.id }, { it.toDto() }))
+                UpdateUsersRequest(users.associateBy({ it.id }, { it.toUserRequest() }))
             },
         ).mapDomain { response ->
             response.users.values.map {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -47,7 +47,6 @@ import io.getstream.chat.android.client.api2.mapping.DomainMapping
 import io.getstream.chat.android.client.api2.mapping.DtoMapping
 import io.getstream.chat.android.client.api2.mapping.EventMapping
 import io.getstream.chat.android.client.api2.mapping.toFilterDomainWithFields
-import io.getstream.chat.android.client.api2.model.dto.PartialUpdateUserDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamPushPreferenceInputDto
 import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
@@ -55,10 +54,8 @@ import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagUserRequest
-import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
 import io.getstream.chat.android.client.api2.model.requests.InviteMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
-import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryDraftMessagesRequest
@@ -141,6 +138,7 @@ import io.getstream.chat.android.network.models.AddUserGroupMembersResponse
 import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.CastPollVoteRequest
 import io.getstream.chat.android.network.models.CreateDeviceRequest
+import io.getstream.chat.android.network.models.CreateGuestRequest
 import io.getstream.chat.android.network.models.CreatePollOptionRequest
 import io.getstream.chat.android.network.models.CreatePollRequest
 import io.getstream.chat.android.network.models.CreateReminderRequest
@@ -177,7 +175,10 @@ import io.getstream.chat.android.network.models.UpdateReminderRequest
 import io.getstream.chat.android.network.models.UpdateThreadPartialRequest
 import io.getstream.chat.android.network.models.UpdateUserGroupRequest
 import io.getstream.chat.android.network.models.UpdateUserGroupResponse
+import io.getstream.chat.android.network.models.UpdateUserPartialRequest
+import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
 import io.getstream.chat.android.network.models.UserGroupResponse
+import io.getstream.chat.android.network.models.UserRequest
 import io.getstream.chat.android.network.models.VoteData
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
@@ -1415,8 +1416,8 @@ constructor(
     override fun partialUpdateUser(id: String, set: Map<String, Any>, unset: List<String>): Call<List<User>> {
         return userApi.partialUpdateUsers(
             connectionId = connectionId,
-            body = PartialUpdateUsersRequest(
-                listOf(PartialUpdateUserDto(id = id, set = set, unset = unset)),
+            body = UpdateUsersPartialRequest(
+                users = listOf(UpdateUserPartialRequest(id = id, set = set, unset = unset)),
             ),
         ).mapDomain { response ->
             response.users.values.map { it.toDomain() }
@@ -1425,7 +1426,7 @@ constructor(
 
     override fun getGuestUser(userId: String, userName: String): Call<GuestUser> {
         return guestApi.getGuestUser(
-            body = GuestUserRequest.create(userId, userName),
+            body = CreateGuestRequest(user = UserRequest(id = userId, name = userName)),
         ).mapDomain { response ->
             GuestUser(
                 response.user.toDomain(),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
@@ -21,7 +21,6 @@ import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
-import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.response.LiveLocationsResponse
 import io.getstream.chat.android.client.api2.model.response.QueryBlockedUsersResponse
 import io.getstream.chat.android.client.api2.model.response.UpdateUsersResponse
@@ -33,6 +32,7 @@ import io.getstream.chat.android.network.models.QueryUsersPayload
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UnblockUsersResponse
 import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
+import io.getstream.chat.android.network.models.UpdateUsersRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
@@ -20,7 +20,6 @@ import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
-import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateLiveLocationRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.response.LiveLocationsResponse
@@ -33,6 +32,7 @@ import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.QueryUsersPayload
 import io.getstream.chat.android.network.models.UnblockUsersRequest
 import io.getstream.chat.android.network.models.UnblockUsersResponse
+import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -63,7 +63,7 @@ internal interface UserApi {
     @JvmSuppressWildcards // See issue: https://github.com/square/retrofit/issues/3275
     fun partialUpdateUsers(
         @Query(QueryParams.CONNECTION_ID) connectionId: String,
-        @Body body: PartialUpdateUsersRequest,
+        @Body body: UpdateUsersPartialRequest,
     ): RetrofitCall<UpdateUsersResponse>
 
     @GET("/users")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DtoMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DtoMapping.kt
@@ -50,7 +50,12 @@ import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserGroup
 import io.getstream.chat.android.models.UserTransformer
+import io.getstream.chat.android.network.models.DeliveryReceiptsResponse
+import io.getstream.chat.android.network.models.PrivacySettingsResponse
 import io.getstream.chat.android.network.models.ReactionRequest
+import io.getstream.chat.android.network.models.ReadReceiptsResponse
+import io.getstream.chat.android.network.models.TypingIndicatorsResponse
+import io.getstream.chat.android.network.models.UserRequest
 
 internal class DtoMapping(
     private val messageTransformer: MessageTransformer,
@@ -265,6 +270,33 @@ internal class DtoMapping(
                     extraData = extraData,
                 )
             }
+
+    /**
+     * Maps the domain [User] model to a network [UserRequest] model.
+     *
+     * Applies [UserTransformer] first, then maps only the fields a client is allowed to set. The
+     * backend marks role/teams/teams_role as ignore_if_client_side, so they are dropped from
+     * client requests server-side regardless; the generated model omits them accordingly.
+     */
+    internal fun User.toUserRequest(): UserRequest =
+        userTransformer.transform(this)
+            .run {
+                UserRequest(
+                    id = id,
+                    name = name,
+                    image = image,
+                    invisible = isInvisible,
+                    language = language,
+                    privacySettings = privacySettings?.toResponse(),
+                    custom = extraData,
+                )
+            }
+
+    private fun PrivacySettings.toResponse(): PrivacySettingsResponse = PrivacySettingsResponse(
+        typingIndicators = typingIndicators?.let { TypingIndicatorsResponse(enabled = it.enabled) },
+        readReceipts = readReceipts?.let { ReadReceiptsResponse(enabled = it.enabled) },
+        deliveryReceipts = deliveryReceipts?.let { DeliveryReceiptsResponse(enabled = it.enabled) },
+    )
 
     /**
      * Maps the domain [ConnectedEvent] model to a network [UpstreamConnectedEventDto] model.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -84,13 +84,6 @@ internal data class DownstreamUserDto(
 ) : ExtraDataDto
 
 @JsonClass(generateAdapter = true)
-internal data class PartialUpdateUserDto(
-    val id: String,
-    val set: Map<String, Any>,
-    val unset: List<String>,
-)
-
-@JsonClass(generateAdapter = true)
 internal data class DownstreamUserBlockDto(
     val user_id: String,
     val blocked_user_id: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -54,6 +54,7 @@ import io.getstream.chat.android.client.parser2.adapters.UpstreamMemberDtoAdapte
 import io.getstream.chat.android.client.parser2.adapters.UpstreamMessageDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamReactionDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamUserDtoAdapter
+import io.getstream.chat.android.client.parser2.adapters.UserRequestAdapter
 import io.getstream.chat.android.client.socket.ErrorResponse
 import io.getstream.chat.android.client.socket.SocketErrorMessage
 import io.getstream.chat.android.network.infrastructure.Serializer
@@ -81,6 +82,7 @@ internal class MoshiChatParser(
             .add(UpstreamReactionDtoAdapter)
             .add(DownstreamUserDtoAdapter)
             .add(UpstreamUserDtoAdapter)
+            .add(UserRequestAdapter)
             .add(DownstreamMemberDtoAdapter)
             .add(UpstreamMemberDtoAdapter)
             .add(UpstreamMemberDataDtoAdapter)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/UserRequestAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/UserRequestAdapter.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2.adapters
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+import io.getstream.chat.android.network.models.UserRequest
+
+// The generated UserRequest carries custom data in a `custom` field that must be flattened to the
+// JSON root on the wire; extraDataPropertyName matches its @Json(name = "custom").
+internal object UserRequestAdapter :
+    CustomObjectDtoAdapter<UserRequest>(UserRequest::class, extraDataPropertyName = "custom") {
+
+    @FromJson
+    @Suppress("UNUSED_PARAMETER")
+    fun fromJson(jsonReader: JsonReader): UserRequest = error("Can't parse this from Json")
+
+    @ToJson
+    fun toJson(
+        jsonWriter: JsonWriter,
+        request: UserRequest?,
+        mapAdapter: JsonAdapter<MutableMap<String, Any?>>,
+        requestAdapter: JsonAdapter<UserRequest>,
+    ) = serializeWithExtraData(jsonWriter, request, mapAdapter, requestAdapter)
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/CreateGuestRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/CreateGuestRequest.kt
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AnonymousApi
-import io.getstream.chat.android.client.api2.model.response.TokenResponse
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.CreateGuestRequest
-import retrofit2.http.Body
-import retrofit2.http.POST
+package io.getstream.chat.android.network.models
 
-@AnonymousApi
-internal interface GuestApi {
+import com.squareup.moshi.Json
 
-    @POST("/guest")
-    fun getGuestUser(
-        @Body body: CreateGuestRequest,
-    ): RetrofitCall<TokenResponse>
-}
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class CreateGuestRequest(
+    @Json(name = "user")
+    internal val user: io.getstream.chat.android.network.models.UserRequest,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/DeliveryReceiptsResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/DeliveryReceiptsResponse.kt
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class GuestUserRequest(
-    val user: GuestUser,
-) {
+import com.squareup.moshi.Json
 
-    @JsonClass(generateAdapter = true)
-    data class GuestUser(
-        val id: String,
-        val name: String,
-    )
-
-    companion object {
-        fun create(id: String, name: String): GuestUserRequest {
-            return GuestUserRequest(GuestUser(id = id, name = name))
-        }
-    }
-}
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class DeliveryReceiptsResponse(
+    @Json(name = "enabled")
+    internal val enabled: Boolean,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/PrivacySettingsResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/PrivacySettingsResponse.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class PrivacySettingsResponse(
+    @Json(name = "delivery_receipts")
+    internal val deliveryReceipts: io.getstream.chat.android.network.models.DeliveryReceiptsResponse? = null,
+
+    @Json(name = "read_receipts")
+    internal val readReceipts: io.getstream.chat.android.network.models.ReadReceiptsResponse? = null,
+
+    @Json(name = "typing_indicators")
+    internal val typingIndicators: io.getstream.chat.android.network.models.TypingIndicatorsResponse? = null,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ReadReceiptsResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ReadReceiptsResponse.kt
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AnonymousApi
-import io.getstream.chat.android.client.api2.model.response.TokenResponse
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.CreateGuestRequest
-import retrofit2.http.Body
-import retrofit2.http.POST
+package io.getstream.chat.android.network.models
 
-@AnonymousApi
-internal interface GuestApi {
+import com.squareup.moshi.Json
 
-    @POST("/guest")
-    fun getGuestUser(
-        @Body body: CreateGuestRequest,
-    ): RetrofitCall<TokenResponse>
-}
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class ReadReceiptsResponse(
+    @Json(name = "enabled")
+    internal val enabled: Boolean,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/TypingIndicatorsResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/TypingIndicatorsResponse.kt
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AnonymousApi
-import io.getstream.chat.android.client.api2.model.response.TokenResponse
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.CreateGuestRequest
-import retrofit2.http.Body
-import retrofit2.http.POST
+package io.getstream.chat.android.network.models
 
-@AnonymousApi
-internal interface GuestApi {
+import com.squareup.moshi.Json
 
-    @POST("/guest")
-    fun getGuestUser(
-        @Body body: CreateGuestRequest,
-    ): RetrofitCall<TokenResponse>
-}
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class TypingIndicatorsResponse(
+    @Json(name = "enabled")
+    internal val enabled: Boolean,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateUserPartialRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateUserPartialRequest.kt
@@ -14,10 +14,28 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
-import io.getstream.chat.android.client.api2.model.dto.PartialUpdateUserDto
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
-internal data class PartialUpdateUsersRequest(val users: List<PartialUpdateUserDto>)
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class UpdateUserPartialRequest(
+    @Json(name = "id")
+    internal val id: String,
+
+    @Json(name = "unset")
+    internal val unset: List<String>? = emptyList(),
+
+    @Json(name = "set")
+    internal val set: Map<String, Any?>? = emptyMap(),
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateUsersPartialRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateUsersPartialRequest.kt
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.endpoint
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import io.getstream.chat.android.client.api.AnonymousApi
-import io.getstream.chat.android.client.api2.model.response.TokenResponse
-import io.getstream.chat.android.client.call.RetrofitCall
-import io.getstream.chat.android.network.models.CreateGuestRequest
-import retrofit2.http.Body
-import retrofit2.http.POST
+package io.getstream.chat.android.network.models
 
-@AnonymousApi
-internal interface GuestApi {
+import com.squareup.moshi.Json
 
-    @POST("/guest")
-    fun getGuestUser(
-        @Body body: CreateGuestRequest,
-    ): RetrofitCall<TokenResponse>
-}
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class UpdateUsersPartialRequest(
+    @Json(name = "users")
+    internal val users: List<io.getstream.chat.android.network.models.UpdateUserPartialRequest> = emptyList(),
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateUsersRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UpdateUsersRequest.kt
@@ -14,12 +14,22 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.requests
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
-import io.getstream.chat.android.client.api2.model.dto.UpstreamUserDto
+package io.getstream.chat.android.network.models
 
-@JsonClass(generateAdapter = true)
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
 internal data class UpdateUsersRequest(
-    val users: Map<String, UpstreamUserDto>,
+    @Json(name = "users")
+    internal val users: Map<String, io.getstream.chat.android.network.models.UserRequest> = emptyMap(),
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UserRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/UserRequest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ * User request object
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class UserRequest(
+    @Json(name = "id")
+    internal val id: String,
+
+    @Json(name = "image")
+    internal val image: String? = null,
+
+    @Json(name = "invisible")
+    internal val invisible: Boolean? = null,
+
+    @Json(name = "language")
+    internal val language: String? = null,
+
+    @Json(name = "name")
+    internal val name: String? = null,
+
+    @Json(name = "custom")
+    internal val custom: Map<String, Any?>? = emptyMap(),
+
+    @Json(name = "privacy_settings")
+    internal val privacySettings: io.getstream.chat.android.network.models.PrivacySettingsResponse? = null,
+)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -42,7 +42,6 @@ import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChatPreferencesDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPushPreferenceDto
-import io.getstream.chat.android.client.api2.model.dto.PartialUpdateUserDto
 import io.getstream.chat.android.client.api2.model.dto.UnreadDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamChatPreferencesDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamPushPreferenceInputDto
@@ -50,9 +49,7 @@ import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagUserRequest
-import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
-import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
@@ -140,6 +137,7 @@ import io.getstream.chat.android.network.models.BlockUsersRequest
 import io.getstream.chat.android.network.models.BlockUsersResponse
 import io.getstream.chat.android.network.models.CastPollVoteRequest
 import io.getstream.chat.android.network.models.CreateDeviceRequest
+import io.getstream.chat.android.network.models.CreateGuestRequest
 import io.getstream.chat.android.network.models.CreatePollOptionRequest
 import io.getstream.chat.android.network.models.CreatePollRequest
 import io.getstream.chat.android.network.models.CreateReminderRequest
@@ -181,6 +179,9 @@ import io.getstream.chat.android.network.models.UpdateReminderRequest
 import io.getstream.chat.android.network.models.UpdateThreadPartialRequest
 import io.getstream.chat.android.network.models.UpdateUserGroupRequest
 import io.getstream.chat.android.network.models.UpdateUserGroupResponse
+import io.getstream.chat.android.network.models.UpdateUserPartialRequest
+import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
+import io.getstream.chat.android.network.models.UserRequest
 import io.getstream.chat.android.network.models.VoteData
 import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
@@ -1830,8 +1831,8 @@ internal class MoshiChatApiTest {
         sut.setConnection(userId = userId, connectionId = connectionId)
         val result = sut.partialUpdateUser(targetUserId, set, unset).await()
         // then
-        val expectedBody = PartialUpdateUsersRequest(
-            users = listOf(PartialUpdateUserDto(targetUserId, set, unset)),
+        val expectedBody = UpdateUsersPartialRequest(
+            users = listOf(UpdateUserPartialRequest(id = targetUserId, set = set, unset = unset)),
         )
         result `should be instance of` expected
         verify(api, times(1)).partialUpdateUsers(connectionId, expectedBody)
@@ -1851,7 +1852,7 @@ internal class MoshiChatApiTest {
         val userName = randomString()
         val result = sut.getGuestUser(userId, userName).await()
         // then
-        val expectedBody = GuestUserRequest.create(userId, userName)
+        val expectedBody = CreateGuestRequest(user = UserRequest(id = userId, name = userName))
         result `should be instance of` expected
         verify(api, times(1)).getGuestUser(expectedBody)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DtoMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DtoMappingTest.kt
@@ -39,7 +39,12 @@ import io.getstream.chat.android.models.NoOpMessageTransformer
 import io.getstream.chat.android.models.NoOpUserTransformer
 import io.getstream.chat.android.models.UserGroup
 import io.getstream.chat.android.models.UserTransformer
+import io.getstream.chat.android.network.models.DeliveryReceiptsResponse
+import io.getstream.chat.android.network.models.PrivacySettingsResponse
 import io.getstream.chat.android.network.models.ReactionRequest
+import io.getstream.chat.android.network.models.ReadReceiptsResponse
+import io.getstream.chat.android.network.models.TypingIndicatorsResponse
+import io.getstream.chat.android.network.models.UserRequest
 import io.getstream.chat.android.randomAttachment
 import io.getstream.chat.android.randomDevice
 import io.getstream.chat.android.randomDraftMessage
@@ -328,6 +333,79 @@ internal class DtoMappingTest {
         dto shouldBeEqualTo expected
         // Verify the transformer is called
         verify(userTransformer, times(1)).transform(user)
+    }
+
+    @Test
+    fun `User with privacy settings is correctly mapped to UserRequest`() {
+        val userTransformer = spy(NoOpUserTransformer)
+        val user = randomUser(
+            privacySettings = PrivacySettings(
+                typingIndicators = TypingIndicators(enabled = true),
+                readReceipts = ReadReceipts(enabled = false),
+                deliveryReceipts = DeliveryReceipts(enabled = true),
+            ),
+        )
+        val mapping = Fixture()
+            .withUserTransformer(userTransformer)
+            .get()
+
+        val request = with(mapping) { user.toUserRequest() }
+
+        val expected = UserRequest(
+            id = user.id,
+            name = user.name,
+            image = user.image,
+            invisible = user.isInvisible,
+            language = user.language,
+            privacySettings = PrivacySettingsResponse(
+                typingIndicators = TypingIndicatorsResponse(enabled = true),
+                readReceipts = ReadReceiptsResponse(enabled = false),
+                deliveryReceipts = DeliveryReceiptsResponse(enabled = true),
+            ),
+            custom = user.extraData,
+        )
+        request shouldBeEqualTo expected
+        // Verify the transformer is called
+        verify(userTransformer, times(1)).transform(user)
+    }
+
+    @Test
+    fun `User with empty privacy settings maps each sub-setting to null`() {
+        val user = randomUser(
+            privacySettings = PrivacySettings(
+                typingIndicators = null,
+                readReceipts = null,
+                deliveryReceipts = null,
+            ),
+        )
+        val mapping = Fixture().get()
+
+        val request = with(mapping) { user.toUserRequest() }
+
+        request.privacySettings shouldBeEqualTo PrivacySettingsResponse(
+            typingIndicators = null,
+            readReceipts = null,
+            deliveryReceipts = null,
+        )
+    }
+
+    @Test
+    fun `User without privacy settings is mapped to UserRequest with null privacy settings`() {
+        val user = randomUser(privacySettings = null)
+        val mapping = Fixture().get()
+
+        val request = with(mapping) { user.toUserRequest() }
+
+        val expected = UserRequest(
+            id = user.id,
+            name = user.name,
+            image = user.image,
+            invisible = user.isInvisible,
+            language = user.language,
+            privacySettings = null,
+            custom = user.extraData,
+        )
+        request shouldBeEqualTo expected
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/UserRequestsAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/UserRequestsAdapterTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2
+
+import io.getstream.chat.android.client.parser2.testdata.UserRequestsTestData
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class UserRequestsAdapterTest {
+    private val parser = ParserFactory.createMoshiChatParser()
+
+    @Test
+    fun `Serialize UpdateUsersPartialRequest`() {
+        val json = parser.toJson(UserRequestsTestData.updateUsersPartialRequest)
+        Assertions.assertEquals(UserRequestsTestData.updateUsersPartialRequestJson, json)
+    }
+
+    @Test
+    fun `Serialize CreateGuestRequest with custom fields`() {
+        val json = parser.toJson(UserRequestsTestData.createGuestRequest)
+        Assertions.assertEquals(UserRequestsTestData.createGuestRequestJson, json)
+    }
+
+    @Test
+    fun `Serialize CreateGuestRequest without custom fields`() {
+        val json = parser.toJson(UserRequestsTestData.createGuestRequestWithoutCustom)
+        Assertions.assertEquals(UserRequestsTestData.createGuestRequestJsonWithoutCustom, json)
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/UserRequestsAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/UserRequestsAdapterTest.kt
@@ -40,4 +40,10 @@ internal class UserRequestsAdapterTest {
         val json = parser.toJson(UserRequestsTestData.createGuestRequestWithoutCustom)
         Assertions.assertEquals(UserRequestsTestData.createGuestRequestJsonWithoutCustom, json)
     }
+
+    @Test
+    fun `Serialize UpdateUsersRequest`() {
+        val json = parser.toJson(UserRequestsTestData.updateUsersRequest)
+        Assertions.assertEquals(UserRequestsTestData.updateUsersRequestJson, json)
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserRequestsTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserRequestsTestData.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2.testdata
+
+import io.getstream.chat.android.network.models.CreateGuestRequest
+import io.getstream.chat.android.network.models.UpdateUserPartialRequest
+import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
+import io.getstream.chat.android.network.models.UserRequest
+import org.intellij.lang.annotations.Language
+
+internal object UserRequestsTestData {
+
+    // UpdateUsersPartialRequest
+
+    @Language("JSON")
+    val updateUsersPartialRequestJson =
+        """{
+          "users": [
+            {
+              "id": "user1",
+              "unset": [
+                "age"
+              ],
+              "set": {
+                "nickname": "neo"
+              }
+            }
+          ]
+        }""".withoutWhitespace()
+
+    val updateUsersPartialRequest = UpdateUsersPartialRequest(
+        users = listOf(
+            UpdateUserPartialRequest(
+                id = "user1",
+                unset = listOf("age"),
+                set = mapOf("nickname" to "neo"),
+            ),
+        ),
+    )
+
+    // CreateGuestRequest (custom flattened onto the nested user object)
+
+    @Language("JSON")
+    val createGuestRequestJson =
+        """{
+          "user": {
+            "id": "user1",
+            "name": "Neo",
+            "customKey": "customValue"
+          }
+        }""".withoutWhitespace()
+
+    val createGuestRequest = CreateGuestRequest(
+        user = UserRequest(
+            id = "user1",
+            name = "Neo",
+            custom = mapOf("customKey" to "customValue"),
+        ),
+    )
+
+    @Language("JSON")
+    val createGuestRequestJsonWithoutCustom =
+        """{
+          "user": {
+            "id": "user1",
+            "name": "Neo"
+          }
+        }""".withoutWhitespace()
+
+    val createGuestRequestWithoutCustom = CreateGuestRequest(
+        user = UserRequest(id = "user1", name = "Neo"),
+    )
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserRequestsTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserRequestsTestData.kt
@@ -17,8 +17,11 @@
 package io.getstream.chat.android.client.parser2.testdata
 
 import io.getstream.chat.android.network.models.CreateGuestRequest
+import io.getstream.chat.android.network.models.PrivacySettingsResponse
+import io.getstream.chat.android.network.models.ReadReceiptsResponse
 import io.getstream.chat.android.network.models.UpdateUserPartialRequest
 import io.getstream.chat.android.network.models.UpdateUsersPartialRequest
+import io.getstream.chat.android.network.models.UpdateUsersRequest
 import io.getstream.chat.android.network.models.UserRequest
 import org.intellij.lang.annotations.Language
 
@@ -83,5 +86,37 @@ internal object UserRequestsTestData {
 
     val createGuestRequestWithoutCustom = CreateGuestRequest(
         user = UserRequest(id = "user1", name = "Neo"),
+    )
+
+    // UpdateUsersRequest (map of user id -> UserRequest, custom flattened onto each user)
+
+    @Language("JSON")
+    val updateUsersRequestJson =
+        """{
+          "users": {
+            "user1": {
+              "id": "user1",
+              "name": "Neo",
+              "privacy_settings": {
+                "read_receipts": {
+                  "enabled": true
+                }
+              },
+              "customKey": "customValue"
+            }
+          }
+        }""".withoutWhitespace()
+
+    val updateUsersRequest = UpdateUsersRequest(
+        users = mapOf(
+            "user1" to UserRequest(
+                id = "user1",
+                name = "Neo",
+                privacySettings = PrivacySettingsResponse(
+                    readReceipts = ReadReceiptsResponse(enabled = true),
+                ),
+                custom = mapOf("customKey" to "customValue"),
+            ),
+        ),
     )
 }


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the `partialUpdateUser`, `getGuestUser`, and `updateUsers` request bodies to the generated `UpdateUsersPartialRequest`/`UpdateUserPartialRequest`, `CreateGuestRequest`, `UpdateUsersRequest`, and `UserRequest` network models.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- `partialUpdateUser` -> `UpdateUsersPartialRequest(UpdateUserPartialRequest(id/set/unset))`.
- `getGuestUser` -> `CreateGuestRequest(UserRequest(id, name))`; the generated `UserRequest` flattens `custom` to the wire root via a new `UserRequestAdapter`.
- `updateUsers` -> `UpdateUsersRequest(Map<String, UserRequest>)` via a new `User.toUserRequest()` mapper.
- Removed hand-written `PartialUpdateUsersRequest`, `GuestUserRequest`, `PartialUpdateUserDto`, and `UpdateUsersRequest`.

**Note on `updateUsers`:** the generated `UserRequest` is leaner than the old `UpstreamUserDto` — it omits `role`/`teams`/`teams_role`/`banned`/`devices`. That's intentional and safe: the backend marks `role`/`teams`/`teams_role` as `ignore_if_client_side` (stripped for client-token requests) and doesn't bind `banned`/`devices` on this endpoint, so the old DTO was shipping fields the server already discarded. Verified on the wire — an `updateUsers` upsert returns `200` and `role`/`teams` are preserved server-side even though the client no longer sends them.

### Testing

- New `UserRequestsAdapterTest` + testdata lock the wire shape (incl. `UserRequest` custom flatten and `privacy_settings`).
- `MoshiChatApiTest` mapper assertions updated.
- `spotlessApply`, `apiDump` (no public-API change), `detekt`, and the full client `testDebugUnitTest` suite pass.
- Device-probed against the live backend: `partialUpdateUser` (set + unset paths) and `updateUsers` (custom sentinel round-trips; `role`/`teams` preserved) confirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved guest-user creation and user update requests for more consistent handling of profiles, custom data, and privacy settings.
  - Added support for partial and bulk user updates, including setting and removing user fields.
  - Improved request processing for typing indicators, read receipts, and delivery receipts.
  - Custom user data is now correctly included in outgoing requests.

- **Reliability**
  - Added coverage for guest creation, partial updates, bulk updates, custom data, and privacy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->