### PR TITLE
client: Fix remaining ChatClientTest event subscription flakiness

### DIFF
--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -24,7 +24,10 @@ import io.getstream.chat.android.client.clientstate.DisconnectCause
 import io.getstream.chat.android.client.clientstate.UserStateService
 import io.getstream.chat.android.client.errors.ChatErrorCode
 import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.events.ConnectedEvent
+import io.getstream.chat.android.client.events.ConnectionErrorEvent
 import io.getstream.chat.android.client.events.DisconnectedEvent
+import io.getstream.chat.android.client.events.HealthEvent
 import io.getstream.chat.android.client.events.UnknownEvent
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.network.NetworkStateProvider
@@ -82,6 +85,7 @@ internal class ChatClientTest {
 
         init {
             val distinctEvents = generateSequence(EventArguments::randomEvent)
+                .filterNot { it is ConnectionErrorEvent || it is ConnectedEvent || it is HealthEvent }
                 .distinctBy { it::class }.take(3).toList()
             eventA = distinctEvents[0]
             eventB = distinctEvents[1]


### PR DESCRIPTION
<!-- pr:test -->

### Goal

Fix the remaining flakiness in `ChatClientTest`'s event subscription tests.

Closes [AND-1365](https://linear.app/stream/issue/AND-1365/fix-remaining-chatclienttest-event-subscription-flakiness-socket)

### Implementation

The distinct-class fix in #6537 still let `eventA`/`eventB`/`eventC` be drawn from `EventArguments.randomEvent()` as a `ConnectionErrorEvent`, which `ChatSocket` routes to `handleError` instead of delivering to subscribers (`ChatSocket.kt:101`). When the random pick landed such an event, the subscription tests that expected it in `result` failed.

- Exclude the events the socket intercepts before subscriber dispatch (`ConnectionErrorEvent`, plus `ConnectedEvent`/`HealthEvent` defensively) from the random selection.

### Testing

- Probed the selection logic across 100k seeds: the old logic picks an intercepted event 4.8% of the time, the new logic never does.
- `:stream-chat-android-client:testDebugUnitTest --tests "*ChatClientTest"` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated randomized event test fixtures to exclude connection-status events, improving test consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->