### PR TITLE
Prevent markRead when the last message is a server-rejected local-only echo

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -254,9 +254,9 @@ internal fun DraftMessage.ensureId(): DraftMessage =
 internal fun fallbackMessageId(): String = UUID.randomUUID().toString().lowercase()
 
 /**
- * @return If the message is not part of the server's message list: it is not synced yet, or has a
- * type the server leaves out of message queries and read state (ephemeral previews, error messages
- * such as rejected or moderation-bounced sends).
+ * @return If the message is not part of the server's message list: it is unsynced, or has a type
+ * the server leaves out of message queries and read state (ephemeral previews, error messages such
+ * as rejected or moderation-bounced sends).
  */
 @InternalStreamChatApi
 public fun Message.isLocalOnly(): Boolean =

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -254,9 +254,9 @@ internal fun DraftMessage.ensureId(): DraftMessage =
 internal fun fallbackMessageId(): String = UUID.randomUUID().toString().lowercase()
 
 /**
- * @return If the message exists only on this client and is not persisted server-side: it is
- * still in flight, failed to send, or has a type the server never persists (ephemeral previews,
- * error messages such as rejected or moderation-bounced sends).
+ * @return If the message is not part of the server's message list: it is not synced yet, or has a
+ * type the server leaves out of message queries and read state (ephemeral previews, error messages
+ * such as rejected or moderation-bounced sends).
  */
 @InternalStreamChatApi
 public fun Message.isLocalOnly(): Boolean =

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -254,20 +254,12 @@ internal fun DraftMessage.ensureId(): DraftMessage =
 internal fun fallbackMessageId(): String = UUID.randomUUID().toString().lowercase()
 
 /**
- * Returns true if this message is local-only and must be preserved across server message
- * window replacements. Local-only messages are never returned by the server after the
- * initial send attempt completes.
- *
- * Covers:
- * - Pending sends: SYNC_NEEDED, IN_PROGRESS
- * - Attachment upload in-flight: AWAITING_ATTACHMENTS
- * - Send failed: FAILED_PERMANENTLY (user must see to retry or dismiss)
- * - Ephemeral: type == "ephemeral" (e.g. Giphy previews — not re-delivered by server)
- * - Error type: type == "error" (client-generated, not re-delivered by server)
- *
- * DOES NOT include COMPLETED messages — those are already in the server response.
+ * @return If the message exists only on this client and is not persisted server-side: it is
+ * still in flight, failed to send, or has a type the server never persists (ephemeral previews,
+ * error messages such as rejected or moderation-bounced sends).
  */
-internal fun Message.isLocalOnly(): Boolean =
+@InternalStreamChatApi
+public fun Message.isLocalOnly(): Boolean =
     syncStatus in LocalOnlySyncStatuses || type in LocalOnlyMessageTypes
 
 internal val LocalOnlySyncStatuses = setOf(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
@@ -37,9 +37,11 @@ import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.Date
 
 internal class MessageUtilsTest {
@@ -564,52 +566,16 @@ internal class MessageUtilsTest {
         Assertions.assertTrue(UuidRegex.matches(draftWithId.id))
     }
 
-    @Test
-    fun `isLocalOnly returns true for SyncStatus SYNC_NEEDED`() {
-        val message = randomMessage(syncStatus = SyncStatus.SYNC_NEEDED, type = MessageType.REGULAR)
-        assertTrue(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns true for SyncStatus IN_PROGRESS`() {
-        val message = randomMessage(syncStatus = SyncStatus.IN_PROGRESS, type = MessageType.REGULAR)
-        assertTrue(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns true for SyncStatus AWAITING_ATTACHMENTS`() {
-        val message = randomMessage(syncStatus = SyncStatus.AWAITING_ATTACHMENTS, type = MessageType.REGULAR)
-        assertTrue(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns true for SyncStatus FAILED_PERMANENTLY`() {
-        val message = randomMessage(syncStatus = SyncStatus.FAILED_PERMANENTLY, type = MessageType.REGULAR)
-        assertTrue(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns true for type ephemeral with COMPLETED syncStatus`() {
-        val message = randomMessage(syncStatus = SyncStatus.COMPLETED, type = MessageType.EPHEMERAL)
-        assertTrue(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns true for type error with COMPLETED syncStatus`() {
-        val message = randomMessage(syncStatus = SyncStatus.COMPLETED, type = MessageType.ERROR)
-        assertTrue(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns false for SyncStatus COMPLETED with type regular`() {
-        val message = randomMessage(syncStatus = SyncStatus.COMPLETED, type = MessageType.REGULAR)
-        assertFalse(message.isLocalOnly())
-    }
-
-    @Test
-    fun `isLocalOnly returns false for system message with COMPLETED`() {
-        val message = randomMessage(syncStatus = SyncStatus.COMPLETED, type = MessageType.SYSTEM)
-        assertFalse(message.isLocalOnly())
+    /** [isLocalOnlyArguments] */
+    @ParameterizedTest
+    @MethodSource("isLocalOnlyArguments")
+    fun `isLocalOnly returns whether the message exists only locally`(
+        syncStatus: SyncStatus,
+        type: String,
+        expected: Boolean,
+    ) {
+        val message = randomMessage(syncStatus = syncStatus, type = type)
+        message.isLocalOnly() shouldBeEqualTo expected
     }
 
     @Test
@@ -694,9 +660,21 @@ internal class MessageUtilsTest {
         assertTrue(result is Result.Success)
     }
 
-    private companion object {
+    companion object {
 
         // Regex matching lowercase UUID format
         private val UuidRegex = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".toRegex()
+
+        @JvmStatic
+        fun isLocalOnlyArguments() = listOf(
+            Arguments.of(SyncStatus.SYNC_NEEDED, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.IN_PROGRESS, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.AWAITING_ATTACHMENTS, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.FAILED_PERMANENTLY, MessageType.REGULAR, true),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.EPHEMERAL, true),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.ERROR, true),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.REGULAR, false),
+            Arguments.of(SyncStatus.COMPLETED, MessageType.SYSTEM, false),
+        )
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
@@ -566,7 +566,6 @@ internal class MessageUtilsTest {
         Assertions.assertTrue(UuidRegex.matches(draftWithId.id))
     }
 
-    /** [isLocalOnlyArguments] */
     @ParameterizedTest
     @MethodSource("isLocalOnlyArguments")
     fun `isLocalOnly returns whether the message exists only locally`(

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -884,8 +884,7 @@ public class MessageComposerController(
             .doOnStart(scope) { loadLatestMessagesIfNeeded() }
             .doOnResult(scope) { result ->
                 result.onSuccessSuspend { resultMessage ->
-                    // A local-only echo (e.g. a rejected send into a frozen channel) has no
-                    // server-side message to mark read.
+                    // A successful send can still be a local-only echo the server refused to persist.
                     if (!resultMessage.isLocalOnly() &&
                         channelState.value?.channelConfig?.value?.markMessagesPending == false
                     ) {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.client.api.state.globalStateFlow
 import io.getstream.chat.android.client.api.state.loadNewestMessages
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.client.utils.message.isLocalOnly
 import io.getstream.chat.android.client.utils.message.isModerationError
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
@@ -883,7 +884,11 @@ public class MessageComposerController(
             .doOnStart(scope) { loadLatestMessagesIfNeeded() }
             .doOnResult(scope) { result ->
                 result.onSuccessSuspend { resultMessage ->
-                    if (channelState.value?.channelConfig?.value?.markMessagesPending == false) {
+                    // A local-only echo (e.g. a rejected send into a frozen channel) has no
+                    // server-side message to mark read.
+                    if (!resultMessage.isLocalOnly() &&
+                        channelState.value?.channelConfig?.value?.markMessagesPending == false
+                    ) {
                         chatClient.markMessageRead(
                             channelType = channelType,
                             channelId = channelId,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.client.utils.message.isError
 import io.getstream.chat.android.client.utils.message.isGiphy
 import io.getstream.chat.android.client.utils.message.isLocalOnly
+import io.getstream.chat.android.client.utils.message.isMine
 import io.getstream.chat.android.client.utils.message.isModerationBounce
 import io.getstream.chat.android.client.utils.message.isModerationError
 import io.getstream.chat.android.client.utils.message.isSystem
@@ -1751,19 +1752,20 @@ public class MessageListController(
      * Marks that the last message in the list as read. This also sets the unread count to 0.
      */
     private fun markLastMessageReadInternal() {
-        val itemState = messagesState.messageItems.lastOrNull { messageItem ->
-            messageItem is HasMessageListItemState
-        } as? HasMessageListItemState
-        val message = itemState?.message
+        val messageItems = messagesState.messageItems.filterIsInstance<HasMessageListItemState>()
+        val message = messageItems.lastOrNull()?.message
         val messageId = message?.id
         val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
 
-        // Marking read while our own local-only message is at the bottom makes a channel the
-        // server sees as empty emit message.read with no last_read_message_id.
+        // The server keeps our own local-only messages out of its read state, so marking read
+        // without any other message makes it emit message.read with no last_read_message_id.
         val currentUserId = clientState.user.value?.id
-        if (message != null && message.user.id == currentUserId && message.isLocalOnly()) {
-            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own local-only): $messageId" }
+        val hasServerSideMessage = messageItems.any { item ->
+            !(item.message.isMine(currentUserId) && item.message.isLocalOnly())
+        }
+        if (!hasServerSideMessage) {
+            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (no server-side message)" }
             return
         }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -43,6 +43,7 @@ import io.getstream.chat.android.client.utils.attachment.isAudioRecording
 import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.client.utils.message.isError
 import io.getstream.chat.android.client.utils.message.isGiphy
+import io.getstream.chat.android.client.utils.message.isLocalOnly
 import io.getstream.chat.android.client.utils.message.isModerationBounce
 import io.getstream.chat.android.client.utils.message.isModerationError
 import io.getstream.chat.android.client.utils.message.isSystem
@@ -65,7 +66,6 @@ import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.PollOption
 import io.getstream.chat.android.models.Reaction
-import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.ui.common.feature.messages.translations.MessageOriginalTranslationsStore
@@ -1759,13 +1759,14 @@ public class MessageListController(
         val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
 
-        // Skip when our own message is at the bottom and hasn't been confirmed by the server.
-        // Without this, marking read on an empty channel (only an in-flight optimistic message
-        // exists) causes the server to persist last_read_message_id = "" because its view of
-        // the channel is empty.
+        // Skip when our own message is at the bottom and the server doesn't have it: still in
+        // flight, or persisted locally but rejected by the server (e.g. a send into a frozen
+        // channel returns 201 with a type "error" echo stored as COMPLETED). Without this,
+        // marking read on a channel the server sees as empty makes it emit message.read with
+        // no last_read_message_id.
         val currentUserId = clientState.user.value?.id
-        if (message != null && message.user.id == currentUserId && message.syncStatus != SyncStatus.COMPLETED) {
-            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own unsynced): $messageId" }
+        if (message != null && message.user.id == currentUserId && message.isLocalOnly()) {
+            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own local-only): $messageId" }
             return
         }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1759,11 +1759,8 @@ public class MessageListController(
         val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
 
-        // Skip when our own message is at the bottom and the server doesn't have it: still in
-        // flight, or persisted locally but rejected by the server (e.g. a send into a frozen
-        // channel returns 201 with a type "error" echo stored as COMPLETED). Without this,
-        // marking read on a channel the server sees as empty makes it emit message.read with
-        // no last_read_message_id.
+        // Marking read while our own local-only message is at the bottom makes a channel the
+        // server sees as empty emit message.read with no last_read_message_id.
         val currentUserId = clientState.user.value?.id
         if (message != null && message.user.id == currentUserId && message.isLocalOnly()) {
             logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own local-only): $messageId" }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -2212,6 +2212,26 @@ internal class MessageComposerControllerTest {
         }
 
     @Test
+    fun `Given markMessagesPending enabled When sent message is confirmed Then markMessageRead is not invoked`() =
+        runTest {
+            val currentUser = User("uid1")
+            val echo = randomMessage(cid = CID, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED)
+            val fixture = Fixture()
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(currentUser)
+                .givenGlobalState()
+                .givenChannelState(configState = MutableStateFlow(Config(markMessagesPending = true)))
+                .givenSendMessage(echo)
+            val controller = fixture.get()
+
+            controller.sendMessage(Message(cid = CID, text = "Hello"), mock())
+            advanceUntilIdle()
+
+            verify(fixture.chatClient, never()).markMessageRead(any(), any(), any())
+        }
+
+    @Test
     fun `Given markMessagesPending disabled When send returns a rejected error echo Then markMessageRead is not invoked`() =
         runTest {
             // A send into a frozen channel returns 201 with a type "error" echo the server never persists.

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -2192,6 +2192,47 @@ internal class MessageComposerControllerTest {
     }
 
     @Test
+    fun `Given markMessagesPending disabled When sent message is confirmed Then markMessageRead is invoked`() =
+        runTest {
+            val currentUser = User("uid1")
+            val echo = randomMessage(cid = CID, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED)
+            val fixture = Fixture()
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(currentUser)
+                .givenGlobalState()
+                .givenChannelState()
+                .givenSendMessage(echo)
+            val controller = fixture.get()
+
+            controller.sendMessage(Message(cid = CID, text = "Hello"), mock())
+            advanceUntilIdle()
+
+            verify(fixture.chatClient).markMessageRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID), eq(echo.id))
+        }
+
+    @Test
+    fun `Given markMessagesPending disabled When send returns a rejected error echo Then markMessageRead is not invoked`() =
+        runTest {
+            // A send into a frozen channel returns 201 with a type "error" echo the server never persists.
+            val currentUser = User("uid1")
+            val echo = randomMessage(cid = CID, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED)
+            val fixture = Fixture()
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(currentUser)
+                .givenGlobalState()
+                .givenChannelState()
+                .givenSendMessage(echo)
+            val controller = fixture.get()
+
+            controller.sendMessage(Message(cid = CID, text = "Hello"), mock())
+            advanceUntilIdle()
+
+            verify(fixture.chatClient, never()).markMessageRead(any(), any(), any())
+        }
+
+    @Test
     fun `Given normal mode When sendMessage called Then data is cleared`() = runTest {
         // Given
         val currentUser = User("uid1")

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -460,6 +460,23 @@ internal class MessageListControllerTests {
     }
 
     @Test
+    fun `When the message list is empty markLastMessageRead should not invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = MutableStateFlow(emptyList()))
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
     fun `When an error message is followed by a synced one markLastMessageRead should invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -410,6 +410,79 @@ internal class MessageListControllerTests {
     }
 
     @Test
+    fun `When current user's last message is a rejected error echo markLastMessageRead should not invoke markRead`() =
+        runTest {
+            // A send into a frozen channel returns 201 with a type "error" echo which is stored
+            // as COMPLETED, but the server never persists it. The peer message makes sure the
+            // error one is the item the gate sees, and not filtered out.
+            val chatClient: ChatClient = mock()
+            val messagesState = MutableStateFlow(
+                listOf(
+                    randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+                    randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
+                ),
+            )
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser()
+                .givenChannelQuery()
+                .givenMarkRead()
+                .givenChannelState(messagesState = messagesState)
+                .get()
+
+            controller.markLastMessageRead()
+            delay(1000)
+
+            verify(chatClient, times(0)).markRead(any(), any())
+            controller.lastSeenMessageId.shouldBeNull()
+        }
+
+    @Test
+    fun `When current user's last message is ephemeral markLastMessageRead should not invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "2", user = user1, type = MessageType.EPHEMERAL, syncStatus = SyncStatus.COMPLETED),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
+    fun `When an error message is followed by a synced one markLastMessageRead should invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "2", user = user1, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "2"
+    }
+
+    @Test
     fun `When peer's last message is not COMPLETED markLastMessageRead should still invoke markRead`() = runTest {
         // syncStatus is local-only and not on the wire. Peer messages inherit the data
         // class default — the gate must not block them on that.

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -410,16 +410,35 @@ internal class MessageListControllerTests {
     }
 
     @Test
-    fun `When current user's last message is a rejected error echo markLastMessageRead should not invoke markRead`() =
+    fun `When the channel holds only our own rejected error echo markLastMessageRead should not invoke markRead`() =
         runTest {
             // A send into a frozen channel returns 201 with a type "error" echo which is stored
-            // as COMPLETED, but the server never persists it. The peer message makes sure the
-            // error one is the item the gate sees, and not filtered out.
+            // as COMPLETED, while the server keeps it out of its read state.
+            val chatClient: ChatClient = mock()
+            val messagesState = MutableStateFlow(
+                listOf(randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED)),
+            )
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser()
+                .givenChannelQuery()
+                .givenMarkRead()
+                .givenChannelState(messagesState = messagesState)
+                .get()
+
+            controller.markLastMessageRead()
+            delay(1000)
+
+            verify(chatClient, times(0)).markRead(any(), any())
+            controller.lastSeenMessageId.shouldBeNull()
+        }
+
+    @Test
+    fun `When the channel holds only our own ephemeral message markLastMessageRead should not invoke markRead`() =
+        runTest {
             val chatClient: ChatClient = mock()
             val messagesState = MutableStateFlow(
                 listOf(
-                    randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
-                    randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
+                    randomMessage(id = "1", user = user1, type = MessageType.EPHEMERAL, syncStatus = SyncStatus.COMPLETED),
                 ),
             )
             val controller = Fixture(chatClient = chatClient)
@@ -437,12 +456,13 @@ internal class MessageListControllerTests {
         }
 
     @Test
-    fun `When current user's last message is ephemeral markLastMessageRead should not invoke markRead`() = runTest {
+    fun `When a server-side message precedes our own error echo markLastMessageRead should invoke markRead`() = runTest {
+        // The server has messages of its own to mark read, so it resolves the read state itself.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
                 randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
-                randomMessage(id = "2", user = user1, type = MessageType.EPHEMERAL, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -455,8 +475,8 @@ internal class MessageListControllerTests {
         controller.markLastMessageRead()
         delay(1000)
 
-        verify(chatClient, times(0)).markRead(any(), any())
-        controller.lastSeenMessageId.shouldBeNull()
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "2"
     }
 
     @Test


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Sending into a frozen channel returns 201 with the message echoed back as `type: "error"`, which the SDK stores as `COMPLETED` while the server persists nothing. The mark-read guard from #6431 only checks `syncStatus != COMPLETED`, so every subsequent channel open calls `markRead` on a channel the server sees as empty, emitting `message.read` events with no `last_read_message_id` (customer-escalated). Aligns with the iOS fix in [stream-chat-swiftui#1452](https://github.com/GetStream/stream-chat-swiftui/pull/1452).

Port of #6643 to develop. Closes [AND-1395](https://linear.app/stream/issue/AND-1395/mark-read-fires-on-server-rejected-message-echoes-emitting-messageread)

### Implementation

- Promote the existing internal `Message.isLocalOnly()` to `@InternalStreamChatApi` public: not yet synced, or a type the server never persists (error, ephemeral). Matches iOS `ChatMessage.isLocalOnly`.
- `MessageListController.markLastMessageReadInternal`: widen the own-message guard from `syncStatus != COMPLETED` to `isLocalOnly()`. The guard returns before updating `lastSeenMessageId`, so mark-read recovers naturally once a real message arrives.
- `MessageComposerController.enqueueSendMessage`: skip the post-send `markMessageRead` when the echoed message is local-only, since its id doesn't exist server side.

### Testing

- Unit tests: error/ephemeral last message doesn't mark read (with a peer message underneath so filtering can't make the test pass vacuously), a synced message after an error one still marks read, post-send `markMessageRead` skipped for an error echo, `isLocalOnly()` truth table (existing tests folded into one parameterized test).
- The same change was verified on device on the v6 branch (#6643): before the fix each channel open fired `POST /read {"message_id":""}` and the server emitted `message.read` without `last_read_message_id`; after the fix the guard rejects the echo and no call is made.

#### Manual testing steps

1. Create a frozen channel with the logged-in user as its only member and no messages, e.g. with the Stream CLI:
   ```
   getstream api chat GetOrCreateChannel --type messaging --id frozen-test \
     --request '{"data":{"created_by_id":"<user-id>","frozen":true,"members":[{"user_id":"<user-id>"}]}}'
   ```
2. Send a message into it with `ChatClient.instance().sendMessage(...)` from a temporary debug button (the UI blocks the composer on frozen channels). The call succeeds and the result is the echo with `type: "error"` and `syncStatus: COMPLETED`.
3. Open the channel a few times, watching logcat with tag `MessageListController` and the HTTP log.
4. Without the fix, each open fires `POST /channels/.../read` with `{"message_id":""}` and the server emits `message.read` with no `last_read_message_id`. With the fix, each open logs `[markLastMessageRead] ... rejected (own local-only)` and makes no call.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-status handling for locally created, pending, error, and ephemeral messages.
  * Prevented messages from being marked as read when delivery is unsuccessful or the message is not eligible.
  * Ensured subsequent synchronized messages are marked as read correctly.

* **New Features**
  * Exposed local-only message detection through an internally supported public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->