### PR TITLE
Fix CDN image resizer host matching and dimension edge cases

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
@@ -34,7 +34,7 @@ private val baseUrlRegex = "^(?:https?://)?(.*?)/*$".toRegex()
 /**
  * Matches the default Stream CDN hosts (imgix and stream-io-cdn). Shared with [AttachmentHelper] so the two
  * can't drift. Anchored on the host only — resizing of custom/proxied Stream CDN domains is opted into via the
- * `cdnHost` parameter of [createResizedStreamCdnImageUrl], mirroring iOS' `StreamCDNRequester(cdnHost:)`.
+ * `cdnHost` parameter of [createResizedStreamCdnImageUrl].
  */
 @InternalStreamChatApi
 public val STREAM_CDN_HOST_PATTERN: Regex =
@@ -44,13 +44,13 @@ public val STREAM_CDN_HOST_PATTERN: Regex =
  * Returns whether this URL is served from a Stream CDN host that understands resizing query parameters.
  *
  * @param cdnHost An optional custom Stream CDN host (e.g. a proxied domain), matched with a substring check
- * in addition to the default [STREAM_CDN_HOST_PATTERN], mirroring iOS' `StreamCDNRequester(cdnHost:)`.
+ * in addition to the default [STREAM_CDN_HOST_PATTERN]. Blank values are treated as absent.
  */
 @InternalStreamChatApi
 public fun String.isStreamCdnHosted(cdnHost: String? = null): Boolean {
     val host = this.toUri().host ?: return false
     return STREAM_CDN_HOST_PATTERN.matches(host) ||
-        (cdnHost != null && host.contains(cdnHost, ignoreCase = true))
+        (!cdnHost.isNullOrBlank() && host.contains(cdnHost, ignoreCase = true))
 }
 
 /**
@@ -161,6 +161,16 @@ public fun String.createResizedStreamCdnImageUrl(
             return this@createResizedStreamCdnImageUrl
         }
 
+        if (streamCdnImageDimensions.originalWidth <= 0 || streamCdnImageDimensions.originalHeight <= 0) {
+            logger.w {
+                "Image URL reports non-positive original dimensions " +
+                    "(${streamCdnImageDimensions.originalWidth}x${streamCdnImageDimensions.originalHeight}) " +
+                    "and was not resized."
+            }
+
+            return this@createResizedStreamCdnImageUrl
+        }
+
         val resizedWidth: Int = (streamCdnImageDimensions.originalWidth * resizedWidthPercentage).toInt()
         val resizedHeight: Int = (streamCdnImageDimensions.originalHeight * resizedHeightPercentage).toInt()
 
@@ -201,14 +211,12 @@ public fun String.createResizedStreamCdnImageUrl(
 
 /**
  * Generates a URL with Stream CDN resizing parameters that cap the image to [maxImagePixels] total
- * pixels (width × height), preserving aspect ratio and never upscaling. Mirrors the iOS SDK's
- * `imageAttachmentMaxPixels`. Only affects images served from a Stream CDN host (see [cdnHost]) that carry
- * original width (ow) and height (oh) params; any other URL, or one already at/under the budget, is
- * returned unchanged.
+ * pixels (width × height), preserving aspect ratio and never upscaling. Only affects images served from
+ * a Stream CDN host (see [cdnHost]) that carry original width (ow) and height (oh) params; any other URL,
+ * or one already at/under the budget, is returned unchanged.
  *
  * @param cdnHost An optional custom Stream CDN host to resize in addition to the default Stream CDN hosts,
- * for integrations serving Stream images from a proxied or custom domain. Mirrors iOS'
- * `StreamCDNRequester(cdnHost:)`.
+ * for integrations serving Stream images from a proxied or custom domain. Blank values are treated as absent.
  */
 public fun String.createResizedStreamCdnImageUrl(
     maxImagePixels: Long,
@@ -219,6 +227,7 @@ public fun String.createResizedStreamCdnImageUrl(
     if (maxImagePixels <= 0L) return this
     if (!isStreamCdnHosted(cdnHost)) return this
     val dimensions = getStreamCdnHostedImageDimensions() ?: return this
+    // Short-circuits before the scale maths; the percentage overload holds the enforcing guard for both entry points.
     if (dimensions.originalWidth <= 0 || dimensions.originalHeight <= 0) return this
     val totalPixels = dimensions.originalWidth.toLong() * dimensions.originalHeight.toLong()
     if (totalPixels <= maxImagePixels) return this

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
@@ -43,18 +43,14 @@ public val STREAM_CDN_HOST_PATTERN: Regex =
 /**
  * Returns whether this URL is served from a Stream CDN host that understands resizing query parameters.
  *
- * @param cdnHost An optional custom Stream CDN host (e.g. a proxied domain). When provided, the URL host is
- * matched against it with a substring check, mirroring iOS' `StreamCDNRequester(cdnHost:)`; when null, the
- * default [STREAM_CDN_HOST_PATTERN] is used.
+ * @param cdnHost An optional custom Stream CDN host (e.g. a proxied domain), matched with a substring check
+ * in addition to the default [STREAM_CDN_HOST_PATTERN], mirroring iOS' `StreamCDNRequester(cdnHost:)`.
  */
 @InternalStreamChatApi
 public fun String.isStreamCdnHosted(cdnHost: String? = null): Boolean {
     val host = this.toUri().host ?: return false
-    return if (cdnHost != null) {
-        host.contains(cdnHost, ignoreCase = true)
-    } else {
-        STREAM_CDN_HOST_PATTERN.matches(host)
-    }
+    return STREAM_CDN_HOST_PATTERN.matches(host) ||
+        (cdnHost != null && host.contains(cdnHost, ignoreCase = true))
 }
 
 /**
@@ -223,8 +219,9 @@ public fun String.createResizedStreamCdnImageUrl(
     if (maxImagePixels <= 0L) return this
     if (!isStreamCdnHosted(cdnHost)) return this
     val dimensions = getStreamCdnHostedImageDimensions() ?: return this
+    if (dimensions.originalWidth <= 0 || dimensions.originalHeight <= 0) return this
     val totalPixels = dimensions.originalWidth.toLong() * dimensions.originalHeight.toLong()
-    if (totalPixels <= 0L || totalPixels <= maxImagePixels) return this
+    if (totalPixels <= maxImagePixels) return this
     val scale = sqrt(maxImagePixels.toDouble() / totalPixels.toDouble()).toFloat()
     return createResizedStreamCdnImageUrl(
         resizedWidthPercentage = scale,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/StringExtensionsKtTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/StringExtensionsKtTest.kt
@@ -230,7 +230,7 @@ internal class StringExtensionsKtTest {
         // Not a known Stream host, so no resizing by default.
         customHostUrl.createResizedStreamCdnImageUrl(maxImagePixels = 2_000_000L) shouldBeEqualTo customHostUrl
 
-        // Opting the custom/proxied host in resizes it (iOS StreamCDNRequester(cdnHost:) parity).
+        // Opting the custom/proxied host in resizes it.
         val resized = customHostUrl.createResizedStreamCdnImageUrl(
             maxImagePixels = 2_000_000L,
             cdnHost = "images.example.com",

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/StringExtensionsKtTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/StringExtensionsKtTest.kt
@@ -254,9 +254,55 @@ internal class StringExtensionsKtTest {
 
     @Test
     fun `Given non-positive original dimensions Should return the url unchanged`() {
-        val negativeDimsUrl = createStreamCdnImageLink(originalWidth = -4000, originalHeight = -2000)
+        val nonPositiveDimensions = listOf(
+            -4000 to -2000, // Both negative - a positive product, missed by the old total-pixel check.
+            -4000 to 2000,
+            4000 to -2000,
+            0 to 2000,
+            4000 to 0,
+            0 to 0,
+        )
 
-        negativeDimsUrl.createResizedStreamCdnImageUrl(maxImagePixels = 2_000_000L) shouldBeEqualTo negativeDimsUrl
+        nonPositiveDimensions.forEach { (width, height) ->
+            val url = createStreamCdnImageLink(originalWidth = width, originalHeight = height)
+
+            url.createResizedStreamCdnImageUrl(maxImagePixels = 2_000_000L) shouldBeEqualTo url
+        }
+    }
+
+    @Test
+    fun `Given non-positive original dimensions Should return the url unchanged from the percentage overload`() {
+        val nonPositiveDimensions = listOf(
+            -4000 to -2000,
+            -4000 to 2000,
+            4000 to -2000,
+            0 to 2000,
+            4000 to 0,
+            0 to 0,
+        )
+
+        nonPositiveDimensions.forEach { (width, height) ->
+            val url = createStreamCdnImageLink(originalWidth = width, originalHeight = height)
+
+            url.createResizedStreamCdnImageUrl(
+                resizedWidthPercentage = 0.5f,
+                resizedHeightPercentage = 0.5f,
+            ) shouldBeEqualTo url
+        }
+    }
+
+    @Test
+    fun `Given a blank custom cdn host Should not resize an off-cdn url`() {
+        val offCdnUrl = "https://images.example.org/photo.jpg?oh=2000&ow=4000"
+
+        offCdnUrl.createResizedStreamCdnImageUrl(
+            maxImagePixels = 2_000_000L,
+            cdnHost = "",
+        ) shouldBeEqualTo offCdnUrl
+        offCdnUrl.createResizedStreamCdnImageUrl(
+            maxImagePixels = 2_000_000L,
+            cdnHost = "   ",
+        ) shouldBeEqualTo offCdnUrl
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/StringExtensionsKtTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/StringExtensionsKtTest.kt
@@ -240,6 +240,26 @@ internal class StringExtensionsKtTest {
     }
 
     @Test
+    fun `custom cdn host matching is additive - default Stream hosts still resize`() {
+        val streamUrl = createStreamCdnImageLink(originalWidth = 4000, originalHeight = 2000)
+
+        // With a custom host configured, default Stream CDN images must still be resized.
+        val resized = streamUrl.createResizedStreamCdnImageUrl(
+            maxImagePixels = 2_000_000L,
+            cdnHost = "images.example.com",
+        )
+        (resized != streamUrl) shouldBeEqualTo true
+        (resized.toUri().getQueryParameter(QUERY_PARAMETER_KEY_RESIZED_WIDTH) != null) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `Given non-positive original dimensions Should return the url unchanged`() {
+        val negativeDimsUrl = createStreamCdnImageLink(originalWidth = -4000, originalHeight = -2000)
+
+        negativeDimsUrl.createResizedStreamCdnImageUrl(maxImagePixels = 2_000_000L) shouldBeEqualTo negativeDimsUrl
+    }
+
+    @Test
     fun `Given a non-positive max pixel budget Should return the url unchanged`() {
         val originalUrl = createStreamCdnImageLink(originalWidth = 4000, originalHeight = 2000)
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -353,7 +353,7 @@ private val LocalMediaGalleryConfig = compositionLocalOf<MediaGalleryConfig> {
  * set [StreamCdnImageResizing.imageResizingEnabled] to true if you wish to enable resizing images. Note that resizing
  * applies only to images hosted on Stream's CDN which contain the original height (oh) and width (ow) query parameters.
  * @param streamCdnImageResizer Sets the strategy for resizing images hosted on Stream's CDN. Defaults to a
- * [StreamCdnMaxPixelsImageResizer] capping images to 2MP, mirroring the iOS SDK. Set it to
+ * [StreamCdnMaxPixelsImageResizer] capping images to 2MP. Set it to
  * [io.getstream.chat.android.ui.common.images.resizing.NoOpStreamCdnImageResizer] to disable resizing.
  * @param ownMessageTheme Theme of the current user messages.
  * @param otherMessageTheme Theme of the other users messages.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizer.kt
@@ -25,7 +25,7 @@ import io.getstream.chat.android.models.streamcdn.image.StreamCdnResizeImageMode
  * full-resolution originals. It is applied to image attachment URLs by the Compose and XML UI kits and
  * configured via `ChatTheme(streamCdnImageResizer = …)` / `ChatUI.streamCdnImageResizer`.
  *
- * Resizing is on by default at a 2MP cap ([StreamCdnMaxPixelsImageResizer]), matching the iOS SDK. Provide
+ * Resizing is on by default at a 2MP cap ([StreamCdnMaxPixelsImageResizer]). Provide
  * [NoOpStreamCdnImageResizer] to opt out, or implement this interface to apply a custom resizing strategy.
  * Only Stream CDN hosted URLs that carry the original dimensions are affected; any other URL is returned
  * unchanged.
@@ -35,7 +35,7 @@ public fun interface StreamCdnImageResizer {
     public fun resizeUrl(imageUrl: String): String
 
     public companion object {
-        /** Total-pixel budget matching the iOS SDK default (2MP). */
+        /** The default total-pixel budget (2MP). */
         public const val DEFAULT_MAX_IMAGE_PIXELS: Long = 2_000_000L
     }
 }
@@ -47,8 +47,7 @@ public fun interface StreamCdnImageResizer {
  * @param resizeMode The Stream CDN resize mode, or null for the CDN default.
  * @param cropMode The Stream CDN crop mode, or null for the CDN default.
  * @param cdnHost An optional custom Stream CDN host to resize in addition to the default Stream CDN hosts,
- * for integrations serving Stream images from a proxied or custom domain. Mirrors iOS'
- * `StreamCDNRequester(cdnHost:)`.
+ * for integrations serving Stream images from a proxied or custom domain. Blank values are treated as absent.
  */
 public class StreamCdnMaxPixelsImageResizer(
     private val maxImagePixels: Long = StreamCdnImageResizer.DEFAULT_MAX_IMAGE_PIXELS,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing.kt
@@ -36,7 +36,7 @@ import io.getstream.chat.android.models.streamcdn.image.StreamCdnResizeImageMode
  */
 @Deprecated(
     "Configure image resizing via a StreamCdnImageResizer — the default StreamCdnMaxPixelsImageResizer caps " +
-        "images to 2MP (iOS parity), or provide your own StreamCdnImageResizer. This percentage-based config is " +
+        "images to 2MP, or provide your own StreamCdnImageResizer. This percentage-based config is " +
         "only honored while enabled and will be removed in the next major version.",
 )
 public data class StreamCdnImageResizing(
@@ -57,7 +57,7 @@ public data class StreamCdnImageResizing(
          */
         @Deprecated(
             "Configure image resizing via a StreamCdnImageResizer — the default StreamCdnMaxPixelsImageResizer " +
-                "caps images to 2MP (iOS parity), or provide your own StreamCdnImageResizer. This percentage-based " +
+                "caps images to 2MP, or provide your own StreamCdnImageResizer. This percentage-based " +
                 "config will be removed in the next major version.",
         )
         @Suppress("DEPRECATION")

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -263,8 +263,8 @@ public object ChatUI {
      */
     @Deprecated(
         "Use streamCdnImageResizer (defaults to a StreamCdnMaxPixelsImageResizer capping images to 2MP). " +
-            "For custom behavior, provide your own StreamCdnImageResizer.",
-        ReplaceWith("streamCdnImageResizer"),
+            "For custom behavior, provide your own StreamCdnImageResizer. This percentage-based config has no " +
+            "one-token replacement — migrate manually.",
     )
     @JvmStatic
     public var streamCdnImageResizing: StreamCdnImageResizing = StreamCdnImageResizing.defaultStreamCdnImageResizing()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -271,7 +271,7 @@ public object ChatUI {
 
     /**
      * Sets the strategy for resizing images hosted on Stream's CDN. Defaults to a [StreamCdnMaxPixelsImageResizer]
-     * capping images to 2MP, mirroring the iOS SDK. Set it to [NoOpStreamCdnImageResizer] to disable resizing. Note
+     * capping images to 2MP. Set it to [NoOpStreamCdnImageResizer] to disable resizing. Note
      * that resizing applies only to images hosted on Stream's CDN which contain the original width (ow) and height (oh)
      * query parameters.
      */


### PR DESCRIPTION
### Goal

Refs [AND-1393](https://linear.app/stream/issue/AND-1393/cdn-image-resizer-review-follow-up-host-match-negative-dims) — backport of #6640 to `v6`. Follow-up correctness fixes for the CDN image resizer (backported in #6633), from code review.

### Implementation

- `isStreamCdnHosted` now matches the default `STREAM_CDN_HOST_PATTERN` **or** a custom `cdnHost` (additive), matching its KDoc — a custom host no longer disables resizing of default Stream CDN images. Blank `cdnHost` values are treated as absent, since `String.contains("")` is always `true` and an explicit `cdnHost = ""` otherwise resized off-CDN URLs carrying `ow`/`oh`.
- The non-positive dimension guard now lives in the **percentage** overload rather than the `maxImagePixels` one. Both overloads are public, and the percentage overload computed `originalWidth * percentage` unchecked, so a direct call on a URL with `ow=-4000` still appended a negative `w`. `maxImagePixels` delegates to it, so one guard now covers both entry points; the `maxImagePixels` path keeps an early return to skip the scale maths.
- Removed the invalid `@Deprecated` `ReplaceWith("streamCdnImageResizer")` on `ChatUI.streamCdnImageResizing` (it generated uncompilable code — a `StreamCdnImageResizing` value assigned to a `StreamCdnImageResizer` property); documented manual migration instead.
- Dropped **every** iOS reference from the resizer's public surface, not just the `StreamCDNRequester(cdnHost:)` one flagged in review: `StreamCdnImageResizer` (interface KDoc + `DEFAULT_MAX_IMAGE_PIXELS` + `StreamCdnMaxPixelsImageResizer`), `ChatTheme`, `ChatUI`, and the two `StreamCdnImageResizing` **deprecation messages**, which surfaced "iOS parity" straight into the IDE. See the parity note below.

### Testing

Client tests: additive host (a default Stream CDN URL still resizes when a custom `cdnHost` is set); blank/whitespace `cdnHost` does not resize an off-CDN URL; non-positive original dimensions via **both** overloads, covering zero, one-negative, and both-negative (the old `totalPixels <= 0` check caught zero and single-negative, so those were unpinned once it was replaced).

Both new guards were verified red before the fix — reverting the blank-host check appends `&w=2000&h=1000` to an off-CDN URL, and removing the percentage-overload guard appends `&w=-2000&h=-1000`.

`spotlessApply`, `detekt`, `apiDump` (no `.api` change), and `StringExtensionsKtTest` (18 tests) all green.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image resizing now works correctly for default Stream CDN URLs even when a custom CDN host is configured.
  - Images with invalid or non-positive dimensions are left unchanged instead of being resized incorrectly.

- **Documentation**
  - Updated the deprecation guidance for percentage-based image resizing to clarify that manual migration is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
