### PR TITLE
Migrate the OG scrape response to the generated GetOGResponse model

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/OpenGraphApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/OpenGraphApi.kt
@@ -18,8 +18,8 @@ package io.getstream.chat.android.client.api2.endpoint
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api.QueryParams
-import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.call.RetrofitCall
+import io.getstream.chat.android.network.models.GetOGResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -30,5 +30,5 @@ import retrofit2.http.Query
 internal interface OpenGraphApi {
 
     @GET("/og")
-    fun get(@Query(QueryParams.URL) url: String): RetrofitCall<AttachmentDto>
+    fun get(@Query(QueryParams.URL) url: String): RetrofitCall<GetOGResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -808,8 +808,16 @@ internal class DomainMapping(
         )
 
     internal fun GetOGResponse.toDomain(): Attachment {
-        // The spec does not declare file_size/image/mime_type/name, so when the wire sends them they
-        // arrive in `custom`. Read them back out and remove them, or they would also sit in extraData
+        // The model declares `author_icon`, `color`, `footer`, `footer_icon`, `pretext`, `actions`,
+        // `fields` and `giphy`, none of which the hand-written DTO declared, so they no longer reach
+        // `extraData`. A scrape cannot produce any of them: the response is built from a fresh attachment
+        // that only ever receives title, title_link, author_name, author_link, text, image_url, thumb_url,
+        // type, asset_url and og_scrape_url. `giphy` in particular has a single producer, the giphy slash
+        // command writing to a message attachment, so the slice adopting the shared Attachment model owns
+        // it and must keep `extraData["giphy"]` populated or `Attachment.giphyInfo()` stops finding urls.
+        //
+        // The spec does not declare file_size/image/mime_type/name either, so if the wire ever sends them
+        // they arrive in `custom`. Read them back out and remove them, or they would also sit in extraData
         // under their wire names, which the hand-written DTO never did.
         val extras = custom.toMutableMap()
         val fileSize = (extras.remove("file_size") as? Number)?.toInt() ?: 0
@@ -836,10 +844,6 @@ internal class DomainMapping(
             originalWidth = originalWidth,
             extraData = extras.mapNotNull { (key, value) -> value?.let { key to it } }.toMap(),
         )
-        // `giphy` is deliberately not mapped: unlike the fields above, it has a single producer -- the
-        // giphy slash command, which writes it to a message attachment -- so it cannot reach /og. The
-        // slice that adopts the shared Attachment model owns it, and must re-emit it into
-        // extraData["giphy"] or Attachment.giphyInfo() stops finding gif urls.
     }
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -139,6 +139,7 @@ import io.getstream.chat.android.network.models.ChatPreferencesResponse
 import io.getstream.chat.android.network.models.DeviceResponse
 import io.getstream.chat.android.network.models.FullUserResponse
 import io.getstream.chat.android.network.models.GetApplicationResponse
+import io.getstream.chat.android.network.models.GetOGResponse
 import io.getstream.chat.android.network.models.PollOptionResponseData
 import io.getstream.chat.android.network.models.PrivacySettingsResponse
 import io.getstream.chat.android.network.models.PushPreferencesResponse
@@ -805,6 +806,41 @@ internal class DomainMapping(
             originalWidth = original_width,
             extraData = extraData.toMutableMap(),
         )
+
+    internal fun GetOGResponse.toDomain(): Attachment {
+        // The spec does not declare file_size/image/mime_type/name, so when the wire sends them they
+        // arrive in `custom`. Read them back out and remove them, or they would also sit in extraData
+        // under their wire names, which the hand-written DTO never did.
+        val extras = custom.toMutableMap()
+        val fileSize = (extras.remove("file_size") as? Number)?.toInt() ?: 0
+        val image = extras.remove("image") as? String
+        val mimeType = extras.remove("mime_type") as? String
+        val name = extras.remove("name") as? String
+        return Attachment(
+            assetUrl = assetUrl,
+            authorName = authorName,
+            authorLink = authorLink,
+            fallback = fallback,
+            fileSize = fileSize,
+            image = image,
+            imageUrl = imageUrl,
+            mimeType = mimeType,
+            name = name,
+            ogUrl = ogScrapeUrl,
+            text = text,
+            thumbUrl = thumbUrl,
+            title = title,
+            titleLink = titleLink,
+            type = type,
+            originalHeight = originalHeight,
+            originalWidth = originalWidth,
+            extraData = extras.mapNotNull { (key, value) -> value?.let { key to it } }.toMap(),
+        )
+        // `giphy` is deliberately not mapped: unlike the fields above, it has a single producer -- the
+        // giphy slash command, which writes it to a message attachment -- so it cannot reach /og. The
+        // slice that adopts the shared Attachment model owns it, and must re-emit it into
+        // extraData["giphy"] or Attachment.giphyInfo() stops finding gif urls.
+    }
 
     /**
      * Transforms [BanResponse] to [BannedUser], or to null when the ban carries no user.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -53,6 +53,7 @@ import io.getstream.chat.android.client.parser2.adapters.EventAdapterFactory
 import io.getstream.chat.android.client.parser2.adapters.EventRequestAdapter
 import io.getstream.chat.android.client.parser2.adapters.ExactDateAdapter
 import io.getstream.chat.android.client.parser2.adapters.FullUserResponseAdapter
+import io.getstream.chat.android.client.parser2.adapters.GetOGResponseAdapter
 import io.getstream.chat.android.client.parser2.adapters.MessageRequestAdapter
 import io.getstream.chat.android.client.parser2.adapters.NullCollectionsAsEmptyFactory
 import io.getstream.chat.android.client.parser2.adapters.PollOptionInputAdapter
@@ -126,6 +127,7 @@ internal class MoshiChatParser(
             .add(PollOptionInputAdapter)
             .add(PollOptionRequestAdapter)
             .add(EventRequestAdapter)
+            .add(GetOGResponseAdapter)
             .add(PollOptionResponseDataAdapter)
             .add(
                 CreatePollRequest.VotingVisibility::class.java,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/GetOGResponseAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/GetOGResponseAdapter.kt
@@ -26,8 +26,9 @@ import io.getstream.chat.android.network.models.GetOGResponse
 /**
  * Collects the root-level custom fields of an OG scrape into `custom`, which is how the API sends them.
  *
- * The endpoint also ships `file_size`, `image`, `mime_type` and `name` at the root even though the spec
- * does not declare them, so they arrive here too; `GetOGResponse.toDomain()` reads them back out.
+ * `file_size`, `image`, `mime_type` and `name` are undeclared by the spec, so when they are sent at the
+ * root they arrive here too; `GetOGResponse.toDomain()` reads them back out. A scrape does not produce
+ * them, so on this endpoint that is a guard rather than an observed shape.
  */
 internal object GetOGResponseAdapter :
     CustomObjectDtoAdapter<GetOGResponse>(GetOGResponse::class, extraDataPropertyName = "custom") {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/GetOGResponseAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/GetOGResponseAdapter.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2.adapters
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+import io.getstream.chat.android.network.models.GetOGResponse
+
+/**
+ * Collects the root-level custom fields of an OG scrape into `custom`, which is how the API sends them.
+ *
+ * The endpoint also ships `file_size`, `image`, `mime_type` and `name` at the root even though the spec
+ * does not declare them, so they arrive here too; `GetOGResponse.toDomain()` reads them back out.
+ */
+internal object GetOGResponseAdapter :
+    CustomObjectDtoAdapter<GetOGResponse>(GetOGResponse::class, extraDataPropertyName = "custom") {
+
+    @FromJson
+    fun fromJson(
+        jsonReader: JsonReader,
+        mapAdapter: JsonAdapter<MutableMap<String, Any>>,
+        valueAdapter: JsonAdapter<GetOGResponse>,
+    ): GetOGResponse? = parseWithExtraData(jsonReader, mapAdapter, valueAdapter)
+
+    @ToJson
+    @Suppress("UNUSED_PARAMETER")
+    fun toJson(jsonWriter: JsonWriter, value: GetOGResponse): Unit = error("Can't convert this to Json")
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/GetOGResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/GetOGResponse.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class GetOGResponse(
+    @Json(name = "duration")
+    internal val duration: String,
+
+    @Json(name = "custom")
+    internal val custom: Map<String, Any?> = emptyMap(),
+
+    @Json(name = "asset_url")
+    internal val assetUrl: String? = null,
+
+    @Json(name = "author_icon")
+    internal val authorIcon: String? = null,
+
+    @Json(name = "author_link")
+    internal val authorLink: String? = null,
+
+    @Json(name = "author_name")
+    internal val authorName: String? = null,
+
+    @Json(name = "color")
+    internal val color: String? = null,
+
+    @Json(name = "fallback")
+    internal val fallback: String? = null,
+
+    @Json(name = "footer")
+    internal val footer: String? = null,
+
+    @Json(name = "footer_icon")
+    internal val footerIcon: String? = null,
+
+    @Json(name = "image_url")
+    internal val imageUrl: String? = null,
+
+    @Json(name = "og_scrape_url")
+    internal val ogScrapeUrl: String? = null,
+
+    @Json(name = "original_height")
+    internal val originalHeight: Int? = null,
+
+    @Json(name = "original_width")
+    internal val originalWidth: Int? = null,
+
+    @Json(name = "pretext")
+    internal val pretext: String? = null,
+
+    @Json(name = "text")
+    internal val text: String? = null,
+
+    @Json(name = "thumb_url")
+    internal val thumbUrl: String? = null,
+
+    @Json(name = "title")
+    internal val title: String? = null,
+
+    @Json(name = "title_link")
+    internal val titleLink: String? = null,
+
+    @Json(name = "type")
+    internal val type: String? = null,
+
+    @Json(name = "actions")
+    internal val actions: List<io.getstream.chat.android.network.models.Action>? = emptyList(),
+
+    @Json(name = "fields")
+    internal val fields: List<io.getstream.chat.android.network.models.Field>? = emptyList(),
+
+    @Json(name = "giphy")
+    internal val giphy: io.getstream.chat.android.network.models.Images? = null,
+)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -100,6 +100,7 @@ import io.getstream.chat.android.network.models.FileUploadConfig
 import io.getstream.chat.android.network.models.FileUploadResponse
 import io.getstream.chat.android.network.models.FullUserResponse
 import io.getstream.chat.android.network.models.GetApplicationResponse
+import io.getstream.chat.android.network.models.GetOGResponse
 import io.getstream.chat.android.network.models.PollOptionResponseData
 import io.getstream.chat.android.network.models.ThreadParticipant
 import io.getstream.chat.android.network.models.UnblockUsersResponse
@@ -804,6 +805,20 @@ internal object Mother {
         last_read_message_id = lastReadMessageId,
         last_delivered_at = lastDeliveredAt,
         last_delivered_message_id = lastDeliveredMessageId,
+    )
+
+    fun randomGetOGResponse(
+        duration: String = randomString(),
+        type: String? = randomString(),
+        ogScrapeUrl: String? = randomString(),
+        imageUrl: String? = randomString(),
+        custom: Map<String, Any?> = emptyMap(),
+    ): GetOGResponse = GetOGResponse(
+        duration = duration,
+        type = type,
+        ogScrapeUrl = ogScrapeUrl,
+        imageUrl = imageUrl,
+        custom = custom,
     )
 
     fun randomAttachmentDto(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -38,7 +38,6 @@ import io.getstream.chat.android.client.api2.endpoint.UserGroupApi
 import io.getstream.chat.android.client.api2.mapping.DomainMapping
 import io.getstream.chat.android.client.api2.mapping.DtoMapping
 import io.getstream.chat.android.client.api2.mapping.EventMapping
-import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
 import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
@@ -131,6 +130,7 @@ import io.getstream.chat.android.network.models.DeliveredMessagePayload
 import io.getstream.chat.android.network.models.EventRequest
 import io.getstream.chat.android.network.models.GetApplicationResponse
 import io.getstream.chat.android.network.models.GetBlockedUsersResponse
+import io.getstream.chat.android.network.models.GetOGResponse
 import io.getstream.chat.android.network.models.GetUserGroupResponse
 import io.getstream.chat.android.network.models.GroupedChannelsGroupRequest
 import io.getstream.chat.android.network.models.GroupedQueryChannelsRequest
@@ -1962,7 +1962,7 @@ internal class MoshiChatApiTest {
 
     @ParameterizedTest
     @MethodSource("io.getstream.chat.android.client.api2.MoshiChatApiTestArguments#ogInput")
-    fun testOg(call: RetrofitCall<AttachmentDto>, expected: KClass<*>) = runTest {
+    fun testOg(call: RetrofitCall<GetOGResponse>, expected: KClass<*>) = runTest {
         // given
         val api = mock<OpenGraphApi>()
         whenever(api.get(any())).doReturn(call)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
@@ -25,7 +25,6 @@ import io.getstream.chat.android.client.Mother.randomUnreadCountByTeamDto
 import io.getstream.chat.android.client.Mother.randomUnreadDto
 import io.getstream.chat.android.client.Mother.randomUnreadThreadDto
 import io.getstream.chat.android.client.api.FakeResponse
-import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReminderDto
 import io.getstream.chat.android.client.api2.model.dto.HealthEventDto
@@ -69,6 +68,7 @@ import io.getstream.chat.android.network.models.CreateGuestResponse
 import io.getstream.chat.android.network.models.CreateUserGroupResponse
 import io.getstream.chat.android.network.models.GetApplicationResponse
 import io.getstream.chat.android.network.models.GetBlockedUsersResponse
+import io.getstream.chat.android.network.models.GetOGResponse
 import io.getstream.chat.android.network.models.GetUserGroupResponse
 import io.getstream.chat.android.network.models.ListDevicesResponse
 import io.getstream.chat.android.network.models.ListUserGroupsResponse
@@ -455,8 +455,8 @@ internal object MoshiChatApiTestArguments {
 
     @JvmStatic
     fun ogInput() = listOf(
-        Arguments.of(RetroSuccess(Mother.randomAttachmentDto()).toRetrofitCall(), Result.Success::class),
-        Arguments.of(RetroError<AttachmentDto>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
+        Arguments.of(RetroSuccess(Mother.randomGetOGResponse()).toRetrofitCall(), Result.Success::class),
+        Arguments.of(RetroError<GetOGResponse>(statusCode = 500).toRetrofitCall(), Result.Failure::class),
     )
 
     @JvmStatic

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/GetOGResponseParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/GetOGResponseParsingTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.parser2
+
+import io.getstream.chat.android.client.api2.mapping.DomainMapping
+import io.getstream.chat.android.models.NoOpChannelTransformer
+import io.getstream.chat.android.models.NoOpMessageTransformer
+import io.getstream.chat.android.models.NoOpUserTransformer
+import io.getstream.chat.android.network.models.GetOGResponse
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+
+internal class GetOGResponseParsingTest {
+    private val parser = ParserFactory.createMoshiChatParser()
+    private val mapping = DomainMapping(
+        currentUserIdProvider = { "me" },
+        channelTransformer = NoOpChannelTransformer,
+        messageTransformer = NoOpMessageTransformer,
+        userTransformer = NoOpUserTransformer,
+    )
+
+    @Test
+    fun `Custom root fields are collected into extraData`() {
+        val response = parser.fromJson(
+            """
+            {
+              "duration": "1ms",
+              "type": "image",
+              "title": "A page",
+              "og_scrape_url": "https://example.com",
+              "image_url": "https://example.com/i.png",
+              "thumb_url": "https://example.com/i.png",
+              "sentinel": "keep-me"
+            }
+            """.trimIndent(),
+            GetOGResponse::class.java,
+        )
+
+        val attachment = with(mapping) { response.toDomain() }
+
+        attachment.type shouldBeEqualTo "image"
+        attachment.title shouldBeEqualTo "A page"
+        attachment.ogUrl shouldBeEqualTo "https://example.com"
+        attachment.imageUrl shouldBeEqualTo "https://example.com/i.png"
+        attachment.thumbUrl shouldBeEqualTo "https://example.com/i.png"
+        attachment.extraData shouldBeEqualTo mapOf("sentinel" to "keep-me")
+    }
+
+    @Test
+    fun `An empty scrape maps to an attachment with domain defaults`() {
+        val response = parser.fromJson("""{"duration":"1ms"}""", GetOGResponse::class.java)
+
+        val attachment = with(mapping) { response.toDomain() }
+
+        attachment.type.shouldBeNull()
+        attachment.ogUrl.shouldBeNull()
+        attachment.fileSize shouldBeEqualTo 0
+        attachment.extraData shouldBeEqualTo emptyMap()
+    }
+
+    // The scraper does not appear to populate site_name/site for any page tried on the wire, so these two
+    // are covered here instead. Same-named on both sides, which is exactly how a swap goes unnoticed.
+    @Test
+    fun `Author name and link are mapped from their own fields`() {
+        val response = parser.fromJson(
+            """
+            {
+              "duration": "1ms",
+              "author_name": "Example Site",
+              "author_link": "https://example.com",
+              "asset_url": "https://example.com/v.mp4",
+              "type": "video"
+            }
+            """.trimIndent(),
+            GetOGResponse::class.java,
+        )
+
+        val attachment = with(mapping) { response.toDomain() }
+
+        attachment.authorName shouldBeEqualTo "Example Site"
+        attachment.authorLink shouldBeEqualTo "https://example.com"
+        attachment.assetUrl shouldBeEqualTo "https://example.com/v.mp4"
+        attachment.type shouldBeEqualTo "video"
+    }
+
+    // The wire was not observed sending these on /og, but three sampled pages cannot prove it never
+    // will, and losing them would be silent. They arrive in `custom` because the spec omits them.
+    @Test
+    fun `Undeclared root fields are mapped and removed from extraData`() {
+        val response = parser.fromJson(
+            """
+            {
+              "duration": "1ms",
+              "type": "file",
+              "og_scrape_url": "https://example.com/doc.pdf",
+              "file_size": 2048,
+              "image": "https://example.com/legacy.png",
+              "mime_type": "application/pdf",
+              "name": "doc.pdf",
+              "fallback": "a fallback",
+              "original_width": 640,
+              "original_height": 480,
+              "sentinel": "keep-me"
+            }
+            """.trimIndent(),
+            GetOGResponse::class.java,
+        )
+
+        val attachment = with(mapping) { response.toDomain() }
+
+        attachment.fileSize shouldBeEqualTo 2048
+        attachment.image shouldBeEqualTo "https://example.com/legacy.png"
+        attachment.mimeType shouldBeEqualTo "application/pdf"
+        attachment.name shouldBeEqualTo "doc.pdf"
+        attachment.fallback shouldBeEqualTo "a fallback"
+        attachment.originalWidth shouldBeEqualTo 640
+        attachment.originalHeight shouldBeEqualTo 480
+        // Read out of `custom`, so they must not also linger under their wire names.
+        attachment.extraData shouldBeEqualTo mapOf("sentinel" to "keep-me")
+    }
+}


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Migrate the OG scrape response to the generated `GetOGResponse` model, so `enrichUrl` no longer parses
into the hand-written `AttachmentDto`.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- `OpenGraphApi.get()` returns the generated `GetOGResponse`, mapped to the domain `Attachment`.
- Add `GetOGResponseAdapter` so root-level custom fields are still collected into `extraData`, which is
  what `AttachmentDtoAdapter` did for this endpoint.
- Add the generated `GetOGResponse`, `Images`, `ImageData`, `Action` and `Field`. The last four come along
  because Go's `GetOGResponse` embeds the whole `Attachment` payload, so the schema inherits every field
  an attachment can carry, not only the ones a scrape produces.

`AttachmentDto` stays: message and draft attachments still use it.

### Notes

`GetOGResponse` embeds the whole attachment shape, so it declares more than a scrape produces. The mapper
covers all of it except `giphy`, which is not mapped here: it has a single producer, the giphy slash
command writing to a message attachment, so it cannot reach `/og`. The slice that adopts the shared
`Attachment` model owns it, and has to re-emit it into `extraData["giphy"]` or `Attachment.giphyInfo()`
stops finding gif urls; `closure.py` prints that reminder for any closure containing `Images`.

`file_size`, `image`, `mime_type` and `name` are absent from the payload struct, so when they are sent they
arrive inside `custom`. The mapper reads them back out and removes them, so they do not also sit in
`extraData` under their wire names, which is how the hand-written DTO behaved.

### E2E

`/og` is routed in the mock server, and it answered with a recorded message attachment carrying no
`duration`, the one field the generated model requires non-null, which turned `HyperLinksTests` red.
[mock-server #64](https://github.com/GetStream/stream-chat-test-mock-server/pull/64) sends `duration` on
that response and is merged, so the suite runs against the default mock branch with no override needed.

### Testing

- `GetOGResponseParsingTest` covers the collected custom data, an empty scrape falling back to domain
  defaults, the undeclared root fields being mapped and removed from `extraData`, and
  `author_name`/`author_link`, which are same-named on both sides so a swap would otherwise go unnoticed.
- Device-probed `enrichUrl` against three pages (an article, an image page and a video page), logging the
  raw response body next to every field of the resulting `Attachment`. The wire returned `type`, `title`,
  `title_link`, `text`, `image_url`, `thumb_url`, `asset_url`, `og_scrape_url` and `duration`, all mapping
  correctly (`duration` is response metadata with no domain field), and `extraData` stayed empty, so
  nothing arrived under an unexpected name. The remaining declared fields were not seen on those three
  pages, which is why they are mapped rather than dropped: three samples cannot show a field is never
  sent, and losing one would be silent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Open Graph link previews by correctly processing metadata such as titles, images, authors, media details, and custom fields.
  - Ensured preview information is mapped consistently to attachment details.
  - Preserved additional Open Graph properties as extra attachment data instead of discarding them.
- **Tests**
  - Added coverage for Open Graph response parsing, empty responses, author information, and custom metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->