### PR TITLE
Keep the chat preferences when mapping a channel push preference response

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -987,7 +987,7 @@ internal class DomainMapping(
     internal fun ChannelPushPreferencesResponse.toDomain(): PushPreference = PushPreference(
         level = PushPreferenceLevel.fromValue(chatLevel),
         disabledUntil = disabledUntil,
-        chatPreferences = null,
+        chatPreferences = chatPreferences?.toDomain(),
     )
 
     internal fun ChatPreferencesResponse.toDomain(): ChatPreferences = ChatPreferences(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ChannelPushPreferencesResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ChannelPushPreferencesResponse.kt
@@ -28,12 +28,14 @@ import com.squareup.moshi.Json
 /**
  *
  */
-
 @com.squareup.moshi.JsonClass(generateAdapter = true)
 internal data class ChannelPushPreferencesResponse(
     @Json(name = "chat_level")
-    val chatLevel: kotlin.String? = null,
+    internal val chatLevel: String? = null,
 
     @Json(name = "disabled_until")
-    val disabledUntil: java.util.Date? = null,
+    internal val disabledUntil: java.util.Date? = null,
+
+    @Json(name = "chat_preferences")
+    internal val chatPreferences: io.getstream.chat.android.network.models.ChatPreferencesResponse? = null,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -82,6 +82,7 @@ import io.getstream.chat.android.models.ChannelInfo
 import io.getstream.chat.android.models.ChannelMute
 import io.getstream.chat.android.models.ChannelTransformer
 import io.getstream.chat.android.models.ChannelUserRead
+import io.getstream.chat.android.models.ChatPreferenceToggle
 import io.getstream.chat.android.models.Command
 import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.Device
@@ -102,6 +103,7 @@ import io.getstream.chat.android.models.NoOpUserTransformer
 import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.PendingMessage
 import io.getstream.chat.android.models.Poll
+import io.getstream.chat.android.models.PushPreferenceLevel
 import io.getstream.chat.android.models.PushProvider
 import io.getstream.chat.android.models.QueryPollVotesResult
 import io.getstream.chat.android.models.QueryPollsResult
@@ -127,6 +129,8 @@ import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.ascByName
 import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.descByName
 import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.network.models.ChannelPushPreferencesResponse
+import io.getstream.chat.android.network.models.ChatPreferencesResponse
 import io.getstream.chat.android.network.models.UserResponse
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomChannel
@@ -137,6 +141,7 @@ import io.getstream.chat.android.randomString
 import io.getstream.chat.android.randomUser
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -1296,6 +1301,33 @@ internal class DomainMappingTest {
                 descByName<Channel>("created_at").ascByName("name"),
             ),
         )
+    }
+
+    @Test
+    fun `Channel push preferences keep their chat preferences`() {
+        val sut = Fixture().get()
+
+        val result = with(sut) {
+            ChannelPushPreferencesResponse(
+                chatLevel = "all",
+                chatPreferences = ChatPreferencesResponse(directMentions = "all", threadReplies = "none"),
+            ).toDomain()
+        }
+
+        assertEquals(PushPreferenceLevel.all, result.level)
+        assertEquals(ChatPreferenceToggle.all, result.chatPreferences?.directMentions)
+        assertEquals(ChatPreferenceToggle.none, result.chatPreferences?.threadReplies)
+    }
+
+    @Test
+    fun `Channel push preferences without chat preferences map to null`() {
+        val sut = Fixture().get()
+
+        val result = with(sut) {
+            ChannelPushPreferencesResponse(chatLevel = "all").toDomain()
+        }
+
+        assertNull(result.chatPreferences)
     }
 
     internal class Fixture {


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Channel chat preferences were dropped when reading a push preference response, so
`PushPreference.chatPreferences` was always null for a channel.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Re-vendor `ChannelPushPreferencesResponse`, which was vendored before the spec published
  `chat_preferences`, so the field was absent from the model.
- Map it instead of passing `null`.

Regressed in #6628, which is not in a release yet, so no shipped version is affected. The
hand-written `DownstreamPushPreferenceDto` carried `chat_preferences` and served both the user and
the channel level. It was replaced by two generated models, and only the user-level one kept the
field. The old DTO is still used for `ChannelResponse.push_preferences`, which is why a channel read
back through `queryChannel` had the preferences while the write response did not.

Affects `setChannelChatPreferences`, `setChannelPushPreference` and `snoozeChannelPushNotifications`.
`setChannelChatPreferences` was the worst case: a caller could not read back the toggles it had just set.

A sweep for the same pattern (a mapper filling a domain field with a literal because the model has no
source for it) turned up one older instance, filed as [AND-1391](https://linear.app/stream/issue/AND-1391/messagerestrictedvisibility-is-never-populated-when-parsing-messages). It predates this migration and is not fixed here.

### Testing

- `DomainMappingTest` covers the mapping and the null case. The first test fails without the fix.
- Device-probed on the wire: set all seven toggles on a channel with a distinct value each, then read the
  channel back through `queryChannel`, which maps the same server state through the older hand-written DTO.
  Both paths now return identical toggles; before the fix they disagreed. Also confirmed that setting a
  level clears the preferences, which is the documented behaviour, and that snoozing sets `disabled_until`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel push preference settings now correctly preserve chat-level preferences.
  * Nested chat preference toggles are accurately reflected when provided.
  * Missing chat preferences continue to be handled safely as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->