### PR TITLE
Prevent markRead when the last message is a server-rejected local-only echo

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -209,6 +209,15 @@ public fun Message.isModerationError(currentUserId: String?): Boolean = isMine(c
     (isError() && isModerationBounce())
 
 /**
+ * @return If the message exists only on this client and is not persisted server-side: it is
+ * still in flight, failed to send, or has a type the server never persists (ephemeral previews,
+ * error messages such as rejected or moderation-bounced sends).
+ */
+@InternalStreamChatApi
+public fun Message.isLocalOnly(): Boolean =
+    syncStatus != SyncStatus.COMPLETED || isEphemeral() || isError()
+
+/**
  * Checks whether we should attempt to delete the message remotely.
  *
  * @param currentUserId The ID of the currently logged in user.

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
@@ -39,6 +39,9 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.Date
 
 @ExperimentalCoroutinesApi
@@ -666,5 +669,32 @@ internal class MessageUtilsTest {
         )
         val result = message.shouldDeleteRemote(randomString())
         assertTrue(result is Result.Success)
+    }
+
+    /** [isLocalOnlyArguments] */
+    @ParameterizedTest
+    @MethodSource("isLocalOnlyArguments")
+    fun `isLocalOnly returns whether the message exists only locally`(
+        syncStatus: SyncStatus,
+        type: String,
+        expected: Boolean,
+    ) {
+        val message = randomMessage(syncStatus = syncStatus, type = type)
+        message.isLocalOnly() shouldBeEqualTo expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun isLocalOnlyArguments() = listOf(
+            Arguments.of(SyncStatus.SYNC_NEEDED, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.IN_PROGRESS, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.AWAITING_ATTACHMENTS, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.FAILED_PERMANENTLY, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.EPHEMERAL, true),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.ERROR, true),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.REGULAR, false),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.SYSTEM, false),
+        )
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
@@ -671,7 +671,6 @@ internal class MessageUtilsTest {
         assertTrue(result is Result.Success)
     }
 
-    /** [isLocalOnlyArguments] */
     @ParameterizedTest
     @MethodSource("isLocalOnlyArguments")
     fun `isLocalOnly returns whether the message exists only locally`(

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -740,8 +740,7 @@ public class MessageComposerController(
                 message.copy(showInChannel = isInThread && alsoSendToChannel.value),
             ).doOnResult(scope) { result ->
                 result.onSuccessSuspend { resultMessage ->
-                    // A local-only echo (e.g. a rejected send into a frozen channel) has no
-                    // server-side message to mark read.
+                    // A successful send can still be a local-only echo the server refused to persist.
                     if (!resultMessage.isLocalOnly() &&
                         channelState.value?.channelConfig?.value?.markMessagesPending == false
                     ) {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.ui.common.feature.messages.composer
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.client.utils.message.isLocalOnly
 import io.getstream.chat.android.client.utils.message.isModerationError
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
@@ -739,7 +740,11 @@ public class MessageComposerController(
                 message.copy(showInChannel = isInThread && alsoSendToChannel.value),
             ).doOnResult(scope) { result ->
                 result.onSuccessSuspend { resultMessage ->
-                    if (channelState.value?.channelConfig?.value?.markMessagesPending == false) {
+                    // A local-only echo (e.g. a rejected send into a frozen channel) has no
+                    // server-side message to mark read.
+                    if (!resultMessage.isLocalOnly() &&
+                        channelState.value?.channelConfig?.value?.markMessagesPending == false
+                    ) {
                         chatClient.markMessageRead(
                             channelType = channelType,
                             channelId = channelId,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -32,6 +32,7 @@ import io.getstream.chat.android.client.utils.attachment.isAudioRecording
 import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.client.utils.message.isError
 import io.getstream.chat.android.client.utils.message.isGiphy
+import io.getstream.chat.android.client.utils.message.isLocalOnly
 import io.getstream.chat.android.client.utils.message.isModerationBounce
 import io.getstream.chat.android.client.utils.message.isModerationError
 import io.getstream.chat.android.client.utils.message.isSystem
@@ -54,7 +55,6 @@ import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.PollOption
 import io.getstream.chat.android.models.Reaction
-import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.state.extensions.awaitRepliesAsState
@@ -1725,13 +1725,14 @@ public class MessageListController(
         val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
 
-        // Skip when our own message is at the bottom and hasn't been confirmed by the server.
-        // Without this, marking read on an empty channel (only an in-flight optimistic message
-        // exists) causes the server to persist last_read_message_id = "" because its view of
-        // the channel is empty.
+        // Skip when our own message is at the bottom and the server doesn't have it: still in
+        // flight, or persisted locally but rejected by the server (e.g. a send into a frozen
+        // channel returns 201 with a type "error" echo stored as COMPLETED). Without this,
+        // marking read on a channel the server sees as empty makes it emit message.read with
+        // no last_read_message_id.
         val currentUserId = clientState.user.value?.id
-        if (message != null && message.user.id == currentUserId && message.syncStatus != SyncStatus.COMPLETED) {
-            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own unsynced): $messageId" }
+        if (message != null && message.user.id == currentUserId && message.isLocalOnly()) {
+            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own local-only): $messageId" }
             return
         }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1725,11 +1725,8 @@ public class MessageListController(
         val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
 
-        // Skip when our own message is at the bottom and the server doesn't have it: still in
-        // flight, or persisted locally but rejected by the server (e.g. a send into a frozen
-        // channel returns 201 with a type "error" echo stored as COMPLETED). Without this,
-        // marking read on a channel the server sees as empty makes it emit message.read with
-        // no last_read_message_id.
+        // Marking read while our own local-only message is at the bottom makes a channel the
+        // server sees as empty emit message.read with no last_read_message_id.
         val currentUserId = clientState.user.value?.id
         if (message != null && message.user.id == currentUserId && message.isLocalOnly()) {
             logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own local-only): $messageId" }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTests.kt
@@ -29,9 +29,14 @@ import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.FileUploadConfig
 import io.getstream.chat.android.models.Member
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.MessageType
+import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.state.plugin.state.global.GlobalState
 import io.getstream.chat.android.test.TestCoroutineExtension
+import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.ui.common.feature.messages.composer.internal.ComposerStateSaver
 import io.getstream.chat.android.ui.common.feature.messages.composer.internal.NoOpComposerStateSaver
 import io.getstream.chat.android.ui.common.feature.messages.composer.mention.Mention
@@ -40,6 +45,7 @@ import io.getstream.chat.android.ui.common.state.messages.MessageInput
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should be equal to`
@@ -48,8 +54,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
 import java.util.Date
@@ -288,6 +297,11 @@ internal class MessageComposerControllerTests {
             whenever(globalState.threadDraftMessages) doReturn MutableStateFlow(threadDrafts)
         }
 
+        fun givenSendMessage(message: Message) = apply {
+            whenever(chatClient.sendMessage(any(), any(), any(), any())) doReturn message.asCall()
+            whenever(chatClient.markMessageRead(any(), any(), any())) doReturn Unit.asCall()
+        }
+
         fun get(
             stateSaver: ComposerStateSaver = NoOpComposerStateSaver,
             config: MessageComposerController.Config = MessageComposerController.Config(),
@@ -424,6 +438,51 @@ internal class MessageComposerControllerTests {
 
         assertTrue(store.cleared)
     }
+
+    // endregion
+
+    // region Post-send mark read
+
+    @Test
+    fun `Given markMessagesPending disabled When sent message is confirmed Then markMessageRead is invoked`() =
+        runTest {
+            val chatClient: ChatClient = mock()
+            val echo = randomMessage(cid = CID, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED)
+            val controller = Fixture(chatClient = chatClient)
+                .givenAppSettings(mock())
+                .givenAudioPlayer(mock())
+                .givenClientState(User("uid1"))
+                .givenGlobalState()
+                .givenChannelState()
+                .givenSendMessage(echo)
+                .get()
+
+            controller.sendMessage(Message(cid = CID, text = "Hello"), mock())
+            advanceUntilIdle()
+
+            verify(chatClient).markMessageRead(CHANNEL_TYPE, CHANNEL_ID, echo.id)
+        }
+
+    @Test
+    fun `Given markMessagesPending disabled When send returns a rejected error echo Then markMessageRead is not invoked`() =
+        runTest {
+            // A send into a frozen channel returns 201 with a type "error" echo the server never persists.
+            val chatClient: ChatClient = mock()
+            val echo = randomMessage(cid = CID, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED)
+            val controller = Fixture(chatClient = chatClient)
+                .givenAppSettings(mock())
+                .givenAudioPlayer(mock())
+                .givenClientState(User("uid1"))
+                .givenGlobalState()
+                .givenChannelState()
+                .givenSendMessage(echo)
+                .get()
+
+            controller.sendMessage(Message(cid = CID, text = "Hello"), mock())
+            advanceUntilIdle()
+
+            verify(chatClient, never()).markMessageRead(any(), any(), any())
+        }
 
     // endregion
 

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTests.kt
@@ -464,6 +464,26 @@ internal class MessageComposerControllerTests {
         }
 
     @Test
+    fun `Given markMessagesPending enabled When sent message is confirmed Then markMessageRead is not invoked`() =
+        runTest {
+            val chatClient: ChatClient = mock()
+            val echo = randomMessage(cid = CID, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED)
+            val controller = Fixture(chatClient = chatClient)
+                .givenAppSettings(mock())
+                .givenAudioPlayer(mock())
+                .givenClientState(User("uid1"))
+                .givenGlobalState()
+                .givenChannelState(configState = MutableStateFlow(Config(markMessagesPending = true)))
+                .givenSendMessage(echo)
+                .get()
+
+            controller.sendMessage(Message(cid = CID, text = "Hello"), mock())
+            advanceUntilIdle()
+
+            verify(chatClient, never()).markMessageRead(any(), any(), any())
+        }
+
+    @Test
     fun `Given markMessagesPending disabled When send returns a rejected error echo Then markMessageRead is not invoked`() =
         runTest {
             // A send into a frozen channel returns 201 with a type "error" echo the server never persists.

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -418,6 +418,79 @@ internal class MessageListControllerTests {
     }
 
     @Test
+    fun `When current user's last message is a rejected error echo markLastMessageRead should not invoke markRead`() =
+        runTest {
+            // A send into a frozen channel returns 201 with a type "error" echo which is stored
+            // as COMPLETED, but the server never persists it. The peer message makes sure the
+            // error one is the item the gate sees, and not filtered out.
+            val chatClient: ChatClient = mock()
+            val messagesState = MutableStateFlow(
+                listOf(
+                    randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+                    randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
+                ),
+            )
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser()
+                .givenChannelQuery()
+                .givenMarkRead()
+                .givenChannelState(messagesState = messagesState)
+                .get()
+
+            controller.markLastMessageRead()
+            delay(1000)
+
+            verify(chatClient, times(0)).markRead(any(), any())
+            controller.lastSeenMessageId.shouldBeNull()
+        }
+
+    @Test
+    fun `When current user's last message is ephemeral markLastMessageRead should not invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "2", user = user1, type = MessageType.EPHEMERAL, syncStatus = SyncStatus.COMPLETED),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
+    fun `When an error message is followed by a synced one markLastMessageRead should invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "2", user = user1, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "2"
+    }
+
+    @Test
     fun `When peer's last message is not COMPLETED markLastMessageRead should still invoke markRead`() = runTest {
         // syncStatus is local-only and not on the wire. Peer messages inherit the data
         // class default — the gate must not block them on that.

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -468,6 +468,23 @@ internal class MessageListControllerTests {
     }
 
     @Test
+    fun `When the message list is empty markLastMessageRead should not invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = MutableStateFlow(emptyList()))
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
     fun `When an error message is followed by a synced one markLastMessageRead should invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Sending into a frozen channel returns 201 with the message echoed back as `type: "error"`, which the SDK stores as `COMPLETED` while the server persists nothing. The mark-read guard from #6431 only checks `syncStatus != COMPLETED`, so every subsequent channel open calls `markRead` on a channel the server sees as empty, emitting `message.read` events with no `last_read_message_id` (customer-escalated). Aligns with the iOS fix in [stream-chat-swiftui#1452](https://github.com/GetStream/stream-chat-swiftui/pull/1452).

Closes [AND-1395](https://linear.app/stream/issue/AND-1395/mark-read-fires-on-server-rejected-message-echoes-emitting-messageread)

### Implementation

- Add `Message.isLocalOnly()` (`@InternalStreamChatApi`): not yet synced, or a type the server never persists (error, ephemeral). Matches iOS `ChatMessage.isLocalOnly`.
- `MessageListController.markLastMessageReadInternal`: widen the own-message guard from `syncStatus != COMPLETED` to `isLocalOnly()`. The guard returns before updating `lastSeenMessageId`, so mark-read recovers naturally once a real message arrives.
- `MessageComposerController.enqueueSendMessage`: skip the post-send `markMessageRead` when the echoed message is local-only, since its id doesn't exist server side.

### Testing

- Unit tests: error/ephemeral last message doesn't mark read (with a peer message underneath so filtering can't make the test pass vacuously), a synced message after an error one still marks read, post-send `markMessageRead` skipped for an error echo, `isLocalOnly()` truth table.
- Verified on device against a real frozen channel: before the fix each channel open fired `POST /read {"message_id":""}` and the server emitted `message.read` without `last_read_message_id`; after the fix the guard rejects the echo and no call is made.


#### Manual testing steps

1. Create a frozen channel with the logged-in user as its only member and no messages, e.g. with the Stream CLI:
   ```
   getstream api chat GetOrCreateChannel --type messaging --id frozen-test \
     --request '{"data":{"created_by_id":"<user-id>","frozen":true,"members":[{"user_id":"<user-id>"}]}}'
   ```
2. Send a message into it with `ChatClient.instance().sendMessage(...)` from a temporary debug button (the UI blocks the composer on frozen channels). The call succeeds and the result is the echo with `type: "error"` and `syncStatus: COMPLETED`.
3. Open the channel a few times, watching logcat with tag `MessageListController` and the HTTP log.
4. Without the fix, each open fires `POST /channels/.../read` with `{"message_id":""}` and the server emits `message.read` with no `last_read_message_id`. With the fix, each open logs `[markLastMessageRead] ... rejected (own local-only)` and makes no call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-status handling for locally generated, ephemeral, and failed messages.
  * Prevented error and pending messages from being incorrectly marked as read.
  * Ensured confirmed messages are marked read according to channel settings.
* **Tests**
  * Added coverage for message synchronization states, error echoes, ephemeral messages, empty lists, and confirmed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
