### PR TITLE
Persist draft messages optimistically and on draft events

### DIFF
--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
@@ -25,6 +25,8 @@ import io.getstream.chat.android.client.events.ChannelUpdatedEvent
 import io.getstream.chat.android.client.events.ChannelUserBannedEvent
 import io.getstream.chat.android.client.events.ChannelVisibleEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
+import io.getstream.chat.android.client.events.DraftMessageDeletedEvent
+import io.getstream.chat.android.client.events.DraftMessageUpdatedEvent
 import io.getstream.chat.android.client.events.MarkAllReadEvent
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MemberRemovedEvent
@@ -61,6 +63,7 @@ import io.getstream.chat.android.client.parser2.adapters.internal.StreamDateForm
 import io.getstream.chat.android.client.query.QueryChannelsSpec
 import io.getstream.chat.android.models.Answer
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.EventType
 import io.getstream.chat.android.models.FilterObject
 import io.getstream.chat.android.models.Member
@@ -79,6 +82,7 @@ import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomChannel
 import io.getstream.chat.android.randomDate
+import io.getstream.chat.android.randomDraftMessage
 import io.getstream.chat.android.randomInt
 import io.getstream.chat.android.randomMember
 import io.getstream.chat.android.randomMessage
@@ -805,6 +809,26 @@ public fun randomPollDeletedEvent(
         poll = poll,
     )
 }
+
+public fun randomDraftMessageUpdatedEvent(
+    createdAt: Date = randomDate(),
+    draftMessage: DraftMessage = randomDraftMessage(),
+): DraftMessageUpdatedEvent = DraftMessageUpdatedEvent(
+    type = EventType.DRAFT_MESSAGE_UPDATED,
+    createdAt = createdAt,
+    rawCreatedAt = streamFormatter.format(createdAt),
+    draftMessage = draftMessage,
+)
+
+public fun randomDraftMessageDeletedEvent(
+    createdAt: Date = randomDate(),
+    draftMessage: DraftMessage = randomDraftMessage(),
+): DraftMessageDeletedEvent = DraftMessageDeletedEvent(
+    type = EventType.DRAFT_MESSAGE_DELETED,
+    createdAt = createdAt,
+    rawCreatedAt = streamFormatter.format(createdAt),
+    draftMessage = draftMessage,
+)
 
 public fun randomPollUpdatedEvent(
     createdAt: Date = randomDate(),

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3411,9 +3411,11 @@ public abstract interface class io/getstream/chat/android/client/plugin/listener
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/DraftMessageListener {
-	public abstract fun onCreateDraftMessageRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCreateDraftMessageRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onCreateDraftMessageRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/listeners/DraftMessageListener;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onCreateDraftMessageResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteDraftMessagesRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteDraftMessagesRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteDraftMessagesRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/listeners/DraftMessageListener;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onDeleteDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Lio/getstream/chat/android/models/FilterObject;ILjava/lang/String;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3135,6 +3135,8 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun deleteChannelMessages (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteDraftMessage (Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteDraftMessage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteDraftMessage$suspendImpl (Lio/getstream/chat/android/client/persistance/repository/MessageRepository;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteMessages (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deletePoll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun evictMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3259,6 +3261,8 @@ public abstract interface class io/getstream/chat/android/client/plugin/Plugin :
 	public static synthetic fun onCreateChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onCreateChannelResult (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onCreateChannelResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCreateDraftMessageRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onCreateDraftMessageRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onCreateDraftMessageResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onCreateDraftMessageResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onDeleteChannelPrecondition (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -3267,6 +3271,8 @@ public abstract interface class io/getstream/chat/android/client/plugin/Plugin :
 	public static synthetic fun onDeleteChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onDeleteChannelResult (Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onDeleteChannelResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteDraftMessagesRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteDraftMessagesRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onDeleteDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onDeleteDraftMessagesResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onDeleteReactionPrecondition (Lio/getstream/chat/android/models/User;)Lio/getstream/result/Result;
@@ -3405,7 +3411,9 @@ public abstract interface class io/getstream/chat/android/client/plugin/listener
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/DraftMessageListener {
+	public abstract fun onCreateDraftMessageRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onCreateDraftMessageResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onDeleteDraftMessagesRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onDeleteDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Lio/getstream/chat/android/models/FilterObject;ILjava/lang/String;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2686,6 +2686,12 @@ internal constructor(
         return message.ensureId(getCurrentUser() ?: getStoredUser()).let { processedDraftMessage ->
             api.createDraftMessage(channelType, channelId, processedDraftMessage)
                 .retry(userScope, retryPolicy)
+                .doOnStart(userScope) {
+                    logger.v { "[createDraftMessage] #doOnStart; cid: $channelType:$channelId" }
+                    plugins.forEach { listener ->
+                        listener.onCreateDraftMessageRequest(channelType, channelId, processedDraftMessage)
+                    }
+                }
                 .doOnResult(userScope) { result ->
                     logger.i { "[createDraftMessage] result: ${result.stringify { it.toString() }}" }
                     plugins.forEach { listener ->
@@ -2714,6 +2720,12 @@ internal constructor(
     ): Call<Unit> {
         return api.deleteDraftMessage(channelType, channelId, message)
             .retry(userScope, retryPolicy)
+            .doOnStart(userScope) {
+                logger.v { "[deleteDraftMessages] #doOnStart; cid: $channelType:$channelId" }
+                plugins.forEach { listener ->
+                    listener.onDeleteDraftMessagesRequest(channelType, channelId, message)
+                }
+            }
             .doOnResult(userScope) { result ->
                 logger.i { "[deleteDraftMessages] result: ${result.stringify { it.toString() }}" }
                 plugins.forEach { listener ->

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -177,6 +177,20 @@ public interface MessageRepository {
     public suspend fun deleteDraftMessage(message: DraftMessage)
 
     /**
+     * Deletes the draft message of a channel, or of a thread when [parentId] is not null. Used when the draft is only
+     * identified by the channel/thread it belongs to, as happens with the `draft.deleted` event.
+     *
+     * The default implementation looks the draft up before deleting it. Override it to delete in a single query.
+     */
+    public suspend fun deleteDraftMessage(cid: String, parentId: String?) {
+        val draftMessage = when (parentId) {
+            null -> selectDraftMessagesByCid(cid)
+            else -> selectDraftMessageByParentId(parentId)
+        }
+        draftMessage?.let { deleteDraftMessage(it) }
+    }
+
+    /**
      * Evict messages from the repository.
      */
     public suspend fun evictMessages()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -41,6 +41,7 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun selectMessageBySyncState(syncStatus: SyncStatus): List<Message> = emptyList()
     override suspend fun selectMessagesWithPoll(pollId: String): List<Message> = emptyList()
     override suspend fun deleteDraftMessage(message: DraftMessage) { /* No-Op */ }
+    override suspend fun deleteDraftMessage(cid: String, parentId: String?) { /* No-Op */ }
     override suspend fun selectDraftMessages(): List<DraftMessage> = emptyList()
     override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = null
     override suspend fun selectDraftMessageByParentId(parentId: String): DraftMessage? = null

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/Plugin.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/Plugin.kt
@@ -459,8 +459,24 @@ public interface Plugin :
         /* No-Op */
     }
 
+    override suspend fun onCreateDraftMessageRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    ) {
+        /* No-Op */
+    }
+
     override suspend fun onCreateDraftMessageResult(
         result: Result<DraftMessage>,
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    ) {
+        /* No-Op */
+    }
+
+    override suspend fun onDeleteDraftMessagesRequest(
         channelType: String,
         channelId: String,
         message: DraftMessage,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/DraftMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/DraftMessageListener.kt
@@ -29,11 +29,24 @@ import io.getstream.result.Result
 public interface DraftMessageListener {
 
     /**
+     * Side effect to be invoked before the original request is launched.
+     *
+     * @param channelType The type of the channel in which message is created.
+     * @param channelId The id of the channel in which message is created.
+     * @param message [DraftMessage] to be created.
+     */
+    public suspend fun onCreateDraftMessageRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    )
+
+    /**
      * Side effect to be invoked when the original request is completed with a response.
      *
      * @param result [Result] response from the original request.
      * @param channelType The type of the channel in which message is created.
-     * @param channelId The id of the the channel in which message is created.
+     * @param channelId The id of the channel in which message is created.
      * @param message [DraftMessage] to be created.
      */
     public suspend fun onCreateDraftMessageResult(
@@ -44,12 +57,25 @@ public interface DraftMessageListener {
     )
 
     /**
+     * Side effect to be invoked before the original request is launched.
+     *
+     * @param channelType The type of the channel in which message is deleted.
+     * @param channelId The id of the channel in which message is deleted.
+     * @param message [DraftMessage] to be deleted.
+     */
+    public suspend fun onDeleteDraftMessagesRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    )
+
+    /**
      * Side effect to be invoked when the original request is completed with a response.
      *
      * @param result [Result] response from the original request.
-     * @param channelType The type of the channel in which message is updated.
-     * @param channelId The id of the the channel in which message is updated.
-     * @param message [DraftMessage] to be updated.
+     * @param channelType The type of the channel in which message is deleted.
+     * @param channelId The id of the channel in which message is deleted.
+     * @param message [DraftMessage] to be deleted.
      */
     public suspend fun onDeleteDraftMessagesResult(
         result: Result<Unit>,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/DraftMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/DraftMessageListener.kt
@@ -39,7 +39,9 @@ public interface DraftMessageListener {
         channelType: String,
         channelId: String,
         message: DraftMessage,
-    )
+    ) {
+        /* No-Op */
+    }
 
     /**
      * Side effect to be invoked when the original request is completed with a response.
@@ -67,7 +69,9 @@ public interface DraftMessageListener {
         channelType: String,
         channelId: String,
         message: DraftMessage,
-    )
+    ) {
+        /* No-Op */
+    }
 
     /**
      * Side effect to be invoked when the original request is completed with a response.

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientDraftsApiTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientDraftsApiTests.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client
 
 import io.getstream.chat.android.client.chatclient.BaseChatClientTest
+import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyNetworkError
@@ -33,12 +34,54 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 /**
  * Test class for the drafts functionality of the [ChatClient].
  */
 internal class ChatClientDraftsApiTests : BaseChatClientTest() {
+
+    @Test
+    fun createDraftNotifiesPluginsBeforeTheResponseArrives() = runTest {
+        // given
+        val channelType = randomString()
+        val channelId = randomString()
+        val draft = randomDraftMessage()
+        val plugin = mock<Plugin>()
+        plugins.add(plugin)
+        whenever(api.createDraftMessage(any(), any(), any()))
+            .doReturn(RetroSuccess(draft).toRetrofitCall())
+        // when
+        chatClient.createDraftMessage(channelType, channelId, draft).await()
+        // then
+        inOrder(plugin).apply {
+            verify(plugin).onCreateDraftMessageRequest(eq(channelType), eq(channelId), any())
+            verify(plugin).onCreateDraftMessageResult(any(), eq(channelType), eq(channelId), any())
+        }
+    }
+
+    @Test
+    fun deleteDraftNotifiesPluginsBeforeTheResponseArrives() = runTest {
+        // given
+        val channelType = randomString()
+        val channelId = randomString()
+        val draft = randomDraftMessage()
+        val plugin = mock<Plugin>()
+        plugins.add(plugin)
+        whenever(api.deleteDraftMessage(any(), any(), any()))
+            .doReturn(RetroSuccess(Unit).toRetrofitCall())
+        // when
+        chatClient.deleteDraftMessages(channelType, channelId, draft).await()
+        // then
+        inOrder(plugin).apply {
+            verify(plugin).onDeleteDraftMessagesRequest(eq(channelType), eq(channelId), eq(draft))
+            verify(plugin).onDeleteDraftMessagesResult(any(), eq(channelType), eq(channelId), eq(draft))
+        }
+    }
 
     @Test
     fun createDraftSuccess() = runTest {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/persistance/repository/MessageRepositoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/persistance/repository/MessageRepositoryTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.persistance.repository
+
+import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.randomCID
+import io.getstream.chat.android.randomDraftMessage
+import io.getstream.chat.android.randomString
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doCallRealMethod
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class MessageRepositoryTest {
+
+    @Test
+    fun `the default deleteDraftMessage should look up the channel draft and delete it`() = runTest {
+        val cid = randomCID()
+        val draftMessage = randomDraftMessage(cid = cid, parentId = null)
+        val repository = repositoryWithDefaultDelete()
+        whenever(repository.selectDraftMessagesByCid(cid)) doReturn draftMessage
+
+        repository.deleteDraftMessage(cid = cid, parentId = null)
+
+        verify(repository).deleteDraftMessage(draftMessage)
+    }
+
+    @Test
+    fun `the default deleteDraftMessage should look up the thread draft and delete it`() = runTest {
+        val parentId = randomString()
+        val draftMessage = randomDraftMessage(parentId = parentId)
+        val repository = repositoryWithDefaultDelete()
+        whenever(repository.selectDraftMessageByParentId(parentId)) doReturn draftMessage
+
+        repository.deleteDraftMessage(cid = draftMessage.cid, parentId = parentId)
+
+        verify(repository).deleteDraftMessage(draftMessage)
+    }
+
+    @Test
+    fun `the default deleteDraftMessage should do nothing when there is no stored draft`() = runTest {
+        val cid = randomCID()
+        val repository = repositoryWithDefaultDelete()
+        whenever(repository.selectDraftMessagesByCid(cid)) doReturn null
+
+        repository.deleteDraftMessage(cid = cid, parentId = null)
+
+        verify(repository, never()).deleteDraftMessage(any<DraftMessage>())
+    }
+
+    private suspend fun repositoryWithDefaultDelete(): MessageRepository = mock<MessageRepository>().also {
+        doCallRealMethod().whenever(it).deleteDraftMessage(any<String>(), anyOrNull())
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/plugin/listeners/DraftMessageListenerTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/plugin/listeners/DraftMessageListenerTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin.listeners
+
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.DraftsSort
+import io.getstream.chat.android.models.FilterObject
+import io.getstream.chat.android.models.QueryDraftsResult
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.randomDraftMessage
+import io.getstream.chat.android.randomString
+import io.getstream.result.Result
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+internal class DraftMessageListenerTest {
+
+    @Test
+    fun `a listener that does not override the request hooks should still be invokable`() = runTest {
+        val listener = RecordingDraftMessageListener()
+
+        listener.onCreateDraftMessageRequest(randomString(), randomString(), randomDraftMessage())
+        listener.onDeleteDraftMessagesRequest(randomString(), randomString(), randomDraftMessage())
+
+        listener.invocations.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a plugin that does not override the request hooks should still be invokable`() = runTest {
+        val plugin = BarePlugin()
+
+        plugin.onCreateDraftMessageRequest(randomString(), randomString(), randomDraftMessage())
+        plugin.onDeleteDraftMessagesRequest(randomString(), randomString(), randomDraftMessage())
+    }
+
+    private class RecordingDraftMessageListener : DraftMessageListener {
+
+        val invocations: MutableList<String> = mutableListOf()
+
+        override suspend fun onCreateDraftMessageResult(
+            result: Result<DraftMessage>,
+            channelType: String,
+            channelId: String,
+            message: DraftMessage,
+        ) {
+            invocations += "onCreateDraftMessageResult"
+        }
+
+        override suspend fun onDeleteDraftMessagesResult(
+            result: Result<Unit>,
+            channelType: String,
+            channelId: String,
+            message: DraftMessage,
+        ) {
+            invocations += "onDeleteDraftMessagesResult"
+        }
+
+        override suspend fun onQueryDraftMessagesResult(
+            result: Result<List<DraftMessage>>,
+            offset: Int?,
+            limit: Int?,
+        ) {
+            invocations += "onQueryDraftMessagesResult"
+        }
+
+        override suspend fun onQueryDraftMessagesResult(
+            result: Result<QueryDraftsResult>,
+            filter: FilterObject,
+            limit: Int,
+            next: String?,
+            sort: QuerySorter<DraftsSort>,
+        ) {
+            invocations += "onQueryDraftMessagesResult"
+        }
+    }
+
+    private class BarePlugin : Plugin {
+        override fun onUserSet(user: User) { /* No-Op */ }
+        override fun onUserDisconnected() { /* No-Op */ }
+
+        @InternalStreamChatApi
+        override fun <T : Any> resolveDependency(klass: KClass<T>): T? = null
+    }
+}

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -112,6 +112,8 @@ public final class io/getstream/chat/android/offline/repository/domain/message/i
 	public fun deleteAttachmentsChunked (Ljava/util/List;)V
 	public fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteDraftMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteDraftMessageByCid (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteDraftMessageByParentId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteMessage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteMessages (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteMessages (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/DraftMessageListenerDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/DraftMessageListenerDatabase.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.offline.plugin.listener.internal
 
-import io.getstream.chat.android.client.errors.isPermanent
 import io.getstream.chat.android.client.persistance.repository.MessageRepository
 import io.getstream.chat.android.client.plugin.listeners.DraftMessageListener
 import io.getstream.chat.android.models.DraftMessage
@@ -25,7 +24,6 @@ import io.getstream.chat.android.models.FilterObject
 import io.getstream.chat.android.models.QueryDraftsResult
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.result.Result
-import io.getstream.result.onErrorSuspend
 import io.getstream.result.onSuccessSuspend
 
 internal class DraftMessageListenerDatabase(
@@ -33,7 +31,24 @@ internal class DraftMessageListenerDatabase(
 ) : DraftMessageListener {
 
     /**
-     * Method called when a request to create a draft message in the API happens
+     * Method called before the request to create a draft message in the API is launched. Persists the draft upfront so
+     * it is not lost if the process dies while the request is in flight.
+     *
+     * @param channelType The type of the channel
+     * @param channelId The id of the channel
+     * @param message The draft message to be created
+     */
+    override suspend fun onCreateDraftMessageRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    ) {
+        messageRepository.insertDraftMessage(message)
+    }
+
+    /**
+     * Method called when a request to create a draft message in the API happens. Replaces the draft persisted by
+     * [onCreateDraftMessageRequest] with the server copy, leaving it untouched on failure.
      *
      * @param result The result of the create draft message request
      * @param channelType The type of the channel
@@ -46,17 +61,28 @@ internal class DraftMessageListenerDatabase(
         channelId: String,
         message: DraftMessage,
     ) {
-        result
-            .onSuccessSuspend { draftMessage -> messageRepository.insertDraftMessage(draftMessage) }
-            .onErrorSuspend { error ->
-                message.takeUnless { error.isPermanent() }?.let { draftMessage ->
-                    messageRepository.insertDraftMessage(draftMessage)
-                }
-            }
+        result.onSuccessSuspend { draftMessage -> messageRepository.insertDraftMessage(draftMessage) }
     }
 
     /**
-     * Method called when a request to delete draft messages in the API happens
+     * Method called before the request to delete draft messages in the API is launched. Removes the draft upfront so it
+     * stays deleted if the process dies while the request is in flight.
+     *
+     * @param channelType The type of the channel
+     * @param channelId The id of the channel
+     * @param message The draft message to be deleted
+     */
+    override suspend fun onDeleteDraftMessagesRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    ) {
+        messageRepository.deleteDraftMessage(message)
+    }
+
+    /**
+     * Method called when a request to delete draft messages in the API happens. No-op, as the draft is already removed
+     * by [onDeleteDraftMessagesRequest].
      *
      * @param result The result of the delete draft messages request
      * @param channelType The type of the channel
@@ -69,13 +95,7 @@ internal class DraftMessageListenerDatabase(
         channelId: String,
         message: DraftMessage,
     ) {
-        result
-            .onSuccessSuspend { messageRepository.deleteDraftMessage(message) }
-            .onErrorSuspend { error ->
-                message.takeUnless { error.isPermanent() }?.let { draftMessage ->
-                    messageRepository.deleteDraftMessage(draftMessage)
-                }
-            }
+        /* No-Op */
     }
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -170,6 +170,13 @@ internal class DatabaseMessageRepository(
         messageDao.deleteDraftMessage(message.id)
     }
 
+    override suspend fun deleteDraftMessage(cid: String, parentId: String?) {
+        when (parentId) {
+            null -> messageDao.deleteDraftMessageByCid(cid)
+            else -> messageDao.deleteDraftMessageByParentId(parentId)
+        }
+    }
+
     override suspend fun selectDraftMessages(): List<DraftMessage> = messageDao.selectDraftMessages()
         .map { it.toModel(::selectMessage) }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -97,6 +97,12 @@ internal interface MessageDao {
     @Query("DELETE FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE id = :messageId")
     suspend fun deleteDraftMessage(messageId: String)
 
+    @Query("DELETE FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE cid = :cid AND parentId IS NULL")
+    suspend fun deleteDraftMessageByCid(cid: String)
+
+    @Query("DELETE FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE parentId = :parentId")
+    suspend fun deleteDraftMessageByParentId(parentId: String)
+
     @Query(
         "SELECT * from $MESSAGE_ENTITY_TABLE_NAME " +
             "WHERE cid = :cid " +

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/DraftMessageListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/DraftMessageListenerDatabaseTest.kt
@@ -30,7 +30,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import java.net.UnknownHostException
 
 internal class DraftMessageListenerDatabaseTest {
 
@@ -40,6 +39,19 @@ internal class DraftMessageListenerDatabaseTest {
     @BeforeEach
     fun setup() {
         Mockito.reset(messageRepository)
+    }
+
+    @Test
+    fun `onCreateDraftMessageRequest should persist the draft before the request completes`() = runTest {
+        val draftMessage = randomDraftMessage()
+
+        listener.onCreateDraftMessageRequest(
+            channelType = randomString(),
+            channelId = randomString(),
+            message = draftMessage,
+        )
+
+        verify(messageRepository).insertDraftMessage(draftMessage)
     }
 
     @Test
@@ -57,65 +69,48 @@ internal class DraftMessageListenerDatabaseTest {
     }
 
     @Test
-    fun `onCreateDraftMessageResult with a non permanent error should update state`() = runTest {
+    fun `onCreateDraftMessageResult should keep the persisted draft on any error`() = runTest {
         val draftMessage = randomDraftMessage()
 
         listener.onCreateDraftMessageResult(
-            result = Result.Failure(Error.NetworkError(randomString(), randomInt(), cause = UnknownHostException())),
+            result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
             channelType = randomString(),
             channelId = randomString(),
             message = draftMessage,
         )
 
-        verify(messageRepository).insertDraftMessage(draftMessage)
-    }
-
-    @Test
-    fun `onCreateDraftMessageResult should not update state on error`() = runTest {
-        listener.onCreateDraftMessageResult(
-            result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
-            channelType = randomString(),
-            channelId = randomString(),
-            message = randomDraftMessage(),
-        )
-
+        verify(messageRepository, never()).deleteDraftMessage(any())
         verify(messageRepository, never()).insertDraftMessage(any())
     }
 
     @Test
-    fun `onDeleteDraftMessagesResult should remove message from state on success`() = runTest {
+    fun `onDeleteDraftMessagesRequest should remove the draft before the request completes`() = runTest {
         val draftMessage = randomDraftMessage()
 
+        listener.onDeleteDraftMessagesRequest(
+            channelType = randomString(),
+            channelId = randomString(),
+            message = draftMessage,
+        )
+
+        verify(messageRepository).deleteDraftMessage(draftMessage)
+    }
+
+    @Test
+    fun `onDeleteDraftMessagesResult should not touch storage on any outcome`() = runTest {
+        val draftMessage = randomDraftMessage()
+
+        listener.onDeleteDraftMessagesResult(
+            result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
+            channelType = randomString(),
+            channelId = randomString(),
+            message = draftMessage,
+        )
         listener.onDeleteDraftMessagesResult(
             result = Result.Success(Unit),
             channelType = randomString(),
             channelId = randomString(),
             message = draftMessage,
-        )
-
-        verify(messageRepository).deleteDraftMessage(draftMessage)
-    }
-
-    @Test
-    fun `onDeleteDraftMessagesResult with a non permanent error should remove message from state`() = runTest {
-        val draftMessage = randomDraftMessage()
-        listener.onDeleteDraftMessagesResult(
-            result = Result.Failure(Error.NetworkError(randomString(), randomInt(), cause = UnknownHostException())),
-            channelType = randomString(),
-            channelId = randomString(),
-            message = draftMessage,
-        )
-
-        verify(messageRepository).deleteDraftMessage(draftMessage)
-    }
-
-    @Test
-    fun `onDeleteDraftMessagesResult should not remove message from state on error`() = runTest {
-        listener.onDeleteDraftMessagesResult(
-            result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
-            channelType = randomString(),
-            channelId = randomString(),
-            message = randomDraftMessage(),
         )
 
         verify(messageRepository, never()).deleteDraftMessage(any())

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/DraftMessageListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/DraftMessageListenerDatabaseTest.kt
@@ -114,6 +114,7 @@ internal class DraftMessageListenerDatabaseTest {
         )
 
         verify(messageRepository, never()).deleteDraftMessage(any())
+        verify(messageRepository, never()).insertDraftMessage(any())
     }
 
     @Test

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/DraftMessageRepositoryIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/DraftMessageRepositoryIntegrationTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.offline.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.offline.integration.BaseDomainTest2
+import io.getstream.chat.android.randomCID
+import io.getstream.chat.android.randomDraftMessage
+import io.getstream.chat.android.randomString
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContainSame
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class DraftMessageRepositoryIntegrationTest : BaseDomainTest2() {
+
+    @Test
+    fun `inserting a channel draft and reading it back by cid should be equal`(): Unit = runTest {
+        val draft = randomDraftMessage(parentId = null, replyMessage = null)
+
+        repos.insertDraftMessage(draft)
+
+        repos.selectDraftMessagesByCid(draft.cid) shouldBeEqualTo draft
+    }
+
+    @Test
+    fun `inserting a thread draft and reading it back by parent id should be equal`(): Unit = runTest {
+        val parentId = randomString()
+        val draft = randomDraftMessage(parentId = parentId, replyMessage = null)
+
+        repos.insertDraftMessage(draft)
+
+        repos.selectDraftMessageByParentId(parentId) shouldBeEqualTo draft
+    }
+
+    @Test
+    fun `deleting a draft by cid should remove it`(): Unit = runTest {
+        val draft = randomDraftMessage(parentId = null, replyMessage = null)
+        repos.insertDraftMessage(draft)
+
+        repos.deleteDraftMessage(cid = draft.cid, parentId = null)
+
+        repos.selectDraftMessagesByCid(draft.cid).shouldBeNull()
+    }
+
+    @Test
+    fun `deleting a draft by parent id should remove it`(): Unit = runTest {
+        val parentId = randomString()
+        val draft = randomDraftMessage(parentId = parentId, replyMessage = null)
+        repos.insertDraftMessage(draft)
+
+        repos.deleteDraftMessage(cid = draft.cid, parentId = parentId)
+
+        repos.selectDraftMessageByParentId(parentId).shouldBeNull()
+    }
+
+    @Test
+    fun `deleting a channel draft by cid should leave thread drafts of the same channel untouched`(): Unit = runTest {
+        val cid = randomCID()
+        val parentId = randomString()
+        val channelDraft = randomDraftMessage(cid = cid, parentId = null, replyMessage = null)
+        val threadDraft = randomDraftMessage(cid = cid, parentId = parentId, replyMessage = null)
+        repos.insertDraftMessage(channelDraft)
+        repos.insertDraftMessage(threadDraft)
+
+        repos.deleteDraftMessage(cid = cid, parentId = null)
+
+        repos.selectDraftMessagesByCid(cid).shouldBeNull()
+        repos.selectDraftMessageByParentId(parentId) shouldBeEqualTo threadDraft
+    }
+
+    @Test
+    fun `deleting a thread draft should leave the channel draft of the same channel untouched`(): Unit = runTest {
+        val cid = randomCID()
+        val parentId = randomString()
+        val channelDraft = randomDraftMessage(cid = cid, parentId = null, replyMessage = null)
+        val threadDraft = randomDraftMessage(cid = cid, parentId = parentId, replyMessage = null)
+        repos.insertDraftMessage(channelDraft)
+        repos.insertDraftMessage(threadDraft)
+
+        repos.deleteDraftMessage(cid = cid, parentId = parentId)
+
+        repos.selectDraftMessageByParentId(parentId).shouldBeNull()
+        repos.selectDraftMessagesByCid(cid) shouldBeEqualTo channelDraft
+    }
+
+    @Test
+    fun `selecting all drafts should return every stored draft`(): Unit = runTest {
+        val channelDraft = randomDraftMessage(parentId = null, replyMessage = null)
+        val threadDraft = randomDraftMessage(parentId = randomString(), replyMessage = null)
+        repos.insertDraftMessage(channelDraft)
+        repos.insertDraftMessage(threadDraft)
+
+        repos.selectDraftMessages() shouldContainSame listOf(channelDraft, threadDraft)
+    }
+
+    @Test
+    fun `deleting a draft by its id should remove it`(): Unit = runTest {
+        val draft = randomDraftMessage(parentId = null, replyMessage = null)
+        repos.insertDraftMessage(draft)
+
+        repos.deleteDraftMessage(draft)
+
+        repos.selectDraftMessagesByCid(draft.cid).shouldBeNull()
+    }
+}

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -923,6 +923,13 @@ internal class EventHandlerSequential(
                 is PollDeletedEvent -> {
                     repos.deletePoll(event.poll.id)
                 }
+                is DraftMessageUpdatedEvent -> {
+                    repos.insertDraftMessage(event.draftMessage)
+                }
+                is DraftMessageDeletedEvent -> {
+                    // The event carries an empty message id, so the draft is identified by its channel/thread.
+                    repos.deleteDraftMessage(event.draftMessage.cid, event.draftMessage.parentId)
+                }
                 is UserMessagesDeletedEvent -> {
                     deleteMessagesFromUser(event.cid, event.user.id, event.hardDelete, event.createdAt)
                 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/DraftMessageListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/DraftMessageListenerState.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.state.plugin.listener.internal
 
-import io.getstream.chat.android.client.errors.isPermanent
 import io.getstream.chat.android.client.plugin.listeners.DraftMessageListener
 import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.DraftsSort
@@ -34,8 +33,24 @@ internal class DraftMessageListenerState(
 ) : DraftMessageListener {
 
     /**
-     * Keeps a reference of the [DraftMessage] in the [MutableGlobalState] when the request to create a draft message
-     * is successful.
+     * Keeps a reference of the [DraftMessage] in the [MutableGlobalState] before the request to create a draft message
+     * is launched, so it shows up right away.
+     *
+     * @param channelType The type of the channel in which message is created.
+     * @param channelId The id of the the channel in which message is created.
+     * @param message [DraftMessage] to be created.
+     */
+    override suspend fun onCreateDraftMessageRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    ) {
+        mutableGlobalState.updateDraftMessage(message)
+    }
+
+    /**
+     * Replaces the reference of the [DraftMessage] in the [MutableGlobalState] with the server copy when the request to
+     * create a draft message is successful, leaving it untouched on failure.
      *
      * @param result [Result] response from the original request.
      * @param channelType The type of the channel in which message is created.
@@ -48,18 +63,28 @@ internal class DraftMessageListenerState(
         channelId: String,
         message: DraftMessage,
     ) {
-        result
-            .onSuccess { draftMessage -> mutableGlobalState.updateDraftMessage(draftMessage) }
-            .onError { error ->
-                message.takeUnless { error.isPermanent() }?.let { draftMessage ->
-                    mutableGlobalState.updateDraftMessage(draftMessage)
-                }
-            }
+        result.onSuccess { draftMessage -> mutableGlobalState.updateDraftMessage(draftMessage) }
     }
 
     /**
-     * Removes the reference of the [DraftMessage] from the [MutableGlobalState] when the request to delete
-     * a draft message is successful.
+     * Removes the reference of the [DraftMessage] from the [MutableGlobalState] before the request to delete a draft
+     * message is launched, so it disappears right away.
+     *
+     * @param channelType The type of the channel in which message is updated.
+     * @param channelId The id of the the channel in which message is updated.
+     * @param message [DraftMessage] to be deleted.
+     */
+    override suspend fun onDeleteDraftMessagesRequest(
+        channelType: String,
+        channelId: String,
+        message: DraftMessage,
+    ) {
+        mutableGlobalState.removeDraftMessage(message)
+    }
+
+    /**
+     * Method called when a request to delete draft messages in the API happens. No-op, as the draft is already removed
+     * by [onDeleteDraftMessagesRequest].
      *
      * @param result [Result] response from the original request.
      * @param channelType The type of the channel in which message is updated.
@@ -72,13 +97,7 @@ internal class DraftMessageListenerState(
         channelId: String,
         message: DraftMessage,
     ) {
-        result
-            .onSuccess { mutableGlobalState.removeDraftMessage(message) }
-            .onError { error ->
-                message.takeUnless { error.isPermanent() }?.let { draftMessage ->
-                    mutableGlobalState.removeDraftMessage(draftMessage)
-                }
-            }
+        /* No-Op */
     }
 
     /**

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialTest.kt
@@ -24,6 +24,8 @@ import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.client.test.randomChannelDeletedEvent
 import io.getstream.chat.android.client.test.randomChannelUpdatedEvent
 import io.getstream.chat.android.client.test.randomConnectedEvent
+import io.getstream.chat.android.client.test.randomDraftMessageDeletedEvent
+import io.getstream.chat.android.client.test.randomDraftMessageUpdatedEvent
 import io.getstream.chat.android.client.test.randomMarkAllReadEvent
 import io.getstream.chat.android.client.test.randomMessageUpdateEvent
 import io.getstream.chat.android.client.test.randomNewMessageEvent
@@ -48,6 +50,7 @@ import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomChannel
 import io.getstream.chat.android.randomChannelMute
+import io.getstream.chat.android.randomDraftMessage
 import io.getstream.chat.android.randomLocation
 import io.getstream.chat.android.randomMember
 import io.getstream.chat.android.randomMessage
@@ -142,6 +145,72 @@ internal class EventHandlerSequentialTest {
         mutableGlobalState.muted.value `should be equal to` expectedMutedUsers
         mutableGlobalState.channelMutes.value `should be equal to` expectedChannelMutes
         mutableGlobalState.blockedUserIds.value `should be equal to` expectedBlockedUserIds
+    }
+
+    @Test
+    fun `When handling DraftMessageDeletedEvent, The draft should be deleted from local storage`() = runTest {
+        // given
+        val storedDraft = randomDraftMessage(parentId = null)
+        // The backend sends an empty message id on draft.deleted, so only the cid identifies the draft.
+        val event = randomDraftMessageDeletedEvent(draftMessage = storedDraft.copy(id = "", text = ""))
+        val repos: RepositoryFacade = mock()
+        whenever(repos.selectMessages(any())) doReturn emptyList()
+        whenever(repos.selectChannels(any())) doReturn emptyList()
+        whenever(repos.selectThreads(any())) doReturn emptyList()
+        val mutableGlobalState = MutableGlobalState(currentUser.id).apply {
+            updateDraftMessage(storedDraft)
+        }
+        val handler = Fixture()
+            .withRepositoryFacade(repos)
+            .withMutableGlobalState(mutableGlobalState)
+            .get(this)
+        // when
+        handler.handleEvents(event)
+        // then
+        mutableGlobalState.channelDraftMessages.value `should be equal to` emptyMap()
+        verify(repos).deleteDraftMessage(storedDraft.cid, null)
+    }
+
+    @Test
+    fun `When handling DraftMessageDeletedEvent for a thread, The draft should be deleted from local storage`() =
+        runTest {
+            // given
+            val parentId = randomString()
+            val storedDraft = randomDraftMessage(parentId = parentId)
+            val event = randomDraftMessageDeletedEvent(draftMessage = storedDraft.copy(id = "", text = ""))
+            val repos: RepositoryFacade = mock()
+            whenever(repos.selectMessages(any())) doReturn emptyList()
+            whenever(repos.selectChannels(any())) doReturn emptyList()
+            whenever(repos.selectThreads(any())) doReturn emptyList()
+            val handler = Fixture()
+                .withRepositoryFacade(repos)
+                .withMutableGlobalState(MutableGlobalState(currentUser.id))
+                .get(this)
+            // when
+            handler.handleEvents(event)
+            // then
+            verify(repos).deleteDraftMessage(storedDraft.cid, parentId)
+        }
+
+    @Test
+    fun `When handling DraftMessageUpdatedEvent, The draft should be stored in local storage`() = runTest {
+        // given
+        val draftMessage = randomDraftMessage(parentId = null)
+        val event = randomDraftMessageUpdatedEvent(draftMessage = draftMessage)
+        val repos: RepositoryFacade = mock()
+        whenever(repos.selectMessages(any())) doReturn emptyList()
+        whenever(repos.selectChannels(any())) doReturn emptyList()
+        whenever(repos.selectThreads(any())) doReturn emptyList()
+        val mutableGlobalState = MutableGlobalState(currentUser.id)
+        val handler = Fixture()
+            .withRepositoryFacade(repos)
+            .withMutableGlobalState(mutableGlobalState)
+            .get(this)
+        // when
+        handler.handleEvents(event)
+        // then
+        mutableGlobalState.channelDraftMessages.value `should be equal to` mapOf(draftMessage.cid to draftMessage)
+        verify(repos).insertDraftMessage(draftMessage)
     }
 
     @Test

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/DraftMessageListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/DraftMessageListenerStateTest.kt
@@ -106,6 +106,7 @@ internal class DraftMessageListenerStateTest {
         )
 
         verify(mutableGlobalState, never()).removeDraftMessage(any())
+        verify(mutableGlobalState, never()).updateDraftMessage(any())
     }
 
     @Test

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/DraftMessageListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/DraftMessageListenerStateTest.kt
@@ -28,12 +28,24 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
-import java.net.UnknownHostException
 
 internal class DraftMessageListenerStateTest {
 
     private val mutableGlobalState: MutableGlobalState = mock()
     private val listener = DraftMessageListenerState(mutableGlobalState)
+
+    @Test
+    fun `onCreateDraftMessageRequest should update state before the request completes`() = runTest {
+        val draftMessage = randomDraftMessage()
+
+        listener.onCreateDraftMessageRequest(
+            channelType = randomString(),
+            channelId = randomString(),
+            message = draftMessage,
+        )
+
+        verify(mutableGlobalState).updateDraftMessage(draftMessage)
+    }
 
     @Test
     fun `onCreateDraftMessageResult should update state on success`() = runTest {
@@ -50,65 +62,47 @@ internal class DraftMessageListenerStateTest {
     }
 
     @Test
-    fun `onCreateDraftMessageResult with a non permanent error should update state`() = runTest {
+    fun `onCreateDraftMessageResult should keep the draft in state on any error`() = runTest {
         val draftMessage = randomDraftMessage()
 
         listener.onCreateDraftMessageResult(
-            result = Result.Failure(Error.NetworkError(randomString(), randomInt(), cause = UnknownHostException())),
+            result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
             channelType = randomString(),
             channelId = randomString(),
             message = draftMessage,
         )
 
-        verify(mutableGlobalState).updateDraftMessage(draftMessage)
+        verify(mutableGlobalState, never()).removeDraftMessage(any())
     }
 
     @Test
-    fun `onCreateDraftMessageResult should not update state on error`() = runTest {
-        listener.onCreateDraftMessageResult(
+    fun `onDeleteDraftMessagesRequest should remove message from state before the request completes`() = runTest {
+        val draftMessage = randomDraftMessage()
+
+        listener.onDeleteDraftMessagesRequest(
+            channelType = randomString(),
+            channelId = randomString(),
+            message = draftMessage,
+        )
+
+        verify(mutableGlobalState).removeDraftMessage(draftMessage)
+    }
+
+    @Test
+    fun `onDeleteDraftMessagesResult should not touch state on any outcome`() = runTest {
+        val draftMessage = randomDraftMessage()
+
+        listener.onDeleteDraftMessagesResult(
             result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
             channelType = randomString(),
             channelId = randomString(),
-            message = randomDraftMessage(),
+            message = draftMessage,
         )
-
-        verify(mutableGlobalState, never()).updateDraftMessage(any())
-    }
-
-    @Test
-    fun `onDeleteDraftMessagesResult should remove message from state on success`() = runTest {
-        val draftMessage = randomDraftMessage()
-
         listener.onDeleteDraftMessagesResult(
             result = Result.Success(Unit),
             channelType = randomString(),
             channelId = randomString(),
             message = draftMessage,
-        )
-
-        verify(mutableGlobalState).removeDraftMessage(draftMessage)
-    }
-
-    @Test
-    fun `onDeleteDraftMessagesResult with a non permanent error should remove message from state`() = runTest {
-        val draftMessage = randomDraftMessage()
-        listener.onDeleteDraftMessagesResult(
-            result = Result.Failure(Error.NetworkError(randomString(), randomInt(), cause = UnknownHostException())),
-            channelType = randomString(),
-            channelId = randomString(),
-            message = draftMessage,
-        )
-
-        verify(mutableGlobalState).removeDraftMessage(draftMessage)
-    }
-
-    @Test
-    fun `onDeleteDraftMessagesResult should not remove message from state on error`() = runTest {
-        listener.onDeleteDraftMessagesResult(
-            result = Result.Failure(Error.NetworkError(message = randomString(), 404)),
-            channelType = randomString(),
-            channelId = randomString(),
-            message = randomDraftMessage(),
         )
 
         verify(mutableGlobalState, never()).removeDraftMessage(any())


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Backport of #6625 to `v6`: draft messages are lost when a request does not complete, and reappear after they have been deleted.

Closes [AND-1373](https://linear.app/stream/issue/AND-1373/draft-messages-are-lost-or-resurrected-because-persistence-is-not)

### Implementation

Same fix as #6625, with the offline and state parts landing in `stream-chat-android-offline` and `stream-chat-android-state`, which are still separate modules on `v6`.

Two additions, since `MessageRepository` and `DraftMessageListener` are part of the public API dump on `v6` but not on `develop`:

- `MessageRepository.deleteDraftMessage(cid, parentId)` gets a default body that resolves the draft through the existing select methods before deleting it, so custom repositories keep compiling and get the fix. `DatabaseMessageRepository` overrides it with a single-query delete.
- The two new `DraftMessageListener` hooks get no-op default bodies.

The module compiles with `-Xjvm-default=all`, so both are real JVM default methods and already-compiled implementations keep working.

### Testing

Unit tests cover both precommit paths, the channel and thread cases for `draft.deleted`, the repository default, and the new draft DAO queries against a real database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deleting draft messages from channels and threads.
  - Added request callbacks for draft creation and deletion, enabling integrations to respond before requests complete.
  - Draft creation and deletion now update local state immediately for a more responsive experience.
  - Offline draft storage now preserves updates and supports reliable deletion by channel or parent message.

- **Bug Fixes**
  - Improved synchronization of draft updates and deletions between local storage and server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->