### PR TITLE
client: Keep persisted channel lastMessageAt consistent with its latest message

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/channel/internal/ChannelMapper.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/channel/internal/ChannelMapper.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client.internal.offline.repository.domain.channel.internal
 
+import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.client.extensions.internal.lastMessage
 import io.getstream.chat.android.client.extensions.syncUnreadCountWithReads
 import io.getstream.chat.android.client.internal.offline.repository.domain.channel.member.internal.MemberEntity
@@ -26,6 +27,7 @@ import io.getstream.chat.android.client.internal.offline.repository.domain.chann
 import io.getstream.chat.android.client.internal.offline.repository.domain.channel.userread.internal.toModel
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.toEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.toModel
+import io.getstream.chat.android.core.utils.date.max
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.DraftMessage
@@ -53,7 +55,7 @@ internal fun Channel.toEntity(): ChannelEntity {
         memberCount = memberCount,
         reads = read.map(ChannelUserRead::toEntity).associateBy(ChannelUserReadEntity::userId).toMutableMap(),
         lastMessageId = lastMessage?.id,
-        lastMessageAt = lastMessageAt,
+        lastMessageAt = max(lastMessageAt, lastMessage?.getCreatedAtOrNull()),
         createdByUserId = createdBy.id,
         watcherIds = watchers.map(User::id),
         watcherCount = watcherCount,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/channel/internal/ChannelMapperTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/channel/internal/ChannelMapperTest.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.randomUser
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.util.Date
 
 internal class ChannelMapperTest {
 
@@ -86,7 +87,7 @@ internal class ChannelMapperTest {
             memberCount = channel.memberCount,
             reads = reads.map { it.toEntity() }.associateBy { it.userId }.toMutableMap(),
             lastMessageId = lastMessage.id,
-            lastMessageAt = channel.lastMessageAt,
+            lastMessageAt = listOfNotNull(channel.lastMessageAt, lastMessage.createdAt).maxOrNull(),
             createdByUserId = createdByUser.id,
             watcherIds = watchers.map { it.id },
             watcherCount = channel.watcherCount,
@@ -100,6 +101,48 @@ internal class ChannelMapperTest {
         val result = channel.toEntity()
 
         assertEquals(expectedChannelEntity, result)
+    }
+
+    @Test
+    fun `toEntity should advance lastMessageAt to the newest message when the stored value is stale`() = runTest {
+        val newest = randomMessage(
+            createdAt = Date(2000),
+            createdLocallyAt = null,
+            parentId = null,
+            deletedAt = null,
+            deletedForMe = false,
+        )
+        val channel = randomChannel(messages = listOf(newest), lastMessageAt = Date(1000))
+
+        val entity = channel.toEntity()
+
+        assertEquals(Date(2000), entity.lastMessageAt)
+        assertEquals(newest.id, entity.lastMessageId)
+    }
+
+    @Test
+    fun `toEntity should keep lastMessageAt when it is newer than the last message`() = runTest {
+        val older = randomMessage(
+            createdAt = Date(1000),
+            createdLocallyAt = null,
+            parentId = null,
+            deletedAt = null,
+            deletedForMe = false,
+        )
+        val channel = randomChannel(messages = listOf(older), lastMessageAt = Date(3000))
+
+        val entity = channel.toEntity()
+
+        assertEquals(Date(3000), entity.lastMessageAt)
+    }
+
+    @Test
+    fun `toEntity should keep lastMessageAt when there is no last message`() = runTest {
+        val channel = randomChannel(messages = emptyList(), lastMessageAt = Date(1000))
+
+        val entity = channel.toEntity()
+
+        assertEquals(Date(1000), entity.lastMessageAt)
     }
 
     @Test


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Channels could be sorted by a stale `lastMessageAt` when the persisted value lagged the channel's newest visible message, so a row would show a newer message than its position in the list reflected.

Closes #6604

### Implementation

When persisting a channel, keep `lastMessageAt` consistent with its last message instead of trusting the stored field, so it never lags behind (nor regresses below) the newest visible message. This matches the iOS SDK's behavior.

### Testing

- `ChannelMapperTest`: added coverage for advancing to a newer message, not regressing when the stored value is newer, and the no-last-message case; updated the existing mapping test.
- On device: confirmed the SDK heals real channels on launch and that `stream_chat_channel_state.lastMessageAt` matches the channel's last message on this build versus staying stale on `develop`.
- `spotlessCheck`, `detekt`, `apiCheck` (no public API change), and the client `testDebugUnitTest` suite pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved channel activity tracking by recording the most recent timestamp between the channel update and its latest message.
  - Preserved the channel timestamp when it is newer than the last message.
  - Correctly handles channels without a last message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->