### PR TITLE
Generate test fixture dates that are serializable and in the future

### DIFF
--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/database/converter/ReminderInfoConverterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/database/converter/ReminderInfoConverterTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.internal.offline.repository.database.converter
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.client.internal.offline.repository.database.converter.internal.ReminderInfoConverter
+import io.getstream.chat.android.client.internal.offline.repository.domain.message.internal.ReminderInfoEntity
+import io.getstream.chat.android.randomDate
+import io.getstream.chat.android.randomDateOrNull
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Date
+
+/**
+ * Runs under Robolectric because the dates are serialised by the API 26+ formatter, which is stricter about the year
+ * than the [java.text.SimpleDateFormat] fallback used below it.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class ReminderInfoConverterTest {
+
+    private val converter = ReminderInfoConverter()
+
+    @Test
+    fun `a reminder built from the date fixtures survives the round trip`() {
+        repeat(ROUNDS) {
+            val reminder = ReminderInfoEntity(
+                remindAt = randomDateOrNull(),
+                createdAt = randomDate(),
+                updatedAt = randomDate(),
+            )
+
+            converter.stringToReminderInfo(converter.reminderInfoToString(reminder)) shouldBeEqualTo reminder
+        }
+    }
+
+    @Test
+    fun `a reminder at the last serializable instant survives the round trip`() {
+        // Guards the upper bound the date fixtures generate up to: past it the year no longer fits the wire format,
+        // and a reminder comes back holding a different date, or fails to be read back at all.
+        val lastSerializable = Date(LAST_SERIALIZABLE_DATE_MILLIS)
+        val reminder = ReminderInfoEntity(
+            remindAt = lastSerializable,
+            createdAt = lastSerializable,
+            updatedAt = lastSerializable,
+        )
+
+        converter.stringToReminderInfo(converter.reminderInfoToString(reminder)) shouldBeEqualTo reminder
+    }
+
+    private companion object {
+        // Enough draws that a fixture generating unserializable dates again fails here, rather than
+        // intermittently somewhere downstream.
+        const val ROUNDS = 5_000
+        const val LAST_SERIALIZABLE_DATE_MILLIS = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/database/converter/ReminderInfoConverterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/internal/offline/repository/database/converter/ReminderInfoConverterTest.kt
@@ -51,7 +51,7 @@ internal class ReminderInfoConverterTest {
     @Test
     fun `a reminder at the last serializable instant survives the round trip`() {
         // Guards the upper bound the date fixtures generate up to: past it the year no longer fits the wire format,
-        // and a reminder comes back holding a different date, or fails to be read back at all.
+        // so a reminder comes back holding a different date, or cannot be read back at all.
         val lastSerializable = Date(LAST_SERIALIZABLE_DATE_MILLIS)
         val reminder = ReminderInfoEntity(
             remindAt = lastSerializable,
@@ -63,8 +63,8 @@ internal class ReminderInfoConverterTest {
     }
 
     private companion object {
-        // Enough draws that a fixture generating unserializable dates again fails here, rather than
-        // intermittently somewhere downstream.
+        // Enough draws that a fixture generating unserializable dates fails here, rather than intermittently
+        // somewhere downstream.
         const val ROUNDS = 5_000
         const val LAST_SERIALIZABLE_DATE_MILLIS = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
     }

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/RandomDateTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/RandomDateTest.kt
@@ -21,15 +21,15 @@ import org.junit.jupiter.api.Test
 import java.util.Date
 
 /**
- * The two properties the rest of the suite leans on. Both have broken before, and because the generator is random,
- * breaking either shows up as an unrelated test failing once in a few hundred CI runs rather than as a failure here.
+ * The two properties the rest of the suite leans on. Because the generator is random, breaking either surfaces as an
+ * unrelated test failing in a fraction of CI runs, far from the cause, rather than as a failure here.
  */
 internal class RandomDateTest {
 
     @Test
     fun `a generated date is always in the future`() {
-        // Production code that keeps only future dates, live locations for one, drops a fixture date that is already
-        // in the past, leaving the test asserting on an empty result.
+        // Production code that holds on to future dates only, live locations for one, drops a fixture date that
+        // sits behind the clock, leaving the test asserting on an empty result.
         val now = Date()
 
         val past = List(ROUNDS) { randomDate() }.filter { it.before(now) }

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/RandomDateTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/RandomDateTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android
+
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+/**
+ * The two properties the rest of the suite leans on. Both have broken before, and because the generator is random,
+ * breaking either shows up as an unrelated test failing once in a few hundred CI runs rather than as a failure here.
+ */
+internal class RandomDateTest {
+
+    @Test
+    fun `a generated date is always in the future`() {
+        // Production code that keeps only future dates, live locations for one, drops a fixture date that is already
+        // in the past, leaving the test asserting on an empty result.
+        val now = Date()
+
+        val past = List(ROUNDS) { randomDate() }.filter { it.before(now) }
+
+        past.firstOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `a generated date is always serializable`() {
+        // The ISO-8601 formatter writes a four digit year, so a later date is written as a different date, or as one
+        // that cannot be read back at all.
+        val lastSerializable = Date(LAST_SERIALIZABLE_DATE_MILLIS)
+
+        val unserializable = List(ROUNDS) { randomDate() }.filter { it.after(lastSerializable) }
+
+        unserializable.firstOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `a date generated after another one is serializable too`() {
+        val lastSerializable = Date(LAST_SERIALIZABLE_DATE_MILLIS)
+
+        val unserializable = List(ROUNDS) { randomDateAfter(randomDate()) }.filter { it.after(lastSerializable) }
+
+        unserializable.firstOrNull().shouldBeNull()
+    }
+
+    private companion object {
+        const val ROUNDS = 100_000
+        const val LAST_SERIALIZABLE_DATE_MILLIS = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
+    }
+}

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -773,10 +773,17 @@ public fun randomFiles(
     creationFunction: (Int) -> File = { randomFile() },
 ): List<File> = (1..size).map(creationFunction)
 
+/**
+ * The last instant the SDK can serialise: the ISO-8601 formatter writes a four digit year, so anything past year 9999
+ * is written as a different date, or as one that cannot be read back at all. Generated dates stay inside this range so
+ * that a fixture date survives a round trip through JSON, and therefore through the database converters.
+ */
+private const val MAX_SERIALIZABLE_DATE_MILLIS: Long = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
+
 public fun randomDateOrNull(): Date? = randomDate().takeIf { randomBoolean() }
-public fun randomDate(): Date = Date(positiveRandomLong())
+public fun randomDate(): Date = Date(positiveRandomLong(MAX_SERIALIZABLE_DATE_MILLIS))
 public fun randomDateBefore(date: Date): Date = Date(date.time - positiveRandomInt())
-public fun randomDateAfter(date: Date): Date = Date(randomLongBetween(date.time))
+public fun randomDateAfter(date: Date): Date = Date(randomLongBetween(date.time, MAX_SERIALIZABLE_DATE_MILLIS))
 
 public fun createDate(
     year: Int = positiveRandomInt(),

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -774,16 +774,22 @@ public fun randomFiles(
 ): List<File> = (1..size).map(creationFunction)
 
 /**
- * The last instant the SDK can serialise: the ISO-8601 formatter writes a four digit year, so anything past year 9999
- * is written as a different date, or as one that cannot be read back at all. Generated dates stay inside this range so
- * that a fixture date survives a round trip through JSON, and therefore through the database converters.
+ * The window generated dates are drawn from.
+ *
+ * The upper bound is the last instant the SDK can serialise: the ISO-8601 formatter writes a four digit year, so
+ * anything past year 9999 is written as a different date, or as one that cannot be read back at all.
+ *
+ * The lower bound keeps generated dates in the future, which is what callers already relied on. Drawing from the whole
+ * positive `Long` range put every date millions of years ahead, so production code that keeps only future dates, live
+ * locations for one, never saw a generated date fall behind the clock. Use [randomDateBefore] for a date in the past.
  */
-private const val MAX_SERIALIZABLE_DATE_MILLIS: Long = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
+private const val MIN_GENERATED_DATE_MILLIS: Long = 32_503_680_000_000L // 3000-01-01T00:00:00.000Z
+private const val MAX_GENERATED_DATE_MILLIS: Long = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z
 
 public fun randomDateOrNull(): Date? = randomDate().takeIf { randomBoolean() }
-public fun randomDate(): Date = Date(positiveRandomLong(MAX_SERIALIZABLE_DATE_MILLIS))
+public fun randomDate(): Date = Date(randomLongBetween(MIN_GENERATED_DATE_MILLIS, MAX_GENERATED_DATE_MILLIS))
 public fun randomDateBefore(date: Date): Date = Date(date.time - positiveRandomInt())
-public fun randomDateAfter(date: Date): Date = Date(randomLongBetween(date.time, MAX_SERIALIZABLE_DATE_MILLIS))
+public fun randomDateAfter(date: Date): Date = Date(randomLongBetween(date.time, MAX_GENERATED_DATE_MILLIS))
 
 public fun createDate(
     year: Int = positiveRandomInt(),

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -779,9 +779,9 @@ public fun randomFiles(
  * The upper bound is the last instant the SDK can serialise: the ISO-8601 formatter writes a four digit year, so
  * anything past year 9999 is written as a different date, or as one that cannot be read back at all.
  *
- * The lower bound keeps generated dates in the future, which is what callers already relied on. Drawing from the whole
- * positive `Long` range put every date millions of years ahead, so production code that keeps only future dates, live
- * locations for one, never saw a generated date fall behind the clock. Use [randomDateBefore] for a date in the past.
+ * The lower bound keeps generated dates in the future, which callers rely on: production code that holds on to future
+ * dates only, live locations for one, drops a date that sits behind the clock, leaving a test asserting on an empty
+ * result. Use `randomDateBefore(Date())` for a date in the past.
  */
 private const val MIN_GENERATED_DATE_MILLIS: Long = 32_503_680_000_000L // 3000-01-01T00:00:00.000Z
 private const val MAX_GENERATED_DATE_MILLIS: Long = 253_402_300_799_999L // 9999-12-31T23:59:59.999Z


### PR DESCRIPTION
<!-- pr:test -->

### Goal

`MessageMemberInfoDaoTest` is flaky: the same commit goes red and then green on rerun, failing with

```
com.squareup.moshi.JsonDataException: Non-null value 'updatedAt' was null at $.updatedAt
  at ReminderInfoEntityJsonAdapter.fromJson
  at ReminderInfoConverter.stringToReminderInfo
```

The cause is in the fixtures. `randomDate()` was `Date(positiveRandomLong())`, so dates ran up to year
292278994, while our ISO-8601 writer emits a four digit year on API 26+ and silently truncates the rest:
year 292278994 is written as `2922`. Almost every fixture date was past year 9999, so almost every date
persisted through a JSON-backed Room converter came back as a different date, which is invisible to a test
that does not assert on it.

It becomes a failure when the truncation lands on a February 29th whose four digit year is not a leap year,
for example `+30000-02-29` written as `3000-02-29`. That string is not a real instant, `IsoDateAdapter`
returns null for it, and Moshi throws on the non-null `ReminderInfoEntity.updatedAt`. `randomMessage`
defaults `reminder` to a `randomMessageReminderInfo()` holding two non-null dates, so every test in that
class was exposed, as is anything else that round-trips a fixture date through these converters.

Closes [AND-1438](https://linear.app/stream/issue/AND-1438/fix-flaky-messagememberinfodaotest-caused-by-unserializable-fixture)

### Implementation

- Draw generated dates from `3000-01-01` to `9999-12-31`. The upper bound is the last instant we can
  serialise. The lower bound keeps them in the future, which callers already relied on: drawing from the
  whole positive `Long` range put every date millions of years ahead, so code that keeps only future dates
  never saw a fixture date fall behind the clock. Use `randomDateBefore(Date())` for a date in the past.
- Add `RandomDateTest`, covering both properties, in three cases: the future bound, the serializable bound,
  and the serializable bound through `randomDateAfter`. Each property has now broken once, and because the
  generator is random, breaking either shows up as an unrelated test failing in a fraction of CI runs
  rather than here.
- Add `ReminderInfoConverterTest`, where the crash surfaced and which had no coverage before.

Pinning `reminder = null` in the failing tests would have fixed the one test and left every other fixture
date silently corrupting through this path.

Left alone, and worth a separate ticket: `IsoDateAdapter.fromJson` catches every `Throwable` and returns
null. That leniency is right for wire data, but on the database path it turns a date we wrote ourselves into
a read-time crash on a non-null column, and into a wrong date on a nullable one.

### Testing

- Deterministic repro: `Date(884546442123004)` is `+30000-02-29T01:02:03.004Z`. Put on a message reminder
  and read back through `MessageDao.select`, it throws the exception above on `develop`.
- Rate through the DAO with fully random messages, exactly as the failing test builds them: 1 crash in
  3,000 round trips on `develop`, and 0 in 20,000 re-measured on the generator as it now stands, lower
  bound included.
- `ReminderInfoConverterTest` fails without the fixture change, on its first iteration, on the silent
  corruption case: `remindAt=... 275752190` came back as `... 2757`. Its 5,000 draws also make the rarer
  crash case very likely to be caught if the fixture regresses, and a second case pins the year 9999
  boundary deterministically.
- Bounding the upper end alone put 0.70% of generated dates in the past (1399 of 200,000), against 0 of
  200,000 before, which broke `EventHandlerSequentialTest` in the merge queue: `MutableGlobalState` keeps
  only live locations whose `endAt` is after now, so a past `endAt` left the assertion comparing against an
  empty list. Hence the lower bound. `EventHandlerSequentialTest` then ran 25 times in a row without a
  failure.
- Each `RandomDateTest` case fails on the state it guards: the future one on the upper-bound-only generator,
  both serializable ones on the original unbounded generator.
- `./gradlew :stream-chat-android-client:testDebugUnitTest :stream-chat-android-core:test` and the
  `ui-common`, `ui-components` and `compose` unit tests, plus `spotlessCheck detekt apiCheck`, green on the
  committed tree, rebased on current `develop`. The client and core suites were then repeated three times
  with `--rerun-tasks`, since one green run proves little against a random generator.
