### PR TITLE
Surface the message author's member custom data on Message.member

### DIFF
--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.MarkAllReadEvent
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MemberRemovedEvent
+import io.getstream.chat.android.client.events.MemberUpdatedEvent
 import io.getstream.chat.android.client.events.MessageDeletedEvent
 import io.getstream.chat.android.client.events.MessageDeliveredEvent
 import io.getstream.chat.android.client.events.MessageReadEvent
@@ -428,6 +429,26 @@ public fun randomMemberAddedEvent(
 ): MemberAddedEvent {
     return MemberAddedEvent(
         type = EventType.MEMBER_ADDED,
+        createdAt = createdAt,
+        rawCreatedAt = streamFormatter.format(createdAt),
+        user = user,
+        cid = cid,
+        channelType = channelType,
+        channelId = channelId,
+        member = member,
+    )
+}
+
+public fun randomMemberUpdatedEvent(
+    createdAt: Date = Date(),
+    user: User = randomUser(),
+    cid: String = randomCID(),
+    channelType: String = randomString(),
+    channelId: String = randomString(),
+    member: Member = randomMember(),
+): MemberUpdatedEvent {
+    return MemberUpdatedEvent(
+        type = EventType.MEMBER_UPDATED,
         createdAt = createdAt,
         rawCreatedAt = streamFormatter.format(createdAt),
         user = user,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.client.api2.model.dto.DownstreamDraftDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamFlagDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberDto
+import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberInfoDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDetailsDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDto
@@ -85,6 +86,7 @@ import io.getstream.chat.android.models.FileUploadConfig
 import io.getstream.chat.android.models.Flag
 import io.getstream.chat.android.models.Location
 import io.getstream.chat.android.models.Member
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageModerationAction
 import io.getstream.chat.android.models.MessageModerationDetails
@@ -229,6 +231,7 @@ internal class DomainMapping(
     /**
      * Transforms [DownstreamMessageDto] to [Message].
      */
+    @Suppress("DEPRECATION")
     internal fun DownstreamMessageDto.toDomain(fallbackChannelInfo: ChannelInfo? = null): Message =
         (channel?.toDomain() ?: fallbackChannelInfo).let { channelInfo: ChannelInfo? ->
             Message(
@@ -280,6 +283,7 @@ internal class DomainMapping(
                 reminder = reminder?.toDomain(),
                 sharedLocation = shared_location?.toDomain(),
                 channelRole = member?.channel_role,
+                member = member?.toDomain(),
                 deletedForMe = deleted_for_me ?: false,
                 extraData = extraData.toMutableMap(),
             ).let(messageTransformer::transform)
@@ -466,6 +470,22 @@ internal class DomainMapping(
             avgResponseTime = avgResponseTime?.toLong(),
             extraData = custom.mapNotNull { (key, value) -> value?.let { key to it } }.toMap(),
         ).let(userTransformer::transform)
+
+    /**
+     * Transforms [DownstreamMemberInfoDto] to [MemberInfo].
+     */
+    internal fun DownstreamMemberInfoDto.toDomain(): MemberInfo =
+        MemberInfo(
+            channelRole = channel_role,
+            notificationsMuted = notifications_muted ?: false,
+            extraData = memberCustom(),
+        )
+
+    /**
+     * The member custom data, regardless of whether API v1 inlined it next to the declared fields or API v2 nested it
+     * under `custom`. The two shapes never coexist, so the merge only ever picks up one of them.
+     */
+    private fun DownstreamMemberInfoDto.memberCustom(): Map<String, Any> = extraData + custom.orEmpty()
 
     internal fun DownstreamLocationDto.toDomain(): Location =
         Location(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MemberDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MemberDtos.kt
@@ -75,11 +75,24 @@ internal data class DownstreamMemberDto(
 ) : ExtraDataDto
 
 /**
- * DTO holding limited data about a channel member.
+ * DTO holding limited data about a channel member, as attached to a message payload.
+ *
+ * See [io.getstream.chat.android.client.parser2.adapters.DownstreamMemberInfoDtoAdapter] for
+ * special [extraData] handling.
  *
  * @property channel_role The role of the member in the channel.
+ * @property notifications_muted If notifications are muted for the member in the channel.
+ * @property custom The member custom data, in the shape API v2 returns it: nested.
+ * @property extraData The member custom data, in the shape API v1 returns it: inlined next to [channel_role].
  */
+@StreamHandsOff(
+    reason = "Field names can't be changed because [CustomObjectDtoAdapter] class uses reflections to add/remove " +
+        "content of [extraData] map",
+)
 @JsonClass(generateAdapter = true)
 internal data class DownstreamMemberInfoDto(
     val channel_role: String?,
-)
+    val notifications_muted: Boolean? = null,
+    val custom: Map<String, Any>? = null,
+    val extraData: Map<String, Any> = emptyMap(),
+) : ExtraDataDto

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Member.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Member.kt
@@ -35,9 +35,10 @@ public fun Collection<Member>.updateUsers(userMap: Map<String, User>): Collectio
 /**
  * Narrows a full [Member] down to the slim [MemberInfo] carried by [Message.member].
  *
- * [Member.extraData] holds every key the member DTO does not declare, which includes `user_id`. The projection the
- * backend puts on `message.member` never carries it, so it is dropped here to keep [MemberInfo.extraData] identical
- * no matter whether it came from a message payload or from a member event.
+ * [Member.extraData] holds every key the member DTO does not declare, which includes `user_id` and the deprecated
+ * member-level `role` that channel payloads send next to `channel_role`. The projection the backend puts on
+ * `message.member` carries neither, so both are dropped here to keep [MemberInfo.extraData] identical no matter
+ * whether it came from a message payload or from a member event.
  */
 @InternalStreamChatApi
 public fun Member.toMemberInfo(): MemberInfo = MemberInfo(
@@ -47,4 +48,4 @@ public fun Member.toMemberInfo(): MemberInfo = MemberInfo(
 )
 
 /** Keys that reach [Member.extraData] only because the member DTO does not declare them. */
-private val NON_CUSTOM_MEMBER_KEYS = setOf("user_id")
+private val NON_CUSTOM_MEMBER_KEYS = setOf("user_id", "role")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Member.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Member.kt
@@ -35,10 +35,10 @@ public fun Collection<Member>.updateUsers(userMap: Map<String, User>): Collectio
 /**
  * Narrows a full [Member] down to the slim [MemberInfo] carried by [Message.member].
  *
- * [Member.extraData] holds every key the member DTO does not declare, which includes `user_id` and the deprecated
- * member-level `role` that channel payloads send next to `channel_role`. The projection the backend puts on
- * `message.member` carries neither, so both are dropped here to keep [MemberInfo.extraData] identical no matter
- * whether it came from a message payload or from a member event.
+ * [Member.extraData] holds every key the member DTO does not declare, which includes stored member fields such as
+ * `role` and `deleted_messages`. The projection the backend puts on `message.member` carries none of them, so they
+ * are dropped here to keep [MemberInfo.extraData] identical no matter whether it came from a message payload or from
+ * a member event.
  */
 @InternalStreamChatApi
 public fun Member.toMemberInfo(): MemberInfo = MemberInfo(
@@ -47,5 +47,16 @@ public fun Member.toMemberInfo(): MemberInfo = MemberInfo(
     extraData = extraData - NON_CUSTOM_MEMBER_KEYS,
 )
 
-/** Keys that reach [Member.extraData] only because the member DTO does not declare them. */
-private val NON_CUSTOM_MEMBER_KEYS = setOf("user_id", "role")
+/**
+ * Keys that reach [Member.extraData] only because the member DTO does not declare them: every `ChannelMemberResponse`
+ * field the DTO leaves out, apart from `custom`, which is where member custom data itself arrives.
+ */
+private val NON_CUSTOM_MEMBER_KEYS = setOf(
+    "user_id",
+    "role",
+    "is_moderator",
+    "deleted_messages",
+    "deleted_at",
+    "ban_from_future_channels",
+    "future_channel_ban_expires",
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Member.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Member.kt
@@ -18,6 +18,8 @@ package io.getstream.chat.android.client.extensions.internal
 
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Member
+import io.getstream.chat.android.models.MemberInfo
+import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 
 /** Updates collection of members with more recent data of [users]. */
@@ -29,3 +31,20 @@ public fun Collection<Member>.updateUsers(userMap: Map<String, User>): Collectio
         member
     }
 }
+
+/**
+ * Narrows a full [Member] down to the slim [MemberInfo] carried by [Message.member].
+ *
+ * [Member.extraData] holds every key the member DTO does not declare, which includes `user_id`. The projection the
+ * backend puts on `message.member` never carries it, so it is dropped here to keep [MemberInfo.extraData] identical
+ * no matter whether it came from a message payload or from a member event.
+ */
+@InternalStreamChatApi
+public fun Member.toMemberInfo(): MemberInfo = MemberInfo(
+    channelRole = channelRole,
+    notificationsMuted = notificationsMuted ?: false,
+    extraData = extraData - NON_CUSTOM_MEMBER_KEYS,
+)
+
+/** Keys that reach [Member.extraData] only because the member DTO does not declare them. */
+private val NON_CUSTOM_MEMBER_KEYS = setOf("user_id")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
@@ -29,15 +29,13 @@ import java.util.Date
 /**
  * Replaces the [Message.member] snapshot of this message, keeping the deprecated [Message.channelRole] in sync with it.
  *
- * A member payload that carries no `channel_role` must not wipe the role already known for the message: the backend
- * always assigns one, so an absent role means "not sent" rather than "no role".
+ * The snapshot is taken verbatim: the same value reaches the in-memory state, the repository cache and the database, so
+ * the three cannot disagree. A blanket column update cannot preserve a previously known role, so neither does this.
  */
 @InternalStreamChatApi
 @Suppress("DEPRECATION")
-public fun Message.withMemberInfo(memberInfo: MemberInfo?): Message {
-    val resolved = memberInfo?.let { it.copy(channelRole = it.channelRole ?: member?.channelRole) }
-    return copy(member = resolved, channelRole = resolved?.channelRole)
-}
+public fun Message.withMemberInfo(memberInfo: MemberInfo?): Message =
+    copy(member = memberInfo, channelRole = memberInfo?.channelRole)
 
 /** Updates collection of messages with more recent data of [users]. */
 @InternalStreamChatApi

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
@@ -42,7 +42,7 @@ public fun Message.withMemberInfo(memberInfo: MemberInfo?): Message =
  */
 @InternalStreamChatApi
 public fun Message.hasOutdatedMemberInfo(userId: String, memberInfo: MemberInfo?): Boolean =
-    isAuthoredBy(userId, memberInfo) || replyTo?.isAuthoredBy(userId, memberInfo) == true
+    hasOutdatedMemberInfoFor(userId, memberInfo) || replyTo?.hasOutdatedMemberInfoFor(userId, memberInfo) == true
 
 /**
  * Applies [memberInfo] to this message and to the quoted message it carries, whichever of the two [userId] authored.
@@ -59,7 +59,7 @@ public fun Message.withRefreshedMemberInfo(userId: String, memberInfo: MemberInf
     }
 }
 
-private fun Message.isAuthoredBy(userId: String, memberInfo: MemberInfo?): Boolean =
+private fun Message.hasOutdatedMemberInfoFor(userId: String, memberInfo: MemberInfo?): Boolean =
     user.id == userId && member != memberInfo
 
 /** Updates collection of messages with more recent data of [users]. */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
@@ -37,6 +37,31 @@ import java.util.Date
 public fun Message.withMemberInfo(memberInfo: MemberInfo?): Message =
     copy(member = memberInfo, channelRole = memberInfo?.channelRole)
 
+/**
+ * Whether this message, or the quoted message it carries, holds an out of date [Message.member] snapshot for [userId].
+ */
+@InternalStreamChatApi
+public fun Message.hasOutdatedMemberInfo(userId: String, memberInfo: MemberInfo?): Boolean =
+    isAuthoredBy(userId, memberInfo) || replyTo?.isAuthoredBy(userId, memberInfo) == true
+
+/**
+ * Applies [memberInfo] to this message and to the quoted message it carries, whichever of the two [userId] authored.
+ *
+ * The quoted copy is a snapshot of its own, so leaving it behind would show two different snapshots for one author.
+ */
+@InternalStreamChatApi
+public fun Message.withRefreshedMemberInfo(userId: String, memberInfo: MemberInfo?): Message {
+    val refreshed = if (user.id == userId) withMemberInfo(memberInfo) else this
+    val quoted = refreshed.replyTo
+    return when {
+        quoted == null || quoted.user.id != userId -> refreshed
+        else -> refreshed.copy(replyTo = quoted.withMemberInfo(memberInfo))
+    }
+}
+
+private fun Message.isAuthoredBy(userId: String, memberInfo: MemberInfo?): Boolean =
+    user.id == userId && member != memberInfo
+
 /** Updates collection of messages with more recent data of [users]. */
 @InternalStreamChatApi
 public fun Collection<Message>.updateUsers(users: Map<String, User>): List<Message> = map { it.updateUsers(users) }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
@@ -20,10 +20,24 @@ import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.User
 import java.util.Date
+
+/**
+ * Replaces the [Message.member] snapshot of this message, keeping the deprecated [Message.channelRole] in sync with it.
+ *
+ * A member payload that carries no `channel_role` must not wipe the role already known for the message: the backend
+ * always assigns one, so an absent role means "not sent" rather than "no role".
+ */
+@InternalStreamChatApi
+@Suppress("DEPRECATION")
+public fun Message.withMemberInfo(memberInfo: MemberInfo?): Message {
+    val resolved = memberInfo?.let { it.copy(channelRole = it.channelRole ?: member?.channelRole) }
+    return copy(member = resolved, channelRole = resolved?.channelRole)
+}
 
 /** Updates collection of messages with more recent data of [users]. */
 @InternalStreamChatApi

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/converter/internal/MemberInfoConverter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/converter/internal/MemberInfoConverter.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.offline.repository.database.converter.internal
+
+import androidx.room.TypeConverter
+import com.squareup.moshi.adapter
+import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.MemberInfoEntity
+
+/**
+ * Converter class defining how the [MemberInfoEntity] is stored in the database.
+ */
+internal class MemberInfoConverter {
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private val adapter = moshi.adapter<MemberInfoEntity>()
+
+    /**
+     * Converts a [String] to a [MemberInfoEntity].
+     */
+    @TypeConverter
+    fun stringToMemberInfo(data: String?): MemberInfoEntity? {
+        if (data.isNullOrEmpty() || data == "null") {
+            return null
+        }
+        return adapter.fromJson(data)
+    }
+
+    /**
+     * Converts a [MemberInfoEntity] to a [String].
+     */
+    @TypeConverter
+    fun memberInfoToString(memberInfo: MemberInfoEntity?): String? {
+        return memberInfo?.let(adapter::toJson)
+    }
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/internal/ChatDatabase.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/internal/ChatDatabase.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.client.internal.offline.repository.database.con
 import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.LocationConverter
 import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.MapConverter
 import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.MemberConverter
+import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.MemberInfoConverter
 import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.ModerationConverter
 import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.ModerationDetailsConverter
 import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.OptionConverter
@@ -103,6 +104,7 @@ import io.getstream.chat.android.client.internal.offline.repository.domain.user.
     SyncStatusConverter::class,
     DateConverter::class,
     MemberConverter::class,
+    MemberInfoConverter::class,
     ModerationDetailsConverter::class,
     ModerationConverter::class,
     ReactionGroupConverter::class,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/internal/ChatDatabase.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/internal/ChatDatabase.kt
@@ -90,7 +90,7 @@ import io.getstream.chat.android.client.internal.offline.repository.domain.user.
         ThreadOrderEntity::class,
         DraftMessageEntity::class,
     ],
-    version = 203,
+    version = 204,
     exportSchema = false,
 )
 @TypeConverters(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -18,7 +18,8 @@ package io.getstream.chat.android.client.internal.offline.repository.domain.mess
 
 import androidx.collection.LruCache
 import io.getstream.chat.android.client.api.models.Pagination
-import io.getstream.chat.android.client.extensions.internal.withMemberInfo
+import io.getstream.chat.android.client.extensions.internal.hasOutdatedMemberInfo
+import io.getstream.chat.android.client.extensions.internal.withRefreshedMemberInfo
 import io.getstream.chat.android.client.internal.offline.extensions.launchWithMutex
 import io.getstream.chat.android.client.persistance.repository.MessageRepository
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
@@ -91,7 +92,7 @@ internal class DatabaseMessageRepository(
         // The caches are read before the database, so they follow the edit straight away.
         patchCachedMember(messageCache, cid, userId, member)
         patchCachedMember(replyMessageCache, cid, userId, member)
-        // Deferred under the same mutex as the inserts, so this cannot run ahead of a message still being written.
+        // Held under the same mutex as the inserts so it cannot interleave with another write.
         scope.launchWithMutex(dbMutex) {
             messageDao.updateMemberByCidAndUserId(cid, userId, entity)
             replyMessageDao.updateMemberByCidAndUserId(cid, userId, entity)
@@ -105,8 +106,8 @@ internal class DatabaseMessageRepository(
         member: MemberInfo?,
     ) {
         cache.snapshot().values
-            .filter { message -> message.cid == cid && message.user.id == userId }
-            .forEach { message -> cache.put(message.id, message.withMemberInfo(member)) }
+            .filter { message -> message.cid == cid && message.hasOutdatedMemberInfo(userId, member) }
+            .forEach { message -> cache.put(message.id, message.withRefreshedMemberInfo(userId, member)) }
     }
 
     private suspend fun selectRepliedMessage(messageId: String): Message? =

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -88,11 +88,14 @@ internal class DatabaseMessageRepository(
 
     override suspend fun updateChannelUserMessagesMember(cid: String, userId: String, member: MemberInfo?) {
         val entity = member?.toEntity()
-        messageDao.updateMemberByCidAndUserId(cid, userId, entity)
-        replyMessageDao.updateMemberByCidAndUserId(cid, userId, entity)
-        // The caches are read before the database, so they have to follow the same edit.
+        // The caches are read before the database, so they follow the edit straight away.
         patchCachedMember(messageCache, cid, userId, member)
         patchCachedMember(replyMessageCache, cid, userId, member)
+        // Deferred under the same mutex as the inserts, so this cannot run ahead of a message still being written.
+        scope.launchWithMutex(dbMutex) {
+            messageDao.updateMemberByCidAndUserId(cid, userId, entity)
+            replyMessageDao.updateMemberByCidAndUserId(cid, userId, entity)
+        }
     }
 
     private fun patchCachedMember(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client.internal.offline.repository.domain.mess
 
 import androidx.collection.LruCache
 import io.getstream.chat.android.client.api.models.Pagination
+import io.getstream.chat.android.client.extensions.internal.withMemberInfo
 import io.getstream.chat.android.client.internal.offline.extensions.launchWithMutex
 import io.getstream.chat.android.client.persistance.repository.MessageRepository
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
@@ -25,6 +26,7 @@ import io.getstream.chat.android.client.utils.message.LocalOnlyMessageTypes
 import io.getstream.chat.android.client.utils.message.LocalOnlySyncStatuses
 import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.SyncStatus
@@ -83,6 +85,26 @@ internal class DatabaseMessageRepository(
     override suspend fun selectAllChannelUserMessages(cid: String, userId: String): List<Message> =
         messageDao.selectByCidAndUserId(cid, userId)
             .map { it.toMessage() }
+
+    override suspend fun updateChannelUserMessagesMember(cid: String, userId: String, member: MemberInfo?) {
+        val entity = member?.toEntity()
+        messageDao.updateMemberByCidAndUserId(cid, userId, entity)
+        replyMessageDao.updateMemberByCidAndUserId(cid, userId, entity)
+        // The caches are read before the database, so they have to follow the same edit.
+        patchCachedMember(messageCache, cid, userId, member)
+        patchCachedMember(replyMessageCache, cid, userId, member)
+    }
+
+    private fun patchCachedMember(
+        cache: LruCache<String, Message>,
+        cid: String,
+        userId: String,
+        member: MemberInfo?,
+    ) {
+        cache.snapshot().values
+            .filter { message -> message.cid == cid && message.user.id == userId }
+            .forEach { message -> cache.put(message.id, message.withMemberInfo(member)) }
+    }
 
     private suspend fun selectRepliedMessage(messageId: String): Message? =
         replyMessageCache[messageId] ?: replyMessageDao.selectById(messageId)?.toModel(getUser, ::getPoll)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MemberInfoEntity.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MemberInfoEntity.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.offline.repository.domain.message.internal
+
+import com.squareup.moshi.JsonClass
+
+/**
+ * DB entity holding limited data about the channel membership of the user who sent a message.
+ *
+ * @property channelRole The channel-level role of the member.
+ * @property notificationsMuted If notifications are muted for the member in the channel.
+ * @property extraData The custom data of the member.
+ */
+@JsonClass(generateAdapter = true)
+internal data class MemberInfoEntity(
+    val channelRole: String? = null,
+    val notificationsMuted: Boolean = false,
+    val extraData: Map<String, Any> = emptyMap(),
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageDao.kt
@@ -239,6 +239,9 @@ internal interface MessageDao {
     @Query("SELECT * FROM $MESSAGE_ENTITY_TABLE_NAME WHERE cid = :cid AND userId = :userId")
     suspend fun selectByCidAndUserId(cid: String, userId: String): List<MessageEntity>
 
+    @Query("UPDATE $MESSAGE_ENTITY_TABLE_NAME SET member = :member WHERE cid = :cid AND userId = :userId")
+    suspend fun updateMemberByCidAndUserId(cid: String, userId: String, member: MemberInfoEntity?)
+
     @Query(
         "SELECT id FROM $MESSAGE_ENTITY_TABLE_NAME " +
             "WHERE syncStatus = :syncStatus " +

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageEntity.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageEntity.kt
@@ -146,8 +146,8 @@ internal data class MessageInnerEntity(
     val reminder: ReminderInfoEntity? = null,
     /** The shared location of the message, if any */
     val sharedLocation: LocationEntity? = null,
-    /** The role of the member(who sent the message) in the channel */
-    val channelRole: String? = null,
+    /** Limited data about the channel membership of the user who sent the message */
+    val member: MemberInfoEntity? = null,
     /** Whether the message was deleted for the current user */
     val deletedForMe: Boolean = false,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMapper.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMapper.kt
@@ -25,12 +25,14 @@ import io.getstream.chat.android.client.internal.offline.repository.domain.messa
 import io.getstream.chat.android.client.internal.offline.repository.domain.reaction.internal.toEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.reaction.internal.toModel
 import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageReminderInfo
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.User
 
+@Suppress("DEPRECATION")
 internal suspend fun MessageEntity.toModel(
     getUser: suspend (userId: String) -> User,
     getReply: suspend (messageId: String) -> Message?,
@@ -87,11 +89,13 @@ internal suspend fun MessageEntity.toModel(
         poll = pollId?.let { getPoll(it) },
         reminder = reminder?.toModel(),
         sharedLocation = sharedLocation?.toModel(),
-        channelRole = channelRole,
+        channelRole = member?.channelRole,
+        member = member?.toModel(),
         deletedForMe = deletedForMe,
     )
 }
 
+@Suppress("DEPRECATION")
 internal fun Message.toEntity(): MessageEntity = MessageEntity(
     messageInnerEntity = MessageInnerEntity(
         id = id,
@@ -140,7 +144,7 @@ internal fun Message.toEntity(): MessageEntity = MessageEntity(
         reminder = reminder?.toEntity(),
         restrictedVisibility = restrictedVisibility,
         sharedLocation = sharedLocation?.toEntity(),
-        channelRole = channelRole,
+        member = memberInfoToEntity(),
         deletedForMe = deletedForMe,
     ),
     attachments = attachments.mapIndexed { index, attachment -> attachment.toEntity(id, index) },
@@ -148,6 +152,7 @@ internal fun Message.toEntity(): MessageEntity = MessageEntity(
     ownReactions = ownReactions.map(Reaction::toEntity),
 )
 
+@Suppress("DEPRECATION")
 internal suspend fun ReplyMessageEntity.toModel(
     getUser: suspend (userId: String) -> User,
     getPoll: suspend (pollId: String) -> Poll?,
@@ -197,11 +202,13 @@ internal suspend fun ReplyMessageEntity.toModel(
             restrictedVisibility = restrictedVisibility,
             channelInfo = channelInfo?.toModel(),
             reminder = reminder?.toModel(),
-            channelRole = channelRole,
+            channelRole = member?.channelRole,
+            member = member?.toModel(),
         )
     }
 }
 
+@Suppress("DEPRECATION")
 internal fun Message.toReplyEntity(): ReplyMessageEntity =
     ReplyMessageEntity(
         replyMessageInnerEntity = ReplyMessageInnerEntity(
@@ -239,7 +246,7 @@ internal fun Message.toReplyEntity(): ReplyMessageEntity =
             moderationDetails = moderationDetails?.toEntity(),
             pollId = poll?.id,
             reminder = reminder?.toEntity(),
-            channelRole = channelRole,
+            member = memberInfoToEntity(),
         ),
         attachments = attachments.mapIndexed { index, attachment -> attachment.toReplyEntity(id, index) },
     )
@@ -285,3 +292,23 @@ internal fun ReminderInfoEntity.toModel(): MessageReminderInfo = MessageReminder
     createdAt = createdAt,
     updatedAt = updatedAt,
 )
+
+internal fun MemberInfo.toEntity(): MemberInfoEntity = MemberInfoEntity(
+    channelRole = channelRole,
+    notificationsMuted = notificationsMuted,
+    extraData = extraData,
+)
+
+internal fun MemberInfoEntity.toModel(): MemberInfo = MemberInfo(
+    channelRole = channelRole,
+    notificationsMuted = notificationsMuted,
+    extraData = extraData,
+)
+
+/**
+ * Maps [Message.member] to its entity, falling back to the deprecated [Message.channelRole] when only that one is set.
+ * Without the fallback a message built with the deprecated field would silently lose its role on the way to the store.
+ */
+@Suppress("DEPRECATION")
+private fun Message.memberInfoToEntity(): MemberInfoEntity? =
+    member?.toEntity() ?: channelRole?.let { MemberInfoEntity(channelRole = it) }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/ReplyMessageDao.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/ReplyMessageDao.kt
@@ -46,6 +46,9 @@ internal interface ReplyMessageDao {
     @Delete
     suspend fun delete(replyMessageInnerEntity: ReplyMessageInnerEntity)
 
+    @Query("UPDATE $REPLY_MESSAGE_ENTITY_TABLE_NAME SET member = :member WHERE cid = :cid AND userId = :userId")
+    suspend fun updateMemberByCidAndUserId(cid: String, userId: String, member: MemberInfoEntity?)
+
     @Query("DELETE FROM $REPLY_MESSAGE_ENTITY_TABLE_NAME")
     suspend fun deleteAll()
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/ReplyMessageEntity.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/ReplyMessageEntity.kt
@@ -115,8 +115,8 @@ internal data class ReplyMessageInnerEntity(
     val restrictedVisibility: List<String> = emptyList(),
     /** Info about the reminder for the message **/
     val reminder: ReminderInfoEntity? = null,
-    /** The role of the member(who sent the message) in the channel */
-    val channelRole: String? = null,
+    /** Limited data about the channel membership of the user who sent the message */
+    val member: MemberInfoEntity? = null,
 )
 
 internal const val REPLY_MESSAGE_ENTITY_TABLE_NAME = "stream_chat_reply_message"

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequential.kt
@@ -96,6 +96,7 @@ import io.getstream.chat.android.client.extensions.internal.mergeReactions
 import io.getstream.chat.android.client.extensions.internal.processPoll
 import io.getstream.chat.android.client.extensions.internal.removeMember
 import io.getstream.chat.android.client.extensions.internal.removeMembership
+import io.getstream.chat.android.client.extensions.internal.toMemberInfo
 import io.getstream.chat.android.client.extensions.internal.toMessageReminderInfo
 import io.getstream.chat.android.client.extensions.internal.updateMember
 import io.getstream.chat.android.client.extensions.internal.updateMemberBanned
@@ -935,6 +936,15 @@ internal class EventHandlerSequential(
                 }
                 is UserMessagesDeletedEvent -> {
                     deleteMessagesFromUser(event.cid, event.user.id, event.hardDelete, event.createdAt)
+                }
+                is MemberUpdatedEvent -> {
+                    // The backend does not emit message.updated for membership changes, so the snapshot denormalized
+                    // onto the stored messages would otherwise stay stale until they are fetched again.
+                    repos.updateChannelUserMessagesMember(
+                        cid = event.cid,
+                        userId = event.member.getUserId(),
+                        member = event.member.toMemberInfo(),
+                    )
                 }
                 else -> Unit // Ignore other events
             }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequential.kt
@@ -583,6 +583,15 @@ internal class EventHandlerSequential(
                 }
             }
 
+        // A membership change carries no message id, so it cannot be grouped like the events above: every active
+        // thread is asked to refresh the author's replies, which the channel state refresh does not reach.
+        sortedEvents.filterIsInstance<MemberUpdatedEvent>().forEach { event ->
+            val memberInfo = event.member.toMemberInfo()
+            logicRegistry.getActiveThreadsLogic().forEach { thread ->
+                thread.updateMessagesMemberInfo(event.cid, event.member.getUserId(), memberInfo)
+            }
+        }
+
         logger.v { "[updateThreadState] completed batchId: ${batchEvent.id}" }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImpl.kt
@@ -263,6 +263,8 @@ internal class ChannelEventHandlerImpl(
 
             is MemberUpdatedEvent -> {
                 state.upsertMember(event.member)
+                // The backend does not emit message.updated for membership changes, so refresh the snapshot ourselves
+                state.updateMessagesMemberInfo(event.member)
                 // Update the channel.membership if the current user's member info is updated
                 if (event.member.getUserId() == getCurrentUserId()) {
                     state.setMembership(event.member)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelEventHandlerLegacyImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/legacy/ChannelEventHandlerLegacyImpl.kt
@@ -196,6 +196,8 @@ internal class ChannelEventHandlerLegacyImpl(
             is MemberUpdatedEvent -> {
                 stateLogic.upsertMember(event.member)
                 stateLogic.updateMembership(event.member)
+                // The backend does not emit message.updated for membership changes, so refresh the snapshot ourselves
+                mutableState.updateMessagesMemberInfo(event.member)
             }
 
             is NotificationAddedToChannelEvent -> {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadLogic.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.client.extensions.internal.processPoll
 import io.getstream.chat.android.client.extensions.internal.toMessageReminderInfo
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.thread.internal.ThreadMutableState
 import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Poll
 
@@ -73,6 +74,9 @@ internal class ThreadLogic(
     internal fun upsertMessage(message: Message) = upsertMessages(listOf(message))
 
     internal fun upsertMessages(messages: List<Message>) = threadStateLogic.upsertMessages(messages)
+
+    internal fun updateMessagesMemberInfo(cid: String, userId: String, memberInfo: MemberInfo) =
+        threadStateLogic.updateMessagesMemberInfo(cid, userId, memberInfo)
 
     internal fun removeLocalMessage(message: Message) {
         threadStateLogic.deleteMessage(message)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogic.kt
@@ -17,7 +17,9 @@
 package io.getstream.chat.android.client.internal.state.plugin.logic.channel.thread.internal
 
 import io.getstream.chat.android.client.extensions.internal.NEVER
+import io.getstream.chat.android.client.extensions.internal.withMemberInfo
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.thread.internal.ThreadMutableState
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
 
@@ -50,6 +52,22 @@ internal class ThreadStateLogic(private val mutableState: ThreadMutableState) {
      * @param message The message to be added or updated.
      */
     fun upsertMessage(message: Message) = upsertMessages(listOf(message))
+
+    /**
+     * Refreshes the [Message.member] snapshot carried by the thread replies the given member authored.
+     *
+     * Thread replies live in this state rather than the channel one, so the channel refresh does not reach them.
+     *
+     * @param cid The channel the membership belongs to.
+     * @param userId The author whose replies should be refreshed.
+     * @param memberInfo The member snapshot to store.
+     */
+    fun updateMessagesMemberInfo(cid: String, userId: String, memberInfo: MemberInfo) {
+        val outdated = mutableState.rawMessage.value.values
+            .filter { message -> message.cid == cid && message.user.id == userId && message.member != memberInfo }
+        if (outdated.isEmpty()) return
+        mutableState.upsertMessages(outdated.map { message -> message.withMemberInfo(memberInfo) })
+    }
 
     /**
      * Upsert messages in the channel.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogic.kt
@@ -17,7 +17,8 @@
 package io.getstream.chat.android.client.internal.state.plugin.logic.channel.thread.internal
 
 import io.getstream.chat.android.client.extensions.internal.NEVER
-import io.getstream.chat.android.client.extensions.internal.withMemberInfo
+import io.getstream.chat.android.client.extensions.internal.hasOutdatedMemberInfo
+import io.getstream.chat.android.client.extensions.internal.withRefreshedMemberInfo
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.thread.internal.ThreadMutableState
 import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
@@ -64,9 +65,9 @@ internal class ThreadStateLogic(private val mutableState: ThreadMutableState) {
      */
     fun updateMessagesMemberInfo(cid: String, userId: String, memberInfo: MemberInfo) {
         val outdated = mutableState.rawMessage.value.values
-            .filter { message -> message.cid == cid && message.user.id == userId && message.member != memberInfo }
+            .filter { message -> message.cid == cid && message.hasOutdatedMemberInfo(userId, memberInfo) }
         if (outdated.isEmpty()) return
-        mutableState.upsertMessages(outdated.map { message -> message.withMemberInfo(memberInfo) })
+        mutableState.upsertMessages(outdated.map { message -> message.withRefreshedMemberInfo(userId, memberInfo) })
     }
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/logic/internal/LogicRegistry.kt
@@ -299,6 +299,8 @@ internal class LogicRegistry internal constructor(
      */
     fun getActiveChannelsLogic(): List<ChannelLogic> = channels.values.toList()
 
+    fun getActiveThreadsLogic(): List<ThreadLogic> = threads.values.toList()
+
     fun isActiveThread(messageId: String): Boolean =
         threads.containsKey(messageId)
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImpl.kt
@@ -26,8 +26,10 @@ import io.getstream.chat.android.client.events.UserStartWatchingEvent
 import io.getstream.chat.android.client.events.UserStopWatchingEvent
 import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
 import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
+import io.getstream.chat.android.client.extensions.internal.toMemberInfo
 import io.getstream.chat.android.client.extensions.internal.updateUsers
 import io.getstream.chat.android.client.extensions.internal.wasCreatedAfter
+import io.getstream.chat.android.client.extensions.internal.withMemberInfo
 import io.getstream.chat.android.client.internal.state.message.attachments.internal.AttachmentUrlValidator
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.internal.ChannelStateImpl.Companion.CACHED_LATEST_MESSAGES_LIMIT
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.internal.ChannelStateImpl.Companion.TRIM_BUFFER
@@ -889,6 +891,24 @@ internal class ChannelStateImpl(
             merged += members.associateBy(Member::getUserId)
             merged.values.toList()
         }
+    }
+
+    /**
+     * Refreshes the [Message.member] snapshot carried by the messages the [member] authored.
+     *
+     * The backend does not emit `message.updated` when a membership changes, so without this the snapshot stored on
+     * already delivered messages would stay stale until they are fetched again.
+     *
+     * @param member The member whose messages should be refreshed.
+     */
+    fun updateMessagesMemberInfo(member: Member) {
+        val userId = member.getUserId()
+        val memberInfo = member.toMemberInfo()
+        val isOutdated = { message: Message -> message.user.id == userId && message.member != memberInfo }
+        val refresh = { message: Message -> message.withMemberInfo(memberInfo) }
+        _messages.update { it.updateIf(isOutdated, refresh) }
+        _cachedLatestMessages.update { it.updateIf(isOutdated, refresh) }
+        _pinnedMessages.update { it.updateIf(isOutdated, refresh) }
     }
 
     // endregion

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImpl.kt
@@ -26,10 +26,11 @@ import io.getstream.chat.android.client.events.UserStartWatchingEvent
 import io.getstream.chat.android.client.events.UserStopWatchingEvent
 import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
 import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
+import io.getstream.chat.android.client.extensions.internal.hasOutdatedMemberInfo
 import io.getstream.chat.android.client.extensions.internal.toMemberInfo
 import io.getstream.chat.android.client.extensions.internal.updateUsers
 import io.getstream.chat.android.client.extensions.internal.wasCreatedAfter
-import io.getstream.chat.android.client.extensions.internal.withMemberInfo
+import io.getstream.chat.android.client.extensions.internal.withRefreshedMemberInfo
 import io.getstream.chat.android.client.internal.state.message.attachments.internal.AttachmentUrlValidator
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.internal.ChannelStateImpl.Companion.CACHED_LATEST_MESSAGES_LIMIT
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.internal.ChannelStateImpl.Companion.TRIM_BUFFER
@@ -904,8 +905,8 @@ internal class ChannelStateImpl(
     fun updateMessagesMemberInfo(member: Member) {
         val userId = member.getUserId()
         val memberInfo = member.toMemberInfo()
-        val isOutdated = { message: Message -> message.user.id == userId && message.member != memberInfo }
-        val refresh = { message: Message -> message.withMemberInfo(memberInfo) }
+        val isOutdated = { message: Message -> message.hasOutdatedMemberInfo(userId, memberInfo) }
+        val refresh = { message: Message -> message.withRefreshedMemberInfo(userId, memberInfo) }
         _messages.update { it.updateIf(isOutdated, refresh) }
         _cachedLatestMessages.update { it.updateIf(isOutdated, refresh) }
         _pinnedMessages.update { it.updateIf(isOutdated, refresh) }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
@@ -581,6 +581,7 @@ internal class ChannelStateLegacyImpl(
         }
         _messages?.apply { value = refresh(value) }
         _pinnedMessages?.apply { value = refresh(value) }
+        cachedLatestMessages.apply { value = refresh(value) }
     }
 
     fun upsertReads(reads: List<ChannelUserRead>) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
@@ -19,8 +19,10 @@ package io.getstream.chat.android.client.internal.state.plugin.state.channel.int
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
 import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
+import io.getstream.chat.android.client.extensions.internal.toMemberInfo
 import io.getstream.chat.android.client.extensions.internal.updateUsers
 import io.getstream.chat.android.client.extensions.internal.wasCreatedAfter
+import io.getstream.chat.android.client.extensions.internal.withMemberInfo
 import io.getstream.chat.android.client.extensions.syncUnreadCountWithReads
 import io.getstream.chat.android.client.internal.state.utils.internal.combineStates
 import io.getstream.chat.android.client.internal.state.utils.internal.mapState
@@ -555,6 +557,30 @@ internal class ChannelStateLegacyImpl(
             value = value.values.updateUsers(mapOf(user.id to user)).associateBy { it.id }
         }
         _pinnedMessages?.apply { value = value.updateUsers(mapOf(user.id to user)) }
+    }
+
+    /**
+     * Refreshes the [Message.member] snapshot carried by the messages the [member] authored.
+     *
+     * The backend does not emit `message.updated` when a membership changes, so without this the snapshot stored on
+     * already delivered messages would stay stale until they are fetched again.
+     *
+     * @param member The member whose messages should be refreshed.
+     */
+    fun updateMessagesMemberInfo(member: Member) {
+        val userId = member.getUserId()
+        val memberInfo = member.toMemberInfo()
+        val refresh: (Map<String, Message>) -> Map<String, Message> = { messages ->
+            messages.mapValues { (_, message) ->
+                if (message.user.id == userId && message.member != memberInfo) {
+                    message.withMemberInfo(memberInfo)
+                } else {
+                    message
+                }
+            }
+        }
+        _messages?.apply { value = refresh(value) }
+        _pinnedMessages?.apply { value = refresh(value) }
     }
 
     fun upsertReads(reads: List<ChannelUserRead>) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImpl.kt
@@ -19,10 +19,11 @@ package io.getstream.chat.android.client.internal.state.plugin.state.channel.int
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
 import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
+import io.getstream.chat.android.client.extensions.internal.hasOutdatedMemberInfo
 import io.getstream.chat.android.client.extensions.internal.toMemberInfo
 import io.getstream.chat.android.client.extensions.internal.updateUsers
 import io.getstream.chat.android.client.extensions.internal.wasCreatedAfter
-import io.getstream.chat.android.client.extensions.internal.withMemberInfo
+import io.getstream.chat.android.client.extensions.internal.withRefreshedMemberInfo
 import io.getstream.chat.android.client.extensions.syncUnreadCountWithReads
 import io.getstream.chat.android.client.internal.state.utils.internal.combineStates
 import io.getstream.chat.android.client.internal.state.utils.internal.mapState
@@ -572,8 +573,8 @@ internal class ChannelStateLegacyImpl(
         val memberInfo = member.toMemberInfo()
         val refresh: (Map<String, Message>) -> Map<String, Message> = { messages ->
             messages.mapValues { (_, message) ->
-                if (message.user.id == userId && message.member != memberInfo) {
-                    message.withMemberInfo(memberInfo)
+                if (message.hasOutdatedMemberInfo(userId, memberInfo)) {
+                    message.withRefreshedMemberInfo(userId, memberInfo)
                 } else {
                     message
                 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.client.parser2.adapters.CreatePollOptionRequest
 import io.getstream.chat.android.client.parser2.adapters.CreatePollRequestAdapter
 import io.getstream.chat.android.client.parser2.adapters.DownstreamChannelDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.DownstreamMemberDtoAdapter
+import io.getstream.chat.android.client.parser2.adapters.DownstreamMemberInfoDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.DownstreamMessageDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.DownstreamModerationDetailsDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.DownstreamPollDtoAdapter
@@ -89,6 +90,7 @@ internal class MoshiChatParser(
             .add(UserResponseAdapter)
             .add(UserRequestAdapter)
             .add(DownstreamMemberDtoAdapter)
+            .add(DownstreamMemberInfoDtoAdapter)
             .add(UpstreamMemberDtoAdapter)
             .add(UpstreamMemberDataDtoAdapter)
             .add(FlagRequestAdapterFactory)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/MemberDtoAdapters.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/MemberDtoAdapters.kt
@@ -22,6 +22,7 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberDto
+import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberInfoDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamMemberDto
 
 /**
@@ -40,6 +41,26 @@ internal object DownstreamMemberDtoAdapter : CustomObjectDtoAdapter<DownstreamMe
     @ToJson
     @Suppress("UNUSED_PARAMETER")
     fun toJson(jsonWriter: JsonWriter, value: DownstreamMemberDto): Unit = error("Can't convert this to Json")
+}
+
+/**
+ * JSON adapter for [DownstreamMemberInfoDto].
+ * Handles the proper deserialization of the [extraData] field, which holds the member custom data that API v1 inlines
+ * next to the declared fields.
+ */
+internal object DownstreamMemberInfoDtoAdapter :
+    CustomObjectDtoAdapter<DownstreamMemberInfoDto>(DownstreamMemberInfoDto::class) {
+
+    @FromJson
+    fun fromJson(
+        jsonReader: JsonReader,
+        mapAdapter: JsonAdapter<MutableMap<String, Any>>,
+        memberInfoAdapter: JsonAdapter<DownstreamMemberInfoDto>,
+    ): DownstreamMemberInfoDto? = parseWithExtraData(jsonReader, mapAdapter, memberInfoAdapter)
+
+    @ToJson
+    @Suppress("UNUSED_PARAMETER")
+    fun toJson(jsonWriter: JsonWriter, value: DownstreamMemberInfoDto): Unit = error("Can't convert this to Json")
 }
 
 /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/JsonParsingUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/JsonParsingUtils.kt
@@ -174,4 +174,26 @@ internal object JsonParsingUtils {
         reader.endObject()
         return map
     }
+
+    /**
+     * Parses a JSON object into a Map<String, Any>, keeping nested values as their natural JSON types.
+     *
+     * @param reader The JsonReader positioned at the object field.
+     * @return A map of string keys to arbitrary values, or null if the JSON value is null, missing, or not an object.
+     */
+    fun parseAnyMap(reader: JsonReader): Map<String, Any>? {
+        if (reader.peek() == JsonReader.Token.NULL) return reader.nextNull()
+        if (reader.peek() != JsonReader.Token.BEGIN_OBJECT) {
+            reader.skipValue()
+            return null
+        }
+        reader.beginObject()
+        val map = mutableMapOf<String, Any>()
+        while (reader.hasNext()) {
+            val key = reader.nextName()
+            reader.readJsonValue()?.let { map[key] = it }
+        }
+        reader.endObject()
+        return map
+    }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/MessageAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/MessageAdapter.kt
@@ -22,6 +22,7 @@ import com.squareup.moshi.JsonWriter
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.ChannelInfo
 import io.getstream.chat.android.models.Location
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageModerationDetails
 import io.getstream.chat.android.models.MessageReminderInfo
@@ -55,7 +56,7 @@ internal class MessageAdapter(
         return fromJson(reader, fallbackChannelInfo = null)
     }
 
-    @Suppress("LongMethod", "ThrowsCount")
+    @Suppress("LongMethod", "ThrowsCount", "DEPRECATION")
     fun fromJson(reader: JsonReader, fallbackChannelInfo: ChannelInfo?): Message? {
         if (reader.peek() == JsonReader.Token.NULL) return reader.nextNull()
 
@@ -103,7 +104,7 @@ internal class MessageAdapter(
         var poll: Poll? = null
         var reminder: MessageReminderInfo? = null
         var sharedLocation: Location? = null
-        var channelRole: String? = null
+        var member: MemberInfo? = null
         var deletedForMe: Boolean? = null
         var extraData: MutableMap<String, Any>? = null
 
@@ -173,7 +174,7 @@ internal class MessageAdapter(
                 "poll" -> poll = pollAdapter.fromJson(reader)
                 "reminder" -> reminder = reminderAdapter.fromJson(reader)
                 "shared_location" -> sharedLocation = locationAdapter.fromJson(reader)
-                "member" -> channelRole = parseMemberChannelRole(reader)
+                "member" -> member = parseMemberInfo(reader)
                 "deleted_for_me" -> deletedForMe = JsonParsingUtils.readNullableBoolean(reader)
                 else -> extraData = JsonParsingUtils.accumulateExtraData(key, reader, extraData)
             }
@@ -270,13 +271,14 @@ internal class MessageAdapter(
             restrictedVisibility = emptyList(),
             reminder = reminder,
             sharedLocation = sharedLocation,
-            channelRole = channelRole,
+            channelRole = member?.channelRole,
+            member = member,
             deletedForMe = deletedForMe ?: false,
             extraData = extraData ?: emptyMap(),
         ).let(messageTransformer::transform)
     }
 
-    private fun parseMemberChannelRole(reader: JsonReader): String? {
+    private fun parseMemberInfo(reader: JsonReader): MemberInfo? {
         if (reader.peek() != JsonReader.Token.BEGIN_OBJECT) {
             reader.skipValue()
             return null
@@ -284,16 +286,30 @@ internal class MessageAdapter(
 
         reader.beginObject()
         var channelRole: String? = null
+        var notificationsMuted: Boolean? = null
+        var custom: MutableMap<String, Any>? = null
 
         while (reader.hasNext()) {
-            when (reader.nextName()) {
+            val key = reader.nextName()
+            when (key) {
                 "channel_role" -> channelRole = JsonParsingUtils.readNullableString(reader)
-                else -> reader.skipValue()
+                "notifications_muted" -> notificationsMuted = JsonParsingUtils.readNullableBoolean(reader)
+                // API v2 nests the member custom data under "custom", API v1 inlines it next to the declared
+                // fields, so unknown keys are member custom data too.
+                "custom" -> {
+                    val nested = JsonParsingUtils.parseAnyMap(reader).orEmpty()
+                    custom = (custom ?: mutableMapOf()).apply { putAll(nested) }
+                }
+                else -> custom = JsonParsingUtils.accumulateExtraData(key, reader, custom)
             }
         }
         reader.endObject()
 
-        return channelRole
+        return MemberInfo(
+            channelRole = channelRole,
+            notificationsMuted = notificationsMuted ?: false,
+            extraData = custom.orEmpty(),
+        )
     }
 
     override fun toJson(p0: JsonWriter, p1: Message?) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.client.persistance.repository
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
 import java.util.Date
@@ -66,6 +67,17 @@ public interface MessageRepository {
      * @param userId The user ID to filter messages.
      */
     public suspend fun selectAllChannelUserMessages(cid: String, userId: String): List<Message>
+
+    /**
+     * Replaces the [Message.member] snapshot on every message a given user authored in a given channel.
+     *
+     * Only that field is written, so a message being modified elsewhere at the same time is not overwritten.
+     *
+     * @param cid The channel ID to filter messages.
+     * @param userId The user ID to filter messages.
+     * @param member The member snapshot to store, or null to clear it.
+     */
+    public suspend fun updateChannelUserMessagesMember(cid: String, userId: String, member: MemberInfo?)
 
     /**
      * Selects messages by IDs.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.client.persistance.repository.noop
 import io.getstream.chat.android.client.persistance.repository.MessageRepository
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
 import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
 import java.util.Date
@@ -57,5 +58,11 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun selectMessagesForThread(messageId: String, limit: Int): List<Message> = emptyList()
     override suspend fun selectAllUserMessages(userId: String): List<Message> = emptyList()
     override suspend fun selectAllChannelUserMessages(cid: String, userId: String): List<Message> = emptyList()
+
+    override suspend fun updateChannelUserMessagesMember(
+        cid: String,
+        userId: String,
+        member: MemberInfo?,
+    ) { /* No-Op */ }
     override suspend fun selectLocalOnlyMessagesForChannel(cid: String): List<Message> = emptyList()
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -761,8 +761,17 @@ internal object Mother {
         extraData = extraData,
     )
 
-    fun randomDownstreamMemberInfoDto(channelRole: String? = randomString()): DownstreamMemberInfoDto =
-        DownstreamMemberInfoDto(channel_role = channelRole)
+    fun randomDownstreamMemberInfoDto(
+        channelRole: String? = randomString(),
+        notificationsMuted: Boolean? = randomBoolean(),
+        custom: Map<String, Any>? = null,
+        extraData: Map<String, Any> = mapOf(randomString() to randomString()),
+    ): DownstreamMemberInfoDto = DownstreamMemberInfoDto(
+        channel_role = channelRole,
+        notifications_muted = notificationsMuted,
+        custom = custom,
+        extraData = extraData,
+    )
 
     fun randomDownstreamChannelUserRead(
         user: DownstreamUserDto = randomDownstreamUserDto(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MemberExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MemberExtensionsTests.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.extensions.internal
+
+import io.getstream.chat.android.models.MemberInfo
+import io.getstream.chat.android.randomMember
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+internal class MemberExtensionsTests {
+
+    @Test
+    fun `toMemberInfo should narrow the member down to the slim shape`() {
+        val member = randomMember(channelRole = "channel_moderator")
+            .copy(notificationsMuted = true, extraData = mapOf("flair" to mapOf("tier" to "gold")))
+
+        member.toMemberInfo() shouldBeEqualTo MemberInfo(
+            channelRole = "channel_moderator",
+            notificationsMuted = true,
+            extraData = mapOf("flair" to mapOf("tier" to "gold")),
+        )
+    }
+
+    @Test
+    fun `toMemberInfo should treat an absent notificationsMuted as false`() {
+        val member = randomMember().copy(notificationsMuted = null, extraData = emptyMap())
+
+        member.toMemberInfo().notificationsMuted shouldBeEqualTo false
+    }
+
+    @Test
+    fun `toMemberInfo should drop keys that are not member custom data`() {
+        // user_id is not declared on the member DTO, so it reaches Member.extraData. The projection the backend puts
+        // on message.member never carries it, so it must not leak into MemberInfo either.
+        val member = randomMember().copy(
+            extraData = mapOf("user_id" to "leandro", "flair" to mapOf("tier" to "gold")),
+        )
+
+        member.toMemberInfo().extraData shouldBeEqualTo mapOf("flair" to mapOf("tier" to "gold"))
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MemberExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MemberExtensionsTests.kt
@@ -48,11 +48,16 @@ internal class MemberExtensionsTests {
 
     @Test
     fun `toMemberInfo should drop keys that are not member custom data`() {
-        // user_id and the deprecated member-level role are not declared on the member DTO, so they reach
-        // Member.extraData. The projection the backend puts on message.member carries neither, so they must not
-        // leak into MemberInfo either.
+        // Stored member fields the member DTO does not declare reach Member.extraData. The projection the backend
+        // puts on message.member carries none of them, so they must not leak into MemberInfo either.
         val member = randomMember().copy(
-            extraData = mapOf("user_id" to "leandro", "role" to "member", "flair" to mapOf("tier" to "gold")),
+            extraData = mapOf(
+                "user_id" to "leandro",
+                "role" to "member",
+                "is_moderator" to true,
+                "deleted_messages" to listOf("messageId"),
+                "flair" to mapOf("tier" to "gold"),
+            ),
         )
 
         member.toMemberInfo().extraData shouldBeEqualTo mapOf("flair" to mapOf("tier" to "gold"))

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MemberExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MemberExtensionsTests.kt
@@ -16,9 +16,13 @@
 
 package io.getstream.chat.android.client.extensions.internal
 
+import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.events.MemberUpdatedEvent
+import io.getstream.chat.android.client.parser2.ParserFactory
 import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.randomMember
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 
 internal class MemberExtensionsTests {
@@ -44,12 +48,50 @@ internal class MemberExtensionsTests {
 
     @Test
     fun `toMemberInfo should drop keys that are not member custom data`() {
-        // user_id is not declared on the member DTO, so it reaches Member.extraData. The projection the backend puts
-        // on message.member never carries it, so it must not leak into MemberInfo either.
+        // user_id and the deprecated member-level role are not declared on the member DTO, so they reach
+        // Member.extraData. The projection the backend puts on message.member carries neither, so they must not
+        // leak into MemberInfo either.
         val member = randomMember().copy(
-            extraData = mapOf("user_id" to "leandro", "flair" to mapOf("tier" to "gold")),
+            extraData = mapOf("user_id" to "leandro", "role" to "member", "flair" to mapOf("tier" to "gold")),
         )
 
         member.toMemberInfo().extraData shouldBeEqualTo mapOf("flair" to mapOf("tier" to "gold"))
+    }
+
+    @Test
+    fun `toMemberInfo should keep only custom data when the member comes off the wire`() {
+        val event = ParserFactory.createMoshiChatParser().fromJson(MEMBER_UPDATED_JSON, ChatEvent::class.java)
+
+        event.shouldBeInstanceOf<MemberUpdatedEvent>()
+        (event as MemberUpdatedEvent).member.toMemberInfo() shouldBeEqualTo MemberInfo(
+            channelRole = "channel_member",
+            notificationsMuted = false,
+            extraData = mapOf("flair" to mapOf("tier" to "gold")),
+        )
+    }
+
+    private companion object {
+        val MEMBER_UPDATED_JSON = """
+            {
+                "type": "member.updated",
+                "created_at": "2020-06-29T06:14:28.000Z",
+                "channel_type": "channelType",
+                "channel_id": "channelId",
+                "cid": "channelType:channelId",
+                "user": { "id": "leandro", "role": "user", "banned": false, "online": true },
+                "member": {
+                    "user_id": "leandro",
+                    "user": { "id": "leandro", "role": "user", "banned": false, "online": true },
+                    "role": "member",
+                    "channel_role": "channel_member",
+                    "notifications_muted": false,
+                    "banned": false,
+                    "shadow_banned": false,
+                    "created_at": "2020-06-29T06:14:28.000Z",
+                    "updated_at": "2020-06-29T06:14:28.000Z",
+                    "flair": { "tier": "gold" }
+                }
+            }
+        """.trimIndent()
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MessageExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MessageExtensionsTests.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.extensions.internal
 
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.randomAttachment
 import io.getstream.chat.android.randomChannel
 import io.getstream.chat.android.randomDate
@@ -625,5 +626,44 @@ internal class MessageExtensionsTests {
 
         // then
         result shouldBeEqualTo false
+    }
+
+    @Test
+    fun `withMemberInfo should set the member snapshot and keep the deprecated channelRole in sync`() {
+        val message = randomMessage(member = null)
+        val memberInfo = MemberInfo(channelRole = "channel_moderator", extraData = mapOf("flair" to "gold"))
+
+        val result = message.withMemberInfo(memberInfo)
+
+        result.member shouldBeEqualTo memberInfo
+        @Suppress("DEPRECATION")
+        result.channelRole shouldBeEqualTo "channel_moderator"
+    }
+
+    @Test
+    fun `withMemberInfo should keep the known role when the incoming member carries none`() {
+        // The backend always assigns a role, so an absent one means "not sent" and must not wipe what we know.
+        val message = randomMessage(member = MemberInfo(channelRole = "channel_moderator"))
+        val memberInfo = MemberInfo(channelRole = null, extraData = mapOf("flair" to "gold"))
+
+        val result = message.withMemberInfo(memberInfo)
+
+        result.member shouldBeEqualTo MemberInfo(
+            channelRole = "channel_moderator",
+            extraData = mapOf("flair" to "gold"),
+        )
+        @Suppress("DEPRECATION")
+        result.channelRole shouldBeEqualTo "channel_moderator"
+    }
+
+    @Test
+    fun `withMemberInfo should clear both fields when the member is absent`() {
+        val message = randomMessage(member = MemberInfo(channelRole = "channel_moderator"))
+
+        val result = message.withMemberInfo(null)
+
+        result.member shouldBeEqualTo null
+        @Suppress("DEPRECATION")
+        result.channelRole shouldBeEqualTo null
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MessageExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MessageExtensionsTests.kt
@@ -29,6 +29,7 @@ import io.getstream.chat.android.randomReaction
 import io.getstream.chat.android.randomUser
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.junit.jupiter.api.Test
 import java.util.Date
 import java.util.concurrent.TimeUnit
@@ -652,6 +653,42 @@ internal class MessageExtensionsTests {
         result.member shouldBeEqualTo memberInfo
         @Suppress("DEPRECATION")
         result.channelRole shouldBeEqualTo null
+    }
+
+    @Test
+    fun `withRefreshedMemberInfo should refresh the quoted copy of the same author`() {
+        // The quoted message carries its own snapshot, so leaving it behind shows one author with two values.
+        val author = randomUser()
+        val quoted = randomMessage(user = author, member = null)
+        val message = randomMessage(user = author, member = null, replyTo = quoted)
+        val memberInfo = MemberInfo(channelRole = "channel_moderator", extraData = mapOf("flair" to "gold"))
+
+        val result = message.withRefreshedMemberInfo(author.id, memberInfo)
+
+        result.member shouldBeEqualTo memberInfo
+        result.replyTo?.member shouldBeEqualTo memberInfo
+    }
+
+    @Test
+    fun `withRefreshedMemberInfo should leave a quoted copy of another author alone`() {
+        val author = randomUser()
+        val quoted = randomMessage(user = randomUser(), member = null)
+        val message = randomMessage(user = author, member = null, replyTo = quoted)
+
+        val result = message.withRefreshedMemberInfo(author.id, MemberInfo(channelRole = "channel_moderator"))
+
+        result.member?.channelRole shouldBeEqualTo "channel_moderator"
+        result.replyTo?.member.shouldBeNull()
+    }
+
+    @Test
+    fun `hasOutdatedMemberInfo should spot an outdated quoted copy`() {
+        val author = randomUser()
+        val memberInfo = MemberInfo(channelRole = "channel_moderator")
+        val quoted = randomMessage(user = author, member = null)
+        val message = randomMessage(user = randomUser(), member = null, replyTo = quoted)
+
+        message.hasOutdatedMemberInfo(author.id, memberInfo) shouldBeEqualTo true
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MessageExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/MessageExtensionsTests.kt
@@ -641,19 +641,17 @@ internal class MessageExtensionsTests {
     }
 
     @Test
-    fun `withMemberInfo should keep the known role when the incoming member carries none`() {
-        // The backend always assigns a role, so an absent one means "not sent" and must not wipe what we know.
+    fun `withMemberInfo should take the incoming snapshot verbatim`() {
+        // The same value has to reach the state, the repository cache and the database, and a blanket column update
+        // cannot preserve a previously known role, so nothing is carried over here either.
         val message = randomMessage(member = MemberInfo(channelRole = "channel_moderator"))
         val memberInfo = MemberInfo(channelRole = null, extraData = mapOf("flair" to "gold"))
 
         val result = message.withMemberInfo(memberInfo)
 
-        result.member shouldBeEqualTo MemberInfo(
-            channelRole = "channel_moderator",
-            extraData = mapOf("flair" to "gold"),
-        )
+        result.member shouldBeEqualTo memberInfo
         @Suppress("DEPRECATION")
-        result.channelRole shouldBeEqualTo "channel_moderator"
+        result.channelRole shouldBeEqualTo null
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/Mother.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.client.internal.offline.repository.domain.messa
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.attachment.internal.UploadStateEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.AnswerEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.LocationEntity
+import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.MemberInfoEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.MessageEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.MessageInnerEntity
 import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.OptionEntity
@@ -161,7 +162,7 @@ internal fun randomMessageEntity(
     pollId: String? = null,
     reminder: ReminderInfoEntity = randomReminderInfoEntity(),
     sharedLocation: LocationEntity? = randomLocationEntity(),
-    channelRole: String? = null,
+    member: MemberInfoEntity? = randomMemberInfoEntity(),
     deletedForMe: Boolean = randomBoolean(),
 ) = MessageEntity(
     messageInnerEntity = MessageInnerEntity(
@@ -199,7 +200,7 @@ internal fun randomMessageEntity(
         pollId = pollId,
         reminder = reminder,
         sharedLocation = sharedLocation,
-        channelRole = channelRole,
+        member = member,
         deletedForMe = deletedForMe,
     ),
     attachments = attachments,
@@ -300,6 +301,16 @@ internal fun randomReplyAttachmentEntity(
     originalHeight = originalHeight,
     originalWidth = originalWidth,
     uploadState = uploadState,
+    extraData = extraData,
+)
+
+internal fun randomMemberInfoEntity(
+    channelRole: String? = randomString(),
+    notificationsMuted: Boolean = randomBoolean(),
+    extraData: Map<String, Any> = mapOf(randomString() to randomString()),
+): MemberInfoEntity = MemberInfoEntity(
+    channelRole = channelRole,
+    notificationsMuted = notificationsMuted,
     extraData = extraData,
 )
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/MessageMemberRefreshRepositoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/MessageMemberRefreshRepositoryTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.offline.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.client.internal.offline.integration.BaseDomainTest2
+import io.getstream.chat.android.models.MemberInfo
+import io.getstream.chat.android.randomMessage
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Covers that refreshing the member snapshot reaches messages already held in the repository's in-memory cache.
+ *
+ * The cache is read before the database, so a targeted database update alone would leave stale objects being served.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class MessageMemberRefreshRepositoryTest : BaseDomainTest2() {
+
+    private val member = MemberInfo(
+        channelRole = "channel_moderator",
+        notificationsMuted = true,
+        extraData = mapOf("flair" to mapOf("tier" to "gold")),
+    )
+
+    @Test
+    fun `refreshing the member updates a cached message`(): Unit = runTest {
+        val message = cachedMessage()
+
+        repos.updateChannelUserMessagesMember(message.cid, message.user.id, member)
+
+        repos.selectMessage(message.id)?.member shouldBeEqualTo member
+    }
+
+    @Test
+    fun `refreshing the member keeps the deprecated channelRole of a cached message in sync`(): Unit = runTest {
+        val message = cachedMessage()
+
+        repos.updateChannelUserMessagesMember(message.cid, message.user.id, member)
+
+        @Suppress("DEPRECATION")
+        repos.selectMessage(message.id)?.channelRole shouldBeEqualTo "channel_moderator"
+    }
+
+    @Test
+    fun `clearing the member updates a cached message`(): Unit = runTest {
+        val message = cachedMessage(member = member)
+
+        repos.updateChannelUserMessagesMember(message.cid, message.user.id, null)
+
+        repos.selectMessage(message.id)?.member.shouldBeNull()
+    }
+
+    @Test
+    fun `refreshing the member leaves a cached message of another user alone`(): Unit = runTest {
+        val message = cachedMessage()
+
+        repos.updateChannelUserMessagesMember(message.cid, "someone-else", member)
+
+        repos.selectMessage(message.id)?.member.shouldBeNull()
+    }
+
+    /** Inserting populates the repository cache synchronously, so the message is served from it afterwards. */
+    private suspend fun cachedMessage(member: MemberInfo? = null) =
+        randomMessage(user = data.user1, member = member, replyTo = null, poll = null)
+            .also { repos.insertMessage(it) }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMapperTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMapperTest.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client.internal.offline.repository.domain.message.internal
 
+import io.getstream.chat.android.client.internal.offline.randomMemberInfoEntity
 import io.getstream.chat.android.client.internal.offline.randomMessageEntity
 import io.getstream.chat.android.client.internal.offline.randomReactionGroupEntity
 import io.getstream.chat.android.client.internal.offline.randomReminderInfoEntity
@@ -122,7 +123,8 @@ internal class MessageMapperTest {
                     deviceId = deviceId,
                 )
             },
-            channelRole = messageEntity.messageInnerEntity.channelRole,
+            channelRole = messageEntity.messageInnerEntity.member?.channelRole,
+            member = messageEntity.messageInnerEntity.member?.toModel(),
             deletedForMe = messageEntity.messageInnerEntity.deletedForMe,
         )
 
@@ -198,7 +200,7 @@ internal class MessageMapperTest {
                         deviceId = deviceId,
                     )
                 },
-                channelRole = message.channelRole,
+                member = message.member?.toEntity(),
                 deletedForMe = message.deletedForMe,
             ),
             attachments = message.attachments.mapIndexed { index, attachment ->
@@ -296,7 +298,7 @@ internal class MessageMapperTest {
                 moderationDetails = message.moderationDetails?.toEntity(),
                 pollId = message.poll?.id,
                 reminder = message.reminder?.toEntity(),
-                channelRole = message.channelRole,
+                member = message.member?.toEntity(),
             ),
             attachments = message.attachments.mapIndexed { index, attachment ->
                 attachment.toReplyEntity(
@@ -353,7 +355,7 @@ internal class MessageMapperTest {
             pollId = null,
             restrictedVisibility = listOf(randomString()),
             reminder = randomReminderInfoEntity(),
-            channelRole = randomString(),
+            member = randomMemberInfoEntity(),
         )
         val replyMessageEntity = ReplyMessageEntity(
             replyMessageInnerEntity = innerEntity,
@@ -403,7 +405,8 @@ internal class MessageMapperTest {
             restrictedVisibility = innerEntity.restrictedVisibility,
             channelInfo = null,
             reminder = innerEntity.reminder?.toModel(),
-            channelRole = innerEntity.channelRole,
+            channelRole = innerEntity.member?.channelRole,
+            member = innerEntity.member?.toModel(),
         )
 
         val result = replyMessageEntity.toModel(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMemberInfoDaoTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMemberInfoDaoTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.offline.repository.domain.message.internal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.client.internal.offline.createRoomDB
+import io.getstream.chat.android.client.internal.offline.repository.database.internal.ChatDatabase
+import io.getstream.chat.android.models.MemberInfo
+import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomUser
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Covers that the member snapshot attached to a message (`message.member`) survives a real database round trip, since
+ * it is the only place the author's projected member custom data is kept.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class MessageMemberInfoDaoTest {
+
+    private lateinit var database: ChatDatabase
+    private lateinit var messageDao: MessageDao
+    private lateinit var replyMessageDao: ReplyMessageDao
+
+    @Before
+    fun setUp() {
+        database = createRoomDB()
+        messageDao = database.messageDao()
+        replyMessageDao = database.replyMessageDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `member custom survives the round trip`(): Unit = runBlocking {
+        val member = MemberInfo(
+            channelRole = "channel_moderator",
+            notificationsMuted = true,
+            extraData = mapOf("flair" to mapOf("tier" to "gold", "badge" to "whale")),
+        )
+        val message = randomMessage(member = member, replyTo = null, poll = null)
+
+        messageDao.insert(message.toEntity())
+
+        messageDao.select(message.id)?.messageInnerEntity?.member shouldBeEqualTo member.toEntity()
+    }
+
+    @Test
+    fun `a member without custom data survives the round trip`(): Unit = runBlocking {
+        val member = MemberInfo(channelRole = "channel_member", notificationsMuted = false, extraData = emptyMap())
+        val message = randomMessage(member = member, replyTo = null, poll = null)
+
+        messageDao.insert(message.toEntity())
+
+        messageDao.select(message.id)?.messageInnerEntity?.member shouldBeEqualTo member.toEntity()
+    }
+
+    @Test
+    fun `an absent member stays absent across the round trip`(): Unit = runBlocking {
+        val message = randomMessage(member = null, replyTo = null, poll = null)
+
+        messageDao.insert(message.toEntity())
+
+        messageDao.select(message.id)?.messageInnerEntity?.member.shouldBeNull()
+    }
+
+    @Test
+    fun `member custom survives the round trip for a quoted message`(): Unit = runBlocking {
+        val member = MemberInfo(
+            channelRole = "channel_moderator",
+            notificationsMuted = true,
+            extraData = mapOf("flair" to "gold"),
+        )
+        val reply = randomMessage(user = randomUser(), member = member, replyTo = null, poll = null)
+
+        replyMessageDao.insert(listOf(reply.toReplyEntity()))
+
+        replyMessageDao.selectById(reply.id)?.replyMessageInnerEntity?.member shouldBeEqualTo member.toEntity()
+    }
+
+    @Test
+    fun `a message carrying only the deprecated channelRole keeps it across the round trip`(): Unit = runBlocking {
+        @Suppress("DEPRECATION")
+        val message = randomMessage(channelRole = "channel_moderator", member = null, replyTo = null, poll = null)
+
+        messageDao.insert(message.toEntity())
+
+        val stored = messageDao.select(message.id)?.messageInnerEntity?.member
+        stored shouldBeEqualTo MemberInfoEntity(channelRole = "channel_moderator")
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMemberInfoDaoTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMemberInfoDaoTest.kt
@@ -110,4 +110,53 @@ internal class MessageMemberInfoDaoTest {
         val stored = messageDao.select(message.id)?.messageInnerEntity?.member
         stored shouldBeEqualTo MemberInfoEntity(channelRole = "channel_moderator")
     }
+
+    @Test
+    fun `updating the member touches only the matching channel and author`(): Unit = runBlocking {
+        val author = randomUser(id = "author")
+        val other = randomUser(id = "other")
+        val mine = randomMessage(cid = CID, user = author, member = null, replyTo = null, poll = null)
+        val theirs = randomMessage(cid = CID, user = other, member = null, replyTo = null, poll = null)
+        val elsewhere = randomMessage(cid = OTHER_CID, user = author, member = null, replyTo = null, poll = null)
+        messageDao.insert(listOf(mine, theirs, elsewhere).map { it.toEntity() })
+        val member = MemberInfoEntity(channelRole = "channel_moderator", extraData = mapOf("flair" to "gold"))
+
+        messageDao.updateMemberByCidAndUserId(CID, author.id, member)
+
+        messageDao.select(mine.id)?.messageInnerEntity?.member shouldBeEqualTo member
+        messageDao.select(theirs.id)?.messageInnerEntity?.member.shouldBeNull()
+        messageDao.select(elsewhere.id)?.messageInnerEntity?.member.shouldBeNull()
+    }
+
+    @Test
+    fun `updating the member leaves the rest of the message untouched`(): Unit = runBlocking {
+        // This is the point of the targeted update: a concurrent edit elsewhere must not be reverted by the refresh.
+        val author = randomUser(id = "author")
+        val message = randomMessage(cid = CID, user = author, member = null, replyTo = null, poll = null)
+        messageDao.insert(message.toEntity())
+
+        messageDao.updateMemberByCidAndUserId(CID, author.id, MemberInfoEntity(channelRole = "channel_moderator"))
+
+        val stored = messageDao.select(message.id)?.messageInnerEntity
+        stored?.text shouldBeEqualTo message.text
+        stored?.extraData shouldBeEqualTo message.extraData
+        stored?.member shouldBeEqualTo MemberInfoEntity(channelRole = "channel_moderator")
+    }
+
+    @Test
+    fun `updating the member clears it when null is stored`(): Unit = runBlocking {
+        val author = randomUser(id = "author")
+        val member = MemberInfo(channelRole = "channel_member", extraData = mapOf("flair" to "gold"))
+        val message = randomMessage(cid = CID, user = author, member = member, replyTo = null, poll = null)
+        messageDao.insert(message.toEntity())
+
+        messageDao.updateMemberByCidAndUserId(CID, author.id, null)
+
+        messageDao.select(message.id)?.messageInnerEntity?.member.shouldBeNull()
+    }
+
+    private companion object {
+        const val CID = "messaging:probe"
+        const val OTHER_CID = "messaging:other"
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMemberInfoDaoTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMemberInfoDaoTest.kt
@@ -22,7 +22,7 @@ import io.getstream.chat.android.client.internal.offline.repository.database.int
 import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomUser
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.After
@@ -54,7 +54,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `member custom survives the round trip`(): Unit = runBlocking {
+    fun `member custom survives the round trip`(): Unit = runTest {
         val member = MemberInfo(
             channelRole = "channel_moderator",
             notificationsMuted = true,
@@ -68,7 +68,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `a member without custom data survives the round trip`(): Unit = runBlocking {
+    fun `a member without custom data survives the round trip`(): Unit = runTest {
         val member = MemberInfo(channelRole = "channel_member", notificationsMuted = false, extraData = emptyMap())
         val message = randomMessage(member = member, replyTo = null, poll = null)
 
@@ -78,7 +78,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `an absent member stays absent across the round trip`(): Unit = runBlocking {
+    fun `an absent member stays absent across the round trip`(): Unit = runTest {
         val message = randomMessage(member = null, replyTo = null, poll = null)
 
         messageDao.insert(message.toEntity())
@@ -87,7 +87,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `member custom survives the round trip for a quoted message`(): Unit = runBlocking {
+    fun `member custom survives the round trip for a quoted message`(): Unit = runTest {
         val member = MemberInfo(
             channelRole = "channel_moderator",
             notificationsMuted = true,
@@ -101,7 +101,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `a message carrying only the deprecated channelRole keeps it across the round trip`(): Unit = runBlocking {
+    fun `a message carrying only the deprecated channelRole keeps it across the round trip`(): Unit = runTest {
         @Suppress("DEPRECATION")
         val message = randomMessage(channelRole = "channel_moderator", member = null, replyTo = null, poll = null)
 
@@ -112,7 +112,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `updating the member touches only the matching channel and author`(): Unit = runBlocking {
+    fun `updating the member touches only the matching channel and author`(): Unit = runTest {
         val author = randomUser(id = "author")
         val other = randomUser(id = "other")
         val mine = randomMessage(cid = CID, user = author, member = null, replyTo = null, poll = null)
@@ -129,7 +129,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `updating the member leaves the rest of the message untouched`(): Unit = runBlocking {
+    fun `updating the member leaves the rest of the message untouched`(): Unit = runTest {
         // This is the point of the targeted update: a concurrent edit elsewhere must not be reverted by the refresh.
         val author = randomUser(id = "author")
         val message = randomMessage(cid = CID, user = author, member = null, replyTo = null, poll = null)
@@ -144,7 +144,7 @@ internal class MessageMemberInfoDaoTest {
     }
 
     @Test
-    fun `updating the member clears it when null is stored`(): Unit = runBlocking {
+    fun `updating the member clears it when null is stored`(): Unit = runTest {
         val author = randomUser(id = "author")
         val member = MemberInfo(channelRole = "channel_member", extraData = mapOf("flair" to "gold"))
         val message = randomMessage(cid = CID, user = author, member = member, replyTo = null, poll = null)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.client.persistance.repository.MessageRepository
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.UploadedFile
@@ -228,6 +229,10 @@ internal class MockMessageRepository : MessageRepository {
     }
 
     override suspend fun selectAllChannelUserMessages(cid: String, userId: String): List<Message> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun updateChannelUserMessagesMember(cid: String, userId: String, member: MemberInfo?) {
         TODO("Not yet implemented")
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequentialMemberUpdatedTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/event/handler/internal/EventHandlerSequentialMemberUpdatedTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.state.event.handler.internal
+
+import io.getstream.chat.android.client.ChatEventListener
+import io.getstream.chat.android.client.api.MessageBufferConfig
+import io.getstream.chat.android.client.api.state.StateRegistry
+import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.events.MemberUpdatedEvent
+import io.getstream.chat.android.client.internal.state.plugin.logic.internal.LogicRegistry
+import io.getstream.chat.android.client.internal.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
+import io.getstream.chat.android.client.setup.state.ClientState
+import io.getstream.chat.android.client.test.randomMemberUpdatedEvent
+import io.getstream.chat.android.client.utils.observable.Disposable
+import io.getstream.chat.android.models.MemberInfo
+import io.getstream.chat.android.randomMember
+import io.getstream.chat.android.randomUser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+/**
+ * Covers the [EventHandlerSequential] handling of [MemberUpdatedEvent]: the backend never emits `message.updated` when
+ * a membership changes, so the member snapshot denormalized onto the stored messages has to be refreshed by the SDK.
+ */
+internal class EventHandlerSequentialMemberUpdatedTest {
+
+    private val currentUser = randomUser()
+    private val author = randomUser()
+    private val testCid = "messaging:123"
+
+    @Test
+    fun `When MemberUpdatedEvent is processed, should refresh the member snapshot on the author's stored messages`() =
+        runTest {
+            // Given
+            val member = randomMember(user = author, channelRole = "channel_moderator")
+                .copy(notificationsMuted = true, extraData = mapOf("flair" to "gold"))
+            val event = randomMemberUpdatedEvent(cid = testCid, user = author, member = member)
+            val repos = mockRepos()
+
+            val handler = createEventHandler(scope = this, repos = repos)
+
+            // When
+            handler.handleEvents(event)
+
+            // Then - only the member column is written, so a concurrent edit elsewhere is not overwritten
+            verify(repos).updateChannelUserMessagesMember(
+                testCid,
+                author.id,
+                MemberInfo(
+                    channelRole = "channel_moderator",
+                    notificationsMuted = true,
+                    extraData = mapOf("flair" to "gold"),
+                ),
+            )
+            verify(repos, never()).insertMessages(argThat { isNotEmpty() })
+        }
+
+    private fun mockRepos(): RepositoryFacade =
+        mock {
+            onBlocking { selectChannels(any()) } doReturn emptyList()
+            onBlocking { selectMessages(any()) } doReturn emptyList()
+            onBlocking { selectThreads(any()) } doReturn emptyList()
+        }
+
+    private fun createEventHandler(
+        scope: CoroutineScope,
+        logicRegistry: LogicRegistry = mock(),
+        repos: RepositoryFacade = mock(),
+    ): EventHandlerSequential {
+        val subscribeForEvents: (ChatEventListener<ChatEvent>) -> Disposable = { _ ->
+            EventHandlerSequential.EMPTY_DISPOSABLE
+        }
+        val stateRegistry: StateRegistry = mock()
+        val clientState: ClientState = mock {
+            on { user } doReturn MutableStateFlow(currentUser)
+        }
+        val mutableGlobalState = MutableGlobalState(currentUser.id)
+        val sideEffect: suspend () -> Unit = {}
+        val syncedEvents: Flow<List<ChatEvent>> = emptyFlow()
+
+        return EventHandlerSequential(
+            currentUserId = currentUser.id,
+            subscribeForEvents = subscribeForEvents,
+            logicRegistry = logicRegistry,
+            stateRegistry = stateRegistry,
+            clientState = clientState,
+            mutableGlobalState = mutableGlobalState,
+            repos = repos,
+            sideEffect = sideEffect,
+            syncedEvents = syncedEvents,
+            bufferConfig = MessageBufferConfig(),
+            isLocalUnreadCountEnabled = false,
+            scope = scope,
+        )
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImplTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/internal/ChannelEventHandlerImplTest.kt
@@ -45,6 +45,7 @@ import io.getstream.chat.android.client.test.randomChannelVisibleEvent
 import io.getstream.chat.android.client.test.randomMarkAllReadEvent
 import io.getstream.chat.android.client.test.randomMemberAddedEvent
 import io.getstream.chat.android.client.test.randomMemberRemovedEvent
+import io.getstream.chat.android.client.test.randomMemberUpdatedEvent
 import io.getstream.chat.android.client.test.randomMessageDeliveredEvent
 import io.getstream.chat.android.client.test.randomMessageReadEvent
 import io.getstream.chat.android.client.test.randomMessageUpdateEvent
@@ -737,6 +738,17 @@ internal class ChannelEventHandlerImplTest {
 
         verify(state).upsertMember(member)
         verify(state).setMembership(member)
+    }
+
+    @Test
+    fun `When MemberUpdatedEvent is handled, Then the member snapshot on the author's messages is refreshed`() {
+        // The backend does not emit message.updated for membership changes, so the SDK refreshes the snapshot itself
+        val member = randomMember()
+        val event = randomMemberUpdatedEvent(cid = cid, member = member)
+
+        handler.handle(event)
+
+        verify(state).updateMessagesMemberInfo(member)
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogicTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/logic/channel/thread/internal/ThreadStateLogicTest.kt
@@ -17,9 +17,13 @@
 package io.getstream.chat.android.client.internal.state.plugin.logic.channel.thread.internal
 
 import io.getstream.chat.android.client.internal.state.plugin.state.channel.thread.internal.ThreadMutableState
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomString
+import io.getstream.chat.android.randomUser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,6 +34,8 @@ import java.util.Date
 internal class ThreadStateLogicTest {
 
     private val parentId = randomString()
+    private val cid = randomCID()
+    private val author = randomUser()
 
     @Test
     fun `updateQuotedMessageReferences should update messages quoting via replyTo`() = runTest {
@@ -84,6 +90,45 @@ internal class ThreadStateLogicTest {
         // then
         assertNull(mutableState.rawMessage.value[quotingMessage.id]?.replyTo)
     }
+
+    @Test
+    fun `updateMessagesMemberInfo should refresh the member snapshot on the author's thread replies`() = runTest {
+        // given - thread replies live in this state, so the channel refresh does not reach them
+        val (mutableState, threadStateLogic) = threadStateLogic(backgroundScope)
+        val reply = threadReply(user = author)
+        threadStateLogic.upsertMessages(listOf(reply))
+        val memberInfo = MemberInfo(channelRole = "channel_moderator", extraData = mapOf("flair" to "gold"))
+        // when
+        threadStateLogic.updateMessagesMemberInfo(cid, author.id, memberInfo)
+        // then
+        assertEquals(memberInfo, mutableState.rawMessage.value[reply.id]?.member)
+    }
+
+    @Test
+    fun `updateMessagesMemberInfo should leave replies of other authors and other channels alone`() = runTest {
+        // given
+        val (mutableState, threadStateLogic) = threadStateLogic(backgroundScope)
+        val otherAuthor = threadReply(user = randomUser())
+        val otherChannel = threadReply(user = author, cid = randomCID())
+        threadStateLogic.upsertMessages(listOf(otherAuthor, otherChannel))
+        // when
+        threadStateLogic.updateMessagesMemberInfo(cid, author.id, MemberInfo(channelRole = "channel_moderator"))
+        // then
+        assertNull(mutableState.rawMessage.value[otherAuthor.id]?.member)
+        assertNull(mutableState.rawMessage.value[otherChannel.id]?.member)
+    }
+
+    /** A reply that survives the thread state's deleted-message filtering. */
+    private fun threadReply(user: User, cid: String = this.cid): Message = randomMessage(
+        cid = cid,
+        user = user,
+        parentId = parentId,
+        member = null,
+        replyTo = null,
+        poll = null,
+        deletedAt = null,
+        deletedForMe = false,
+    )
 
     private fun threadStateLogic(scope: CoroutineScope): Pair<ThreadMutableState, ThreadStateLogic> {
         val mutableState = ThreadMutableState(parentId, scope)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImplMembersTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateImplMembersTest.kt
@@ -409,6 +409,65 @@ internal class ChannelStateImplMembersTest : ChannelStateImplTestBase() {
         }
     }
 
+    @Nested
+    inner class UpdateMessagesMemberInfo {
+
+        @Test
+        fun `updateMessagesMemberInfo should refresh the member snapshot on the author's messages`() = runTest {
+            // given - the backend does not emit message.updated when a membership changes
+            val author = randomUser(id = "author")
+            val message = createMessage(1, user = author)
+            channelState.setMessages(listOf(message))
+            // when
+            val member = randomMember(user = author, channelRole = "channel_moderator")
+                .copy(notificationsMuted = true, extraData = mapOf("flair" to "gold"))
+            channelState.updateMessagesMemberInfo(member)
+            // then
+            val updated = channelState.messages.value.first()
+            assertEquals("channel_moderator", updated.member?.channelRole)
+            assertEquals(true, updated.member?.notificationsMuted)
+            assertEquals(mapOf("flair" to "gold"), updated.member?.extraData)
+        }
+
+        @Test
+        fun `updateMessagesMemberInfo should keep the deprecated channelRole in sync`() = runTest {
+            // given
+            val author = randomUser(id = "author")
+            channelState.setMessages(listOf(createMessage(1, user = author)))
+            // when
+            channelState.updateMessagesMemberInfo(randomMember(user = author, channelRole = "channel_moderator"))
+            // then
+            @Suppress("DEPRECATION")
+            assertEquals("channel_moderator", channelState.messages.value.first().channelRole)
+        }
+
+        @Test
+        fun `updateMessagesMemberInfo should leave messages of other users untouched`() = runTest {
+            // given
+            val author = randomUser(id = "author")
+            val otherAuthor = randomUser(id = "other_author")
+            val otherMessage = createMessage(2, user = otherAuthor)
+            channelState.setMessages(listOf(createMessage(1, user = author), otherMessage))
+            // when
+            channelState.updateMessagesMemberInfo(randomMember(user = author))
+            // then
+            val untouched = channelState.messages.value.first { it.id == otherMessage.id }
+            assertNull(untouched.member)
+        }
+
+        @Test
+        fun `updateMessagesMemberInfo should refresh pinned messages too`() = runTest {
+            // given
+            val author = randomUser(id = "author")
+            val pinnedMessage = createMessage(1, user = author, pinned = true, pinnedAt = Date())
+            channelState.addPinnedMessages(listOf(pinnedMessage))
+            // when
+            channelState.updateMessagesMemberInfo(randomMember(user = author, channelRole = "channel_moderator"))
+            // then
+            assertEquals("channel_moderator", channelState.pinnedMessages.value.first().member?.channelRole)
+        }
+    }
+
     private fun createMember(index: Int): Member {
         val user = randomUser(id = "user_$index", name = "User $index")
         return randomMember(user = user)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImplMemberInfoTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/state/plugin/state/channel/internal/ChannelStateLegacyImplMemberInfoTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.state.plugin.state.channel.internal
+
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomMember
+import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomUser
+import io.getstream.chat.android.test.TestCoroutineExtension
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.util.Date
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Tests for refreshing the member snapshot carried by messages on the legacy channel state implementation. The backend
+ * does not emit `message.updated` when a membership changes, so the snapshot has to be refreshed by the SDK.
+ */
+internal class ChannelStateLegacyImplMemberInfoTest {
+
+    private val userFlow = MutableStateFlow(currentUser)
+
+    @Test
+    fun `updateMessagesMemberInfo refreshes the member snapshot on the author's messages`() = runTest {
+        // given
+        val state = channelState()
+        val author = randomUser(id = "author")
+        state.setMessages(listOf(authoredMessage(author)))
+        val member = randomMember(user = author, channelRole = "channel_moderator")
+            .copy(notificationsMuted = true, extraData = mapOf("flair" to "gold"))
+        // when
+        state.updateMessagesMemberInfo(member)
+        // then
+        val updated = state.messages.value.first()
+        assertEquals("channel_moderator", updated.member?.channelRole)
+        assertEquals(true, updated.member?.notificationsMuted)
+        assertEquals(mapOf("flair" to "gold"), updated.member?.extraData)
+    }
+
+    @Test
+    fun `updateMessagesMemberInfo leaves messages of other users untouched`() = runTest {
+        // given
+        val state = channelState()
+        val otherAuthor = randomUser(id = "other_author")
+        state.setMessages(listOf(authoredMessage(otherAuthor)))
+        // when
+        state.updateMessagesMemberInfo(randomMember(user = randomUser(id = "author")))
+        // then
+        assertTrue(state.messages.value.all { it.member == null })
+    }
+
+    @Test
+    fun `updateMessagesMemberInfo refreshes pinned messages too`() = runTest {
+        // given
+        val state = channelState()
+        val author = randomUser(id = "author")
+        val pinnedMessage = authoredMessage(author).copy(
+            pinned = true,
+            pinnedAt = Date(currentTime()),
+            pinExpires = Date(currentTime() + 1.hours.inWholeMilliseconds),
+        )
+        state.setPinnedMessages(listOf(pinnedMessage))
+        // when
+        state.updateMessagesMemberInfo(randomMember(user = author, channelRole = "channel_moderator"))
+        // then
+        assertEquals("channel_moderator", state.pinnedMessages.value.first().member?.channelRole)
+    }
+
+    private fun authoredMessage(author: User) = randomMessage(
+        cid = CID,
+        user = author,
+        parentId = null,
+        shadowed = false,
+        deletedAt = null,
+        deletedForMe = false,
+        member = null,
+    )
+
+    private fun channelState() = ChannelStateLegacyImpl(
+        channelType = CHANNEL_TYPE,
+        channelId = CHANNEL_ID,
+        userFlow = userFlow,
+        latestUsers = MutableStateFlow(mapOf(currentUser.id to currentUser)),
+        activeLiveLocations = MutableStateFlow(emptyList()),
+        baseMessageLimit = null,
+        now = ::currentTime,
+    )
+
+    private companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+
+        const val CHANNEL_TYPE = "messaging"
+        const val CHANNEL_ID = "123"
+        const val CID = "messaging:123"
+
+        val currentUser = User(id = "tom", name = "Tom")
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        fun currentTime() = testCoroutines.dispatcher.scheduler.currentTime
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/DownstreamMemberInfoDtoAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/DownstreamMemberInfoDtoAdapterTest.kt
@@ -30,4 +30,22 @@ internal class DownstreamMemberInfoDtoAdapterTest {
         val member = parser.fromJson(MemberInfoDtoTestData.downstreamJson, DownstreamMemberInfoDto::class.java)
         member shouldBeEqualTo MemberInfoDtoTestData.downstreamMemberInfo
     }
+
+    @Test
+    fun `Deserialize JSON member info with member custom inlined by API v1`() {
+        val member = parser.fromJson(
+            MemberInfoDtoTestData.downstreamJsonWithInlineCustom,
+            DownstreamMemberInfoDto::class.java,
+        )
+        member shouldBeEqualTo MemberInfoDtoTestData.downstreamMemberInfoWithInlineCustom
+    }
+
+    @Test
+    fun `Deserialize JSON member info with member custom nested by API v2`() {
+        val member = parser.fromJson(
+            MemberInfoDtoTestData.downstreamJsonWithNestedCustom,
+            DownstreamMemberInfoDto::class.java,
+        )
+        member shouldBeEqualTo MemberInfoDtoTestData.downstreamMemberInfoWithNestedCustom
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/MessageParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/MessageParsingTest.kt
@@ -394,4 +394,32 @@ internal class MessageParsingTest {
     }
 
     // endregion
+    // region Member info (message.member)
+
+    @Test
+    fun `Both paths - member without projected custom keys`() {
+        val result = assertBothPaths(MessageTestData.jsonWithMemberWithoutCustom)
+        assertEquals(MessageTestData.expectedMemberWithoutCustom, result.member)
+        assertEquals(emptyMap<String, Any>(), result.member?.extraData)
+    }
+
+    @Test
+    fun `Both paths - member custom inlined by API v1 lands on the domain field`() {
+        val result = assertBothPaths(MessageTestData.jsonWithMemberCustomInlined)
+        assertEquals(MessageTestData.expectedMemberWithCustom, result.member)
+    }
+
+    @Test
+    fun `Both paths - member custom nested by API v2 lands on the same domain field`() {
+        val result = assertBothPaths(MessageTestData.jsonWithMemberCustomNested)
+        assertEquals(MessageTestData.expectedMemberWithCustom, result.member)
+    }
+
+    @Test
+    fun `Both paths - member absent yields a null member`() {
+        val result = assertBothPaths(MessageTestData.jsonOptionalFieldsMissing)
+        assertEquals(null, result.member)
+    }
+
+    // endregion
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MemberInfoDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MemberInfoDtoTestData.kt
@@ -29,4 +29,36 @@ internal object MemberInfoDtoTestData {
     """.trimIndent()
 
     val downstreamMemberInfo = DownstreamMemberInfoDto(channel_role = "channel_member")
+
+    /** API v1 inlines the projected member custom keys next to the declared fields. */
+    @Language("JSON")
+    val downstreamJsonWithInlineCustom: String = """
+        {
+          "channel_role": "channel_member",
+          "notifications_muted": true,
+          "flair": { "tier": "gold" }
+        }
+    """.trimIndent()
+
+    val downstreamMemberInfoWithInlineCustom = DownstreamMemberInfoDto(
+        channel_role = "channel_member",
+        notifications_muted = true,
+        extraData = mapOf("flair" to mapOf("tier" to "gold")),
+    )
+
+    /** API v2 nests the same keys under `custom`. */
+    @Language("JSON")
+    val downstreamJsonWithNestedCustom: String = """
+        {
+          "channel_role": "channel_member",
+          "notifications_muted": true,
+          "custom": { "flair": { "tier": "gold" } }
+        }
+    """.trimIndent()
+
+    val downstreamMemberInfoWithNestedCustom = DownstreamMemberInfoDto(
+        channel_role = "channel_member",
+        notifications_muted = true,
+        custom = mapOf("flair" to mapOf("tier" to "gold")),
+    )
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageTestData.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.parser2.testdata
 
 import io.getstream.chat.android.models.ChannelInfo
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.User
@@ -1120,6 +1121,68 @@ internal object MessageTestData {
         "silent": false,
         "mentioned_roles": null
     }"""
+
+    // endregion
+    // region Member info (message.member)
+
+    private const val BASE_FIELDS = """
+        "id": "msg-1",
+        "cid": "messaging:general",
+        "text": "Hello world",
+        "html": "<p>Hello world</p>",
+        "type": "regular",
+        "user": {"id": "user-1", "role": "user", "banned": false, "online": true},
+        "attachments": [],
+        "latest_reactions": [],
+        "own_reactions": [],
+        "mentioned_users": [],
+        "reply_count": 0,
+        "deleted_reply_count": 0,
+        "created_at": "2020-01-01T00:00:00.000Z",
+        "updated_at": "2020-01-01T00:00:00.000Z",
+        "silent": false
+    """
+
+    /** Baseline shape: the member object without any projected custom keys. */
+    @Language("JSON")
+    val jsonWithMemberWithoutCustom = """{
+        $BASE_FIELDS,
+        "member": {"channel_role": "channel_member", "notifications_muted": false}
+    }"""
+
+    /** API v1 inlines the projected member custom keys next to `channel_role`. */
+    @Language("JSON")
+    val jsonWithMemberCustomInlined = """{
+        $BASE_FIELDS,
+        "member": {
+            "channel_role": "channel_moderator",
+            "notifications_muted": true,
+            "flair": {"tier": "gold"}
+        }
+    }"""
+
+    /** API v2 nests the same keys under `custom`. */
+    @Language("JSON")
+    val jsonWithMemberCustomNested = """{
+        $BASE_FIELDS,
+        "member": {
+            "channel_role": "channel_moderator",
+            "notifications_muted": true,
+            "custom": {"flair": {"tier": "gold"}}
+        }
+    }"""
+
+    val expectedMemberWithoutCustom = MemberInfo(
+        channelRole = "channel_member",
+        notificationsMuted = false,
+        extraData = emptyMap(),
+    )
+
+    val expectedMemberWithCustom = MemberInfo(
+        channelRole = "channel_moderator",
+        notificationsMuted = true,
+        extraData = mapOf("flair" to mapOf("tier" to "gold")),
+    )
 
     // endregion
 }

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -1359,14 +1359,32 @@ public final class io/getstream/chat/android/models/MemberData : io/getstream/ch
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/models/MemberInfo : io/getstream/chat/android/models/CustomObject {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;ZLjava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;ZLjava/util/Map;)Lio/getstream/chat/android/models/MemberInfo;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/MemberInfo;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/models/MemberInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelRole ()Ljava/lang/String;
+	public fun getExtraData ()Ljava/util/Map;
+	public fun getExtraValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getNotificationsMuted ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/models/Message : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public static final field Companion Lio/getstream/chat/android/models/Message$Companion;
 	public static final field TYPE_EPHEMERAL Ljava/lang/String;
 	public static final field TYPE_ERROR Ljava/lang/String;
 	public static final field TYPE_REGULAR Ljava/lang/String;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;ZZZLjava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;ZZZLjava/util/List;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;Lio/getstream/chat/android/models/MemberInfo;ZZZLjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;Lio/getstream/chat/android/models/MemberInfo;ZZZLjava/util/List;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()I
 	public final fun component11 ()I
@@ -1409,18 +1427,19 @@ public final class io/getstream/chat/android/models/Message : io/getstream/chat/
 	public final fun component45 ()Lio/getstream/chat/android/models/MessageReminderInfo;
 	public final fun component46 ()Lio/getstream/chat/android/models/Location;
 	public final fun component47 ()Ljava/lang/String;
-	public final fun component48 ()Z
+	public final fun component48 ()Lio/getstream/chat/android/models/MemberInfo;
 	public final fun component49 ()Z
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component50 ()Z
-	public final fun component51 ()Ljava/util/List;
+	public final fun component51 ()Z
 	public final fun component52 ()Ljava/util/List;
+	public final fun component53 ()Ljava/util/List;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;ZZZLjava/util/List;Ljava/util/List;)Lio/getstream/chat/android/models/Message;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;ZZZLjava/util/List;Ljava/util/List;IILjava/lang/Object;)Lio/getstream/chat/android/models/Message;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;Lio/getstream/chat/android/models/MemberInfo;ZZZLjava/util/List;Ljava/util/List;)Lio/getstream/chat/android/models/Message;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/chat/android/models/SyncStatus;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/Map;ZZLjava/util/Map;ZLio/getstream/chat/android/models/ChannelInfo;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZLjava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/User;Ljava/util/List;ZZLio/getstream/chat/android/models/MessageModerationDetails;Lio/getstream/chat/android/models/Moderation;Ljava/util/Date;Lio/getstream/chat/android/models/Poll;Ljava/util/List;Lio/getstream/chat/android/models/MessageReminderInfo;Lio/getstream/chat/android/models/Location;Ljava/lang/String;Lio/getstream/chat/android/models/MemberInfo;ZZZLjava/util/List;Ljava/util/List;IILjava/lang/Object;)Lio/getstream/chat/android/models/Message;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getChannelInfo ()Lio/getstream/chat/android/models/ChannelInfo;
@@ -1439,6 +1458,7 @@ public final class io/getstream/chat/android/models/Message : io/getstream/chat/
 	public final fun getI18n ()Ljava/util/Map;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getMember ()Lio/getstream/chat/android/models/MemberInfo;
 	public final fun getMentionedChannel ()Z
 	public final fun getMentionedGroups ()Ljava/util/List;
 	public final fun getMentionedHere ()Z
@@ -1504,6 +1524,7 @@ public final class io/getstream/chat/android/models/Message$Builder {
 	public final fun withI18n (Ljava/util/Map;)Lio/getstream/chat/android/models/Message$Builder;
 	public final fun withId (Ljava/lang/String;)Lio/getstream/chat/android/models/Message$Builder;
 	public final fun withLatestReactions (Ljava/util/List;)Lio/getstream/chat/android/models/Message$Builder;
+	public final fun withMember (Lio/getstream/chat/android/models/MemberInfo;)Lio/getstream/chat/android/models/Message$Builder;
 	public final fun withMentionedChannel (Z)Lio/getstream/chat/android/models/Message$Builder;
 	public final fun withMentionedGroups (Ljava/util/List;)Lio/getstream/chat/android/models/Message$Builder;
 	public final fun withMentionedHere (Z)Lio/getstream/chat/android/models/Message$Builder;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/MemberInfo.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/MemberInfo.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Model holding limited data about a channel member, as attached to a [Message] by [Message.member].
+ *
+ * This is not a full [Member]: there is no user, no timestamps and no invite or ban state.
+ */
+@Immutable
+public data class MemberInfo(
+    /**
+     * The channel-level role of the member.
+     */
+    val channelRole: String? = null,
+
+    /**
+     * If notifications are muted for the member in the channel.
+     */
+    val notificationsMuted: Boolean = false,
+
+    /**
+     * A map of custom fields for the member.
+     *
+     * Only populated when the app has member custom data on messages enabled.
+     */
+    override val extraData: Map<String, Any> = emptyMap(),
+) : CustomObject

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Message.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Message.kt
@@ -649,6 +649,7 @@ public data class Message(
 
         @Suppress("DEPRECATION")
         public fun build(): Message {
+            val resolvedMember = member ?: channelRole?.let { MemberInfo(channelRole = it) }
             return Message(
                 id = id,
                 cid = cid,
@@ -696,8 +697,8 @@ public data class Message(
                 poll = poll,
                 reminder = reminder,
                 sharedLocation = sharedLocation,
-                channelRole = channelRole,
-                member = member,
+                channelRole = resolvedMember?.channelRole,
+                member = resolvedMember,
                 deletedForMe = deletedForMe,
                 mentionedHere = mentionedHere,
                 mentionedChannel = mentionedChannel,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Message.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Message.kt
@@ -267,7 +267,17 @@ public data class Message(
     /**
      * The role of the member(who sent the message) in the channel.
      */
+    @Deprecated(
+        message = "Use member?.channelRole instead.",
+        replaceWith = ReplaceWith("member?.channelRole"),
+        level = DeprecationLevel.WARNING,
+    )
     val channelRole: String? = null,
+
+    /**
+     * Data about the channel membership of the user who sent the message.
+     */
+    val member: MemberInfo? = null,
 
     /**
      * Whether the message was deleted for the current user.
@@ -412,7 +422,7 @@ public data class Message(
         if (moderationDetails != null) append(", moderationDetails=").append(moderationDetails)
         if (moderation != null) append(", moderation=").append(moderation)
         if (poll != null) append(", poll=").append(poll)
-        if (channelRole != null) append(", channelRole=").append(channelRole)
+        if (member != null) append(", member=").append(member)
         append(", deletedForMe=").append(deletedForMe)
         if (mentionedHere) append(", mentionedHere=true")
         if (mentionedChannel) append(", mentionedChannel=true")
@@ -475,12 +485,14 @@ public data class Message(
         private var reminder: MessageReminderInfo? = null
         private var sharedLocation: Location? = null
         private var channelRole: String? = null
+        private var member: MemberInfo? = null
         private var deletedForMe: Boolean = false
         private var mentionedHere: Boolean = false
         private var mentionedChannel: Boolean = false
         private var mentionedGroups: List<UserGroup> = emptyList()
         private var mentionedRoles: List<String> = emptyList()
 
+        @Suppress("DEPRECATION")
         public constructor(message: Message) : this() {
             id = message.id
             cid = message.cid
@@ -529,6 +541,7 @@ public data class Message(
             reminder = message.reminder
             sharedLocation = message.sharedLocation
             channelRole = message.channelRole
+            member = message.member
             deletedForMe = message.deletedForMe
             mentionedHere = message.mentionedHere
             mentionedChannel = message.mentionedChannel
@@ -614,7 +627,14 @@ public data class Message(
         public fun withSharedLocation(sharedLocation: Location?): Builder = apply {
             this.sharedLocation = sharedLocation
         }
+
+        @Deprecated(
+            message = "Use withMember instead.",
+            replaceWith = ReplaceWith("withMember(MemberInfo(channelRole = channelRole))"),
+            level = DeprecationLevel.WARNING,
+        )
         public fun withChannelRole(channelRole: String?): Builder = apply { this.channelRole = channelRole }
+        public fun withMember(member: MemberInfo?): Builder = apply { this.member = member }
         public fun withDeletedForMe(deletedForMe: Boolean): Builder = apply { this.deletedForMe = deletedForMe }
         public fun withMentionedHere(mentionedHere: Boolean): Builder = apply { this.mentionedHere = mentionedHere }
         public fun withMentionedChannel(mentionedChannel: Boolean): Builder = apply {
@@ -627,6 +647,7 @@ public data class Message(
             this.mentionedRoles = mentionedRoles
         }
 
+        @Suppress("DEPRECATION")
         public fun build(): Message {
             return Message(
                 id = id,
@@ -676,6 +697,7 @@ public data class Message(
                 reminder = reminder,
                 sharedLocation = sharedLocation,
                 channelRole = channelRole,
+                member = member,
                 deletedForMe = deletedForMe,
                 mentionedHere = mentionedHere,
                 mentionedChannel = mentionedChannel,

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageTest.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.randomChannelInfo
 import io.getstream.chat.android.randomDate
 import io.getstream.chat.android.randomInt
 import io.getstream.chat.android.randomLocation
+import io.getstream.chat.android.randomMemberInfo
 import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomMessageModerationDetails
 import io.getstream.chat.android.randomMessageReminderInfo
@@ -93,6 +94,7 @@ internal class MessageTest {
             reminder = randomMessageReminderInfo(),
             sharedLocation = randomLocation(),
             channelRole = randomString(),
+            member = randomMemberInfo(),
             deletedForMe = randomBoolean(),
             mentionedHere = randomBoolean(),
             mentionedChannel = randomBoolean(),
@@ -148,6 +150,7 @@ internal class MessageTest {
             .withReminder(expected.reminder)
             .withSharedLocation(expected.sharedLocation)
             .withChannelRole(expected.channelRole)
+            .withMember(expected.member)
             .withDeletedForMe(expected.deletedForMe)
             .withMentionedHere(expected.mentionedHere)
             .withMentionedChannel(expected.mentionedChannel)
@@ -166,6 +169,7 @@ internal class MessageTest {
             moderationDetails = randomMessageModerationDetails(),
             moderation = randomModeration(),
             channelRole = randomString(),
+            member = randomMemberInfo(),
             threadParticipants = listOf(randomUser()),
             mentionedGroups = listOf(randomUserGroup()),
             mentionedRoles = listOf(randomString()),

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageTest.kt
@@ -43,6 +43,29 @@ import org.junit.jupiter.api.Test
 
 internal class MessageTest {
 
+    /** `Message` keeps `member` and the deprecated `channelRole` in sync, so fixtures must agree on both. */
+    private val consistentMember = randomMemberInfo()
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `builder should promote the deprecated channelRole into a member`() {
+        val built = Message.Builder().withChannelRole("channel_moderator").build()
+
+        assertEquals(MemberInfo(channelRole = "channel_moderator"), built.member)
+        assertEquals("channel_moderator", built.channelRole)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `builder should let an explicit member win over the deprecated channelRole`() {
+        val member = MemberInfo(channelRole = "channel_member", extraData = mapOf("flair" to "gold"))
+
+        val built = Message.Builder().withChannelRole("channel_moderator").withMember(member).build()
+
+        assertEquals(member, built.member)
+        assertEquals("channel_member", built.channelRole)
+    }
+
     @Test
     @Suppress("LongMethod")
     fun `builder should set every field`() {
@@ -93,8 +116,8 @@ internal class MessageTest {
             restrictedVisibility = listOf(randomString()),
             reminder = randomMessageReminderInfo(),
             sharedLocation = randomLocation(),
-            channelRole = randomString(),
-            member = randomMemberInfo(),
+            channelRole = consistentMember.channelRole,
+            member = consistentMember,
             deletedForMe = randomBoolean(),
             mentionedHere = randomBoolean(),
             mentionedChannel = randomBoolean(),
@@ -168,8 +191,8 @@ internal class MessageTest {
             poll = randomPoll(),
             moderationDetails = randomMessageModerationDetails(),
             moderation = randomModeration(),
-            channelRole = randomString(),
-            member = randomMemberInfo(),
+            channelRole = consistentMember.channelRole,
+            member = consistentMember,
             threadParticipants = listOf(randomUser()),
             mentionedGroups = listOf(randomUserGroup()),
             mentionedRoles = listOf(randomString()),

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -39,6 +39,7 @@ import io.getstream.chat.android.models.Flag
 import io.getstream.chat.android.models.Location
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.MemberData
+import io.getstream.chat.android.models.MemberInfo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageModerationAction
 import io.getstream.chat.android.models.MessageModerationDetails
@@ -387,6 +388,7 @@ public fun randomMessage(
     i18n: Map<String, String> = emptyMap(),
     reminder: MessageReminderInfo? = randomMessageReminderInfo(),
     channelRole: String? = null,
+    member: MemberInfo? = null,
     deletedForMe: Boolean = randomBoolean(),
     mentionedHere: Boolean = randomBoolean(),
     mentionedChannel: Boolean = randomBoolean(),
@@ -438,6 +440,7 @@ public fun randomMessage(
     i18n = i18n,
     reminder = reminder,
     channelRole = channelRole,
+    member = member,
     deletedForMe = deletedForMe,
     mentionedHere = mentionedHere,
     mentionedChannel = mentionedChannel,
@@ -731,6 +734,16 @@ public fun randomMember(
     banExpires = banExpires,
     pinnedAt = pinnedAt,
     archivedAt = archivedAt,
+)
+
+public fun randomMemberInfo(
+    channelRole: String? = randomString(),
+    notificationsMuted: Boolean = randomBoolean(),
+    extraData: Map<String, Any> = randomExtraData(),
+): MemberInfo = MemberInfo(
+    channelRole = channelRole,
+    notificationsMuted = notificationsMuted,
+    extraData = extraData,
 )
 
 public fun randomMemberData(


### PR DESCRIPTION
<!-- pr:new-feature -->

### Goal

Surface the message author's channel-member custom data, which the backend can now project onto message payloads, and keep it fresh when the membership changes. The SDK previously read only `channel_role` from `message.member` and dropped the rest.

The projection is gated by the app-level `member_custom_on_messages_enabled` toggle, off by default, so nothing changes for apps that do not enable it.

Closes [AND-1352](https://linear.app/stream/issue/AND-1352/surface-authors-channelmember-custom-on-message-payloads-member-custom)

### Implementation

- Add `MemberInfo` (`channelRole`, `notificationsMuted`, `extraData`) as `Message.member`, deprecating `Message.channelRole` in favour of `member?.channelRole`. Both stay populated.
- Persist it as `MemberInfoEntity` on the message and reply tables, replacing the `channelRole` column, and bump the DB version.
- Refresh channel state, thread replies and the repository on `member.updated`, since the backend sends no `message.updated` for a membership change. The repository write is a targeted column update, deferred under the same mutex as the message inserts.
- Drop `user_id` from the snapshot: the member DTO does not declare it, so the overflow adapter would otherwise pass it off as customer custom data.

### Testing

- Parser parity for both wire shapes and an absent member, Room round trip, targeted update scoping, and the state refresh for both channel state implementations and thread replies.
- Device verified against a live backend: projection present on a wiped database, surviving react and un-react, cleared on unset, no `message.updated` throughout.
- Send and update message responses still omit the projection server side, tracked by the backend team. Not patched here, since an absent value cannot be told apart from a removal, and `message.new` carries it anyway.

### Manual testing

The demo is already set up: the toggle is on in Nessy and `Silent Active` already has flair on two members.

1. Run the sample, log in as any user who is a member of `Silent Active`, and open it.
2. Messages from `Padmé Amidala` carry `member.extraData = {flair={tier=gold}}` and those from `C-3PO` `{tier=bronze}`; everyone else's is empty. Check `Message.member` in the debugger, or `adb logcat | grep Chat:Http | grep flair` for the wire.
3. Change a member's custom data (e.g. with the getstream cli) and confirm messages already on screen pick it up, with no refetch and no `message.updated`:

```
getstream api UpdateMemberPartial --type messaging --id sample-app-channel-8 \
  --request '{"user_id":"leandro","set":{"flair":{"tier":"silver"}}}'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MemberInfo` to messages, including channel role, notification status, and custom data.
  * Added message builder support for setting member information.
  * Added parsing support for both legacy inline and nested custom member data.

* **Bug Fixes**
  * Member updates now refresh message and thread author details in real time and offline caches.
  * Preserved compatibility with the deprecated `channelRole` field.

* **Refactor**
  * Improved persistence and synchronization of member snapshots for messages and replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->