### PR TITLE
Skip mark-read when the server tracks none of the loaded messages

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1791,9 +1791,9 @@ public class MessageListController(
         }
     }
 
-    // The server keeps our own local-only messages out of its read state, along with silent,
-    // shadowed and deleted ones, so none of them can resolve a mark-read call. Deleted for the
-    // current user only does not count: the message is still there for everyone else.
+    // The server keeps our own local-only messages out of its channel read state, along with
+    // silent, shadowed and deleted ones, so none of them can resolve a mark-read call. Deleted for
+    // the current user only does not count: the message is still there for everyone else.
     private fun Message.isInServerReadState(currentUserId: String?): Boolean =
         !(isMine(currentUserId) && isLocalOnly()) && !silent && !shadowed && deletedAt == null
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1758,13 +1758,10 @@ public class MessageListController(
         val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
 
-        // The server keeps our own local-only messages out of its read state, so marking read
-        // without any other message makes it emit message.read with no last_read_message_id.
+        // Marking read with nothing the server tracks makes it emit message.read with no
+        // last_read_message_id.
         val currentUserId = clientState.user.value?.id
-        val hasServerSideMessage = messageItems.any { item ->
-            !(item.message.isMine(currentUserId) && item.message.isLocalOnly())
-        }
-        if (!hasServerSideMessage) {
+        if (messageItems.none { it.message.isInServerReadState(currentUserId) }) {
             logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (no server-side message)" }
             return
         }
@@ -1793,6 +1790,11 @@ public class MessageListController(
             markChannelAsRead()
         }
     }
+
+    // The server keeps our own local-only messages out of its read state, and silent and shadowed
+    // ones from anyone, so none of them can resolve a mark-read call.
+    private fun Message.isInServerReadState(currentUserId: String?): Boolean =
+        !(isMine(currentUserId) && isLocalOnly()) && !silent && !shadowed
 
     private fun markChannelAsRead() {
         val (channelType, channelId) = cid.cidToTypeAndId()

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1791,10 +1791,11 @@ public class MessageListController(
         }
     }
 
-    // The server keeps our own local-only messages out of its read state, and silent and shadowed
-    // ones from anyone, so none of them can resolve a mark-read call.
+    // The server keeps our own local-only messages out of its read state, along with silent,
+    // shadowed and deleted ones, so none of them can resolve a mark-read call. Deleted for the
+    // current user only does not count: the message is still there for everyone else.
     private fun Message.isInServerReadState(currentUserId: String?): Boolean =
-        !(isMine(currentUserId) && isLocalOnly()) && !silent && !shadowed
+        !(isMine(currentUserId) && isLocalOnly()) && !silent && !shadowed && deletedAt == null
 
     private fun markChannelAsRead() {
         val (channelType, channelId) = cid.cidToTypeAndId()

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -343,9 +343,9 @@ internal class MessageListControllerTests {
     fun `When repetitive markLastMessageRead calls appear only single API call should be sent`() = runTest {
         val chatClient: ChatClient = mock()
         val messages = arrayListOf(
-            randomMessage(id = "1", syncStatus = SyncStatus.COMPLETED, silent = false),
-            randomMessage(id = "2", syncStatus = SyncStatus.COMPLETED, silent = false),
-            randomMessage(id = "3", syncStatus = SyncStatus.COMPLETED, silent = false),
+            trackedMessage(id = "1"),
+            trackedMessage(id = "2"),
+            trackedMessage(id = "3"),
         )
         val messagesState = MutableStateFlow(messages)
         val controller = Fixture(chatClient = chatClient)
@@ -373,7 +373,7 @@ internal class MessageListControllerTests {
     fun `When current user's last message is COMPLETED markLastMessageRead should invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.COMPLETED, silent = false)),
+            listOf(trackedMessage(id = "1", user = user1)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -475,8 +475,15 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = false),
-                randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED, silent = false),
+                trackedMessage(id = "1", user = user2),
+                randomMessage(
+                    id = "2",
+                    user = user1,
+                    type = MessageType.ERROR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = false,
+                    deletedAt = null,
+                ),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -524,6 +531,8 @@ internal class MessageListControllerTests {
 
     @Test
     fun `When the channel holds only a shadowed message markLastMessageRead should not invoke markRead`() = runTest {
+        // Defensive only: the server clears shadowed for the author, and ChannelStateImpl drops
+        // other users' shadowed messages, so this state does not reach the list today.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
@@ -552,12 +561,81 @@ internal class MessageListControllerTests {
     }
 
     @Test
+    fun `When the channel holds only a deleted message markLastMessageRead should not invoke markRead`() = runTest {
+        // The server drops a deleted message from its read state, so it has nothing to resolve.
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(
+                    id = "1",
+                    user = user2,
+                    type = MessageType.REGULAR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = false,
+                    deletedAt = randomDate(),
+                ),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
+    fun `When a message is deleted for the current user only markLastMessageRead should invoke markRead`() = runTest {
+        // Deleted for me leaves the message in place for everyone else, so the server can still
+        // resolve the read state.
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(
+                    id = "1",
+                    user = user2,
+                    type = MessageType.REGULAR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = false,
+                    deletedAt = null,
+                    deletedForMe = true,
+                ),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "1"
+    }
+
+    @Test
     fun `When a silent message follows a tracked one markLastMessageRead should invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = false),
-                randomMessage(id = "2", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = true),
+                trackedMessage(id = "1", user = user2),
+                randomMessage(
+                    id = "2",
+                    user = user2,
+                    type = MessageType.REGULAR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = true,
+                    deletedAt = null,
+                ),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -596,8 +674,15 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED, silent = false),
-                randomMessage(id = "2", user = user1, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = false),
+                randomMessage(
+                    id = "1",
+                    user = user1,
+                    type = MessageType.ERROR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = false,
+                    deletedAt = null,
+                ),
+                trackedMessage(id = "2", user = user1),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -620,7 +705,7 @@ internal class MessageListControllerTests {
         // class default — the gate must not block them on that.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(randomMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS, silent = false)),
+            listOf(trackedMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -1930,6 +2015,24 @@ internal class MessageListControllerTests {
         @OptIn(ExperimentalCoroutinesApi::class)
         private fun nowDate() = Date(testCoroutines.dispatcher.scheduler.currentTime)
 
+        /**
+         * A message the server tracks in its read state. [randomMessage] randomises `silent` and
+         * `deletedAt`, which the mark-read gate keys on, so both are pinned here.
+         */
+        private fun trackedMessage(
+            id: String = randomString(),
+            user: User = randomUser(),
+            syncStatus: SyncStatus = SyncStatus.COMPLETED,
+        ) = randomMessage(
+            id = id,
+            user = user,
+            type = MessageType.REGULAR,
+            syncStatus = syncStatus,
+            silent = false,
+            shadowed = false,
+            deletedAt = null,
+        )
+
         private fun nowMessage(
             author: User,
             type: String,
@@ -1942,8 +2045,9 @@ internal class MessageListControllerTests {
                 type = type,
                 text = text,
                 syncStatus = syncStatus,
-                // randomMessage randomises silent, which the mark-read gate keys on.
+                // randomMessage randomises silent and deletedAt, which the mark-read gate keys on.
                 silent = false,
+                deletedAt = null,
                 createdAt = nowDate,
                 updatedAt = nowDate,
                 deletedAt = null,

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -1015,14 +1015,21 @@ internal class MessageListControllerTests {
             controller.unreadLabelState.value `should be equal to` null
 
             messagesState.value = listOf(
-                randomMessage(id = "last_read_message_id", user = user1, deletedAt = null, deletedForMe = false),
-                randomMessage(id = "unread_1", user = user2, deletedAt = null, deletedForMe = false),
+                randomMessage(
+                    id = "last_read_message_id",
+                    user = user1,
+                    deletedAt = null,
+                    deletedForMe = false,
+                    silent = false,
+                ),
+                randomMessage(id = "unread_1", user = user2, deletedAt = null, deletedForMe = false, silent = false),
                 randomMessage(
                     id = "unread_2",
                     user = user2,
                     syncStatus = SyncStatus.COMPLETED,
                     deletedAt = null,
                     deletedForMe = false,
+                    silent = false,
                 ),
             )
             controller.markLastMessageRead()
@@ -1035,7 +1042,12 @@ internal class MessageListControllerTests {
     fun `Keep unread label, when marking read zeroes the read state`() =
         runTest {
             val chatClient: ChatClient = mock()
-            val lastReadMessage = randomMessage(id = "last_read_message_id", deletedAt = null, deletedForMe = false)
+            val lastReadMessage = randomMessage(
+                id = "last_read_message_id",
+                deletedAt = null,
+                deletedForMe = false,
+                silent = false,
+            )
             val messages = listOf(
                 lastReadMessage,
                 randomMessage(
@@ -1044,6 +1056,7 @@ internal class MessageListControllerTests {
                     syncStatus = SyncStatus.COMPLETED,
                     deletedAt = null,
                     deletedForMe = false,
+                    silent = false,
                 ),
             )
             val channelRead = MutableStateFlow(

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -343,9 +343,9 @@ internal class MessageListControllerTests {
     fun `When repetitive markLastMessageRead calls appear only single API call should be sent`() = runTest {
         val chatClient: ChatClient = mock()
         val messages = arrayListOf(
-            randomMessage(id = "1", syncStatus = SyncStatus.COMPLETED),
-            randomMessage(id = "2", syncStatus = SyncStatus.COMPLETED),
-            randomMessage(id = "3", syncStatus = SyncStatus.COMPLETED),
+            randomMessage(id = "1", syncStatus = SyncStatus.COMPLETED, silent = false),
+            randomMessage(id = "2", syncStatus = SyncStatus.COMPLETED, silent = false),
+            randomMessage(id = "3", syncStatus = SyncStatus.COMPLETED, silent = false),
         )
         val messagesState = MutableStateFlow(messages)
         val controller = Fixture(chatClient = chatClient)
@@ -373,7 +373,7 @@ internal class MessageListControllerTests {
     fun `When current user's last message is COMPLETED markLastMessageRead should invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.COMPLETED)),
+            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.COMPLETED, silent = false)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -393,7 +393,7 @@ internal class MessageListControllerTests {
     fun `When current user's last message is not COMPLETED markLastMessageRead should not invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.IN_PROGRESS)),
+            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.IN_PROGRESS, silent = false)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -416,7 +416,15 @@ internal class MessageListControllerTests {
             // as COMPLETED, while the server keeps it out of its read state.
             val chatClient: ChatClient = mock()
             val messagesState = MutableStateFlow(
-                listOf(randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED)),
+                listOf(
+                    randomMessage(
+                        id = "1",
+                        user = user1,
+                        type = MessageType.ERROR,
+                        syncStatus = SyncStatus.COMPLETED,
+                        silent = false,
+                    ),
+                ),
             )
             val controller = Fixture(chatClient = chatClient)
                 .givenCurrentUser()
@@ -438,7 +446,13 @@ internal class MessageListControllerTests {
             val chatClient: ChatClient = mock()
             val messagesState = MutableStateFlow(
                 listOf(
-                    randomMessage(id = "1", user = user1, type = MessageType.EPHEMERAL, syncStatus = SyncStatus.COMPLETED),
+                    randomMessage(
+                        id = "1",
+                        user = user1,
+                        type = MessageType.EPHEMERAL,
+                        syncStatus = SyncStatus.COMPLETED,
+                        silent = false,
+                    ),
                 ),
             )
             val controller = Fixture(chatClient = chatClient)
@@ -461,8 +475,89 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
-                randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = false),
+                randomMessage(id = "2", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED, silent = false),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "2"
+    }
+
+    @Test
+    fun `When the channel holds only a silent message markLastMessageRead should not invoke markRead`() = runTest {
+        // A silent message does not mark a channel unread, so the server has nothing to resolve.
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(
+                    id = "1",
+                    user = user2,
+                    type = MessageType.REGULAR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = true,
+                ),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
+    fun `When the channel holds only a shadowed message markLastMessageRead should not invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(
+                    id = "1",
+                    user = user1,
+                    type = MessageType.REGULAR,
+                    syncStatus = SyncStatus.COMPLETED,
+                    silent = false,
+                    shadowed = true,
+                ),
+            ),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
+    fun `When a silent message follows a tracked one markLastMessageRead should invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(
+                randomMessage(id = "1", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = false),
+                randomMessage(id = "2", user = user2, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = true),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -501,8 +596,8 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED),
-                randomMessage(id = "2", user = user1, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED),
+                randomMessage(id = "1", user = user1, type = MessageType.ERROR, syncStatus = SyncStatus.COMPLETED, silent = false),
+                randomMessage(id = "2", user = user1, type = MessageType.REGULAR, syncStatus = SyncStatus.COMPLETED, silent = false),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -525,7 +620,7 @@ internal class MessageListControllerTests {
         // class default — the gate must not block them on that.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(randomMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS)),
+            listOf(randomMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS, silent = false)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -1834,6 +1929,8 @@ internal class MessageListControllerTests {
                 type = type,
                 text = text,
                 syncStatus = syncStatus,
+                // randomMessage randomises silent, which the mark-read gate keys on.
+                silent = false,
                 createdAt = nowDate,
                 updatedAt = nowDate,
                 deletedAt = null,

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -343,9 +343,9 @@ internal class MessageListControllerTests {
     fun `When repetitive markLastMessageRead calls appear only single API call should be sent`() = runTest {
         val chatClient: ChatClient = mock()
         val messages = arrayListOf(
-            trackedMessage(id = "1"),
-            trackedMessage(id = "2"),
-            trackedMessage(id = "3"),
+            gateMessage(id = "1"),
+            gateMessage(id = "2"),
+            gateMessage(id = "3"),
         )
         val messagesState = MutableStateFlow(messages)
         val controller = Fixture(chatClient = chatClient)
@@ -373,7 +373,7 @@ internal class MessageListControllerTests {
     fun `When current user's last message is COMPLETED markLastMessageRead should invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(trackedMessage(id = "1", user = user1)),
+            listOf(gateMessage(id = "1", user = user1)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -393,7 +393,7 @@ internal class MessageListControllerTests {
     fun `When current user's last message is not COMPLETED markLastMessageRead should not invoke markRead`() = runTest {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.IN_PROGRESS, silent = false)),
+            listOf(gateMessage(id = "1", user = user1, syncStatus = SyncStatus.IN_PROGRESS)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -416,15 +416,7 @@ internal class MessageListControllerTests {
             // as COMPLETED, while the server keeps it out of its read state.
             val chatClient: ChatClient = mock()
             val messagesState = MutableStateFlow(
-                listOf(
-                    randomMessage(
-                        id = "1",
-                        user = user1,
-                        type = MessageType.ERROR,
-                        syncStatus = SyncStatus.COMPLETED,
-                        silent = false,
-                    ),
-                ),
+                listOf(gateMessage(id = "1", user = user1, type = MessageType.ERROR)),
             )
             val controller = Fixture(chatClient = chatClient)
                 .givenCurrentUser()
@@ -445,15 +437,7 @@ internal class MessageListControllerTests {
         runTest {
             val chatClient: ChatClient = mock()
             val messagesState = MutableStateFlow(
-                listOf(
-                    randomMessage(
-                        id = "1",
-                        user = user1,
-                        type = MessageType.EPHEMERAL,
-                        syncStatus = SyncStatus.COMPLETED,
-                        silent = false,
-                    ),
-                ),
+                listOf(gateMessage(id = "1", user = user1, type = MessageType.EPHEMERAL)),
             )
             val controller = Fixture(chatClient = chatClient)
                 .givenCurrentUser()
@@ -475,15 +459,8 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                trackedMessage(id = "1", user = user2),
-                randomMessage(
-                    id = "2",
-                    user = user1,
-                    type = MessageType.ERROR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = false,
-                    deletedAt = null,
-                ),
+                gateMessage(id = "1", user = user2),
+                gateMessage(id = "2", user = user1, type = MessageType.ERROR),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -505,15 +482,7 @@ internal class MessageListControllerTests {
         // A silent message does not mark a channel unread, so the server has nothing to resolve.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(
-                randomMessage(
-                    id = "1",
-                    user = user2,
-                    type = MessageType.REGULAR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = true,
-                ),
-            ),
+            listOf(gateMessage(id = "1", user = user2, silent = true)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -535,16 +504,7 @@ internal class MessageListControllerTests {
         // other users' shadowed messages, so this state does not reach the list today.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(
-                randomMessage(
-                    id = "1",
-                    user = user1,
-                    type = MessageType.REGULAR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = false,
-                    shadowed = true,
-                ),
-            ),
+            listOf(gateMessage(id = "1", user = user1, shadowed = true)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -565,16 +525,7 @@ internal class MessageListControllerTests {
         // The server drops a deleted message from its read state, so it has nothing to resolve.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(
-                randomMessage(
-                    id = "1",
-                    user = user2,
-                    type = MessageType.REGULAR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = false,
-                    deletedAt = randomDate(),
-                ),
-            ),
+            listOf(gateMessage(id = "1", user = user2, deletedAt = randomDate())),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -596,17 +547,7 @@ internal class MessageListControllerTests {
         // resolve the read state.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(
-                randomMessage(
-                    id = "1",
-                    user = user2,
-                    type = MessageType.REGULAR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = false,
-                    deletedAt = null,
-                    deletedForMe = true,
-                ),
-            ),
+            listOf(gateMessage(id = "1", user = user2, deletedForMe = true)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -627,15 +568,8 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                trackedMessage(id = "1", user = user2),
-                randomMessage(
-                    id = "2",
-                    user = user2,
-                    type = MessageType.REGULAR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = true,
-                    deletedAt = null,
-                ),
+                gateMessage(id = "1", user = user2),
+                gateMessage(id = "2", user = user2, silent = true),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -674,15 +608,8 @@ internal class MessageListControllerTests {
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
             listOf(
-                randomMessage(
-                    id = "1",
-                    user = user1,
-                    type = MessageType.ERROR,
-                    syncStatus = SyncStatus.COMPLETED,
-                    silent = false,
-                    deletedAt = null,
-                ),
-                trackedMessage(id = "2", user = user1),
+                gateMessage(id = "1", user = user1, type = MessageType.ERROR),
+                gateMessage(id = "2", user = user1),
             ),
         )
         val controller = Fixture(chatClient = chatClient)
@@ -705,7 +632,7 @@ internal class MessageListControllerTests {
         // class default — the gate must not block them on that.
         val chatClient: ChatClient = mock()
         val messagesState = MutableStateFlow(
-            listOf(trackedMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS)),
+            listOf(gateMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS)),
         )
         val controller = Fixture(chatClient = chatClient)
             .givenCurrentUser()
@@ -2016,21 +1943,28 @@ internal class MessageListControllerTests {
         private fun nowDate() = Date(testCoroutines.dispatcher.scheduler.currentTime)
 
         /**
-         * A message the server tracks in its read state. [randomMessage] randomises `silent` and
-         * `deletedAt`, which the mark-read gate keys on, so both are pinned here.
+         * A message for the mark-read gate, tracked by the server's read state unless a field is
+         * overridden. [randomMessage] randomises `silent`, `deletedAt` and `deletedForMe`, so every
+         * field the gate reads is pinned here and each test overrides only the one it covers.
          */
-        private fun trackedMessage(
+        private fun gateMessage(
             id: String = randomString(),
             user: User = randomUser(),
+            type: String = MessageType.REGULAR,
             syncStatus: SyncStatus = SyncStatus.COMPLETED,
+            silent: Boolean = false,
+            shadowed: Boolean = false,
+            deletedAt: Date? = null,
+            deletedForMe: Boolean = false,
         ) = randomMessage(
             id = id,
             user = user,
-            type = MessageType.REGULAR,
+            type = type,
             syncStatus = syncStatus,
-            silent = false,
-            shadowed = false,
-            deletedAt = null,
+            silent = silent,
+            shadowed = shadowed,
+            deletedAt = deletedAt,
+            deletedForMe = deletedForMe,
         )
 
         private fun nowMessage(

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -2047,7 +2047,6 @@ internal class MessageListControllerTests {
                 syncStatus = syncStatus,
                 // randomMessage randomises silent and deletedAt, which the mark-read gate keys on.
                 silent = false,
-                deletedAt = null,
                 createdAt = nowDate,
                 updatedAt = nowDate,
                 deletedAt = null,


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Develop port of #6646. The mark-read guard from #6644 skips whenever the last item in the list is the current user's own local-only message, which also suppresses legitimate mark-read in channels the server does have messages for. An `error` message is terminal, so a rejected or moderation-bounced send stays the last item and keeps those channels unread indefinitely.

Skip only when the server tracks none of the loaded messages. Read state leaves out our own not-yet-persisted messages, and silent, shadowed and deleted ones from anyone, so none of them can resolve a mark-read call. Silent is documented as not marking a channel unread, and a deleted message is removed from read state by `HandleMessageDeleted`, so a channel holding only those has nothing to mark read. Deleted for the current user only does not count, since the message stays in the channel for everyone else.

Part of [AND-1395](https://linear.app/stream/issue/AND-1395/mark-read-fires-on-server-rejected-message-echoes-emitting-messageread)

### Implementation

- `MessageListController.markLastMessageReadInternal`: replace the "last item is our own local-only message" check with "no loaded message is one the server tracks", via a new `Message.isInServerReadState` predicate covering local-only, `silent` and `shadowed`.
- Tests: error and ephemeral cases now hold only our own local-only message, plus new cases for a silent-only channel, a shadowed-only channel, a silent message following a tracked one, and a server-side message preceding the echo.
- `randomMessage` randomises both `silent` and `deletedAt`, which the gate now keys on, so gate-dependent tests build their messages through a `trackedMessage` helper that pins them, and the `nowMessage` helper pins them too. This includes the two unread-label tests that only exist here, one of which asserts state computed inside the branch the gate guards.
- The shadowed case cannot occur today (the server clears the flag for the author, and `ChannelStateImpl.shouldIgnoreUpsertion` drops other users' shadowed messages). The check stays as defensive cover and its test says so.

The deleted case will be ported to v6 separately, since #6646 merged without it.

### Testing

- Unit tests as above, with the `ui-common` suite rerun to confirm the gate no longer depends on a randomised field.
- The same change was verified on device on the v6 branch (#6646): with no server-side message the guard rejects and no read request is sent, and with server-side messages the request goes out and the emitted event carries a populated `last_read_message_id`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message read tracking to exclude silent and shadowed messages from server read state.
  * Corrected read-status handling when silent messages, shadowed messages, or error echoes appear in the message list.
* **Tests**
  * Added coverage for read tracking and unread indicators across these message scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
