### PR TITLE
Decouple adding a channel to a channel list from the `watch()` call

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -308,7 +308,7 @@ internal class EventHandlerSequential(
 
     private suspend fun handleChatEvents(batchEvent: BatchEvent, queryChannelsLogic: QueryChannelsLogic) {
         logger.v { "[handleChatEvents] batchId: ${batchEvent.id}, batchEvent.size: ${batchEvent.size}" }
-        queryChannelsLogic.parseChatEventResults(batchEvent.sortedEvents).forEach { result ->
+        queryChannelsLogic.parseChatEventResults(batchEvent.sortedEvents).forEach { (event, result) ->
             when (result) {
                 is EventHandlingResult.Add -> {
                     // Use trackChannel instead of addChannel to avoid overwriting the shared
@@ -318,7 +318,11 @@ internal class EventHandlerSequential(
                     // the query map with the live per-channel data.
                     queryChannelsLogic.trackChannel(result.channel)
                 }
-                is EventHandlingResult.WatchAndAdd -> queryChannelsLogic.watchAndAddChannel(result.cid)
+                is EventHandlingResult.WatchAndAdd -> {
+                    // Pass the event's own channel so the query is populated from the payload rather
+                    // than from the watch response. See QueryChannelsLogic.addAndWatchChannel.
+                    queryChannelsLogic.addAndWatchChannel(cid = result.cid, channel = (event as? HasChannel)?.channel)
+                }
                 is EventHandlingResult.Remove -> queryChannelsLogic.removeChannel(result.cid)
                 is EventHandlingResult.Skip -> Unit
             }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -225,7 +225,7 @@ internal class QueryChannelsLogic(
             // Add the channel to the list, regardless of the `watch` outcome
             addChannel(channel)
         }
-        when (val result = client.channel(cid = cid).watch().await()) {
+        when (val result = client.channel(cid = "malformed").watch().await()) {
             // Re-adding the same channel is idempotent, and the watch response is the
             // authoritative one, so it always wins over the event payload seeded above.
             is Result.Success -> addChannel(result.value)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -225,7 +225,7 @@ internal class QueryChannelsLogic(
             // Add the channel to the list, regardless of the `watch` outcome
             addChannel(channel)
         }
-        when (val result = client.channel(cid = cid).watch().await()) {
+        when (val result = client.channel(cid = "malformed-$cid").watch().await()) {
             // Re-adding the same channel is idempotent, and the watch response is the
             // authoritative one, so it always wins over the event payload seeded above.
             is Result.Success -> addChannel(result.value)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -225,7 +225,7 @@ internal class QueryChannelsLogic(
             // Add the channel to the list, regardless of the `watch` outcome
             addChannel(channel)
         }
-        when (val result = client.channel(cid = "malformed-$cid").watch().await()) {
+        when (val result = client.channel(cid = cid).watch().await()) {
             // Re-adding the same channel is idempotent, and the watch response is the
             // authoritative one, so it always wins over the event payload seeded above.
             is Result.Success -> addChannel(result.value)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -225,7 +225,7 @@ internal class QueryChannelsLogic(
             // Add the channel to the list, regardless of the `watch` outcome
             addChannel(channel)
         }
-        when (val result = client.channel(cid = "malformed").watch().await()) {
+        when (val result = client.channel(cid = cid).watch().await()) {
             // Re-adding the same channel is idempotent, and the watch response is the
             // authoritative one, so it always wins over the event payload seeded above.
             is Result.Success -> addChannel(result.value)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -211,15 +211,28 @@ internal class QueryChannelsLogic(
     }
 
     /**
-     * Calls watch channel and adds result to the query.
+     * Adds the channel to this query and starts watching it.
+     *
+     * When the event that produced this call carried a [channel] payload, the channel is added
+     * from that payload *before* the watch request.
+     * The `watch` request is then best-effort, attempting to register the channel for live updates.
      *
      * @param cid cid of the channel.
+     * @param channel Channel data carried by the originating event, when it had any.
      */
-    internal suspend fun watchAndAddChannel(cid: String) {
-        val result = client.channel(cid = cid).watch().await()
-
-        if (result is Result.Success) {
-            addChannel(result.value)
+    internal suspend fun addAndWatchChannel(cid: String, channel: Channel? = null) {
+        if (channel != null) {
+            // Add the channel to the list, regardless of the `watch` outcome
+            addChannel(channel)
+        }
+        when (val result = client.channel(cid = cid).watch().await()) {
+            // Re-adding the same channel is idempotent, and the watch response is the
+            // authoritative one, so it always wins over the event payload seeded above.
+            is Result.Success -> addChannel(result.value)
+            is Result.Failure -> logger.e {
+                "[addAndWatchChannel] failed to watch $cid: ${result.value}; " +
+                    "addedFromEvent: ${channel != null}"
+            }
         }
     }
 
@@ -500,7 +513,13 @@ internal class QueryChannelsLogic(
         queryChannelsStateLogic.getQuerySpecs().cids.let(::refreshChannelsState)
     }
 
-    internal suspend fun parseChatEventResults(chatEvents: List<ChatEvent>): List<EventHandlingResult> {
+    /**
+     * Computes the handling result for each event, paired with the event it came from so callers
+     * can reach the event's own payload (see [addAndWatchChannel]). Order matches [chatEvents].
+     */
+    internal suspend fun parseChatEventResults(
+        chatEvents: List<ChatEvent>,
+    ): List<Pair<ChatEvent, EventHandlingResult>> {
         val cids = chatEvents.filterIsInstance<CidEvent>().map { it.cid }.distinct()
         // Prefer in-memory per-channel state which has already been updated by the channel
         // event handlers. Fall back to DB for channels that are not currently active in memory.
@@ -517,7 +536,7 @@ internal class QueryChannelsLogic(
 
         return chatEvents.map { event ->
             val channel = (event as? CidEvent)?.let { resolvedChannels[it.cid] }
-            queryChannelsStateLogic.handleChatEvent(event, channel)
+            event to queryChannelsStateLogic.handleChatEvent(event, channel)
         }
     }
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicTest.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.PredefinedFilter
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsResult
+import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.internal.state.plugin.QueryChannelsIdentifier
 import io.getstream.chat.android.client.query.QueryChannelsSpec
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
@@ -34,6 +35,7 @@ import io.getstream.chat.android.state.plugin.state.querychannels.GroupedQueryCo
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.asCall
+import io.getstream.result.Error
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -411,6 +413,57 @@ internal class QueryChannelsLogicTest {
 
     // endregion
 
+    // region addAndWatchChannel
+
+    @Test
+    fun `addAndWatchChannel should add the channel from the event payload when watch fails`() = runTest {
+        // Given
+        val channel = randomChannel(type = "messaging", id = "ch1")
+        val channelClient = mock<ChannelClient>()
+        whenever(client.channel(channel.cid)) doReturn channelClient
+        whenever(channelClient.watch()) doReturn Error.GenericError("boom").asCall<Channel>()
+
+        // When
+        logic.addAndWatchChannel(cid = channel.cid, channel = channel)
+
+        // Then – membership does not depend on the watch round-trip
+        verify(queryChannelsStateLogic).addChannelsState(listOf(channel))
+    }
+
+    @Test
+    fun `addAndWatchChannel should not add anything when watch fails and the event had no channel`() = runTest {
+        // Given
+        val cid = "messaging:ch1"
+        val channelClient = mock<ChannelClient>()
+        whenever(client.channel(cid)) doReturn channelClient
+        whenever(channelClient.watch()) doReturn Error.GenericError("boom").asCall<Channel>()
+
+        // When
+        logic.addAndWatchChannel(cid = cid, channel = null)
+
+        // Then
+        verify(queryChannelsStateLogic, never()).addChannelsState(any())
+    }
+
+    @Test
+    fun `addAndWatchChannel should add both the event payload and the watched channel on success`() = runTest {
+        // Given
+        val eventChannel = randomChannel(type = "messaging", id = "ch1")
+        val watchedChannel = eventChannel.copy(name = "refreshed")
+        val channelClient = mock<ChannelClient>()
+        whenever(client.channel(eventChannel.cid)) doReturn channelClient
+        whenever(channelClient.watch()) doReturn watchedChannel.asCall()
+
+        // When
+        logic.addAndWatchChannel(cid = eventChannel.cid, channel = eventChannel)
+
+        // Then – the payload seeds the list, the watch response refreshes it
+        verify(queryChannelsStateLogic).addChannelsState(listOf(eventChannel))
+        verify(queryChannelsStateLogic).addChannelsState(listOf(watchedChannel))
+    }
+
+    // endregion
+
     // region parseChatEventResults
 
     @Test
@@ -428,7 +481,7 @@ internal class QueryChannelsLogicTest {
 
         // Then
         verify(queryChannelsDatabaseLogic, never()).selectChannels(any())
-        assertEquals(listOf(expectedResult), results)
+        assertEquals(listOf(event to expectedResult), results)
     }
 
     @Test
@@ -447,7 +500,7 @@ internal class QueryChannelsLogicTest {
 
         // Then
         verify(queryChannelsDatabaseLogic).selectChannels(listOf(channel.cid))
-        assertEquals(listOf(expectedResult), results)
+        assertEquals(listOf(event to expectedResult), results)
     }
 
     @Test


### PR DESCRIPTION
### Goal

`EventHandlingResult.WatchAndAdd` is the only way a channel the client has never seen can enter a channel list. It is produced by `notification.added_to_channel`, `notification.message_new` and `channel.visible`, and it was implemented as:

```kotlin
val result = client.channel(cid = cid).watch().await()
if (result is Result.Success) {
    addChannel(result.value)
}
// no else, no log
```

This makes list membership conditional on a network round-trip, and silently discards the channel when that call fails.

It is worse than a transient miss, because `watch` also **subscribes the user to the channel server-side**. Once subscribed, the server stops sending that user `notification.*` events for the channel and sends only channel-scoped ones, which cannot introduce a channel the client does not already know about. A failed `watch` therefore leaves the user subscribed to a channel that is in no list, with no event able to repair it until the next query — i.e. until the app is restarted.

Android is the only SDK that works this way. iOS links the channel into the query straight from the event payload (`ChannelListLinker`) and treats the watch as a non-gating follow-up whose failure is a warning log; stream-chat-js promotes not-yet-loaded channels (`allowNotLoadedChannelPromotionForEvent`, all four flags default `true`); Flutter re-queries the list.

Related: AND-1447.

### Implementation

Invert the order — seed the list from the event's own channel payload, then watch as a refresh:

```kotlin
internal suspend fun addAndWatchChannel(cid: String, channel: Channel? = null) {
    if (channel != null) {
        // Add the channel to the list, regardless of the `watch` outcome
        addChannel(channel)
    }
    when (val result = client.channel(cid = cid).watch().await()) {
        is Result.Success -> addChannel(result.value)
        is Result.Failure -> logger.e { "[addAndWatchChannel] failed to watch $cid: ${result.value}; addedFromEvent: ${channel != null}" }
    }
}
```

The event payload is sufficient to build the list entry — verified over the wire that `notification.added_to_channel` carries a fully populated channel (`config`, `members`, `own_capabilities`, custom fields).

To reach the payload at the call site, `parseChatEventResults` now returns `List<Pair<ChatEvent, EventHandlingResult>>` and `EventHandlerSequential.handleChatEvents` passes `(event as? HasChannel)?.channel`. Both are `internal`, so there is no public API change and no `apiDump` needed.

All three `WatchAndAdd` producers implement `HasChannel`. A custom `ChatEventHandler` returning `WatchAndAdd` for some other event still works — `channel` is null and the previous behaviour applies.

Re-adding the same channel on success is idempotent: `QueryChannelsSpec.cids` is a `Set`, `rawChannels` is keyed by cid, `joinMessages` ends in `distinctBy { it.id }` and `joinMembers` merges via `associateBy { getUserId() }`.

### UI Changes

No UI changes.

### Testing

Unit tests added to `QueryChannelsLogicTest`:
- the channel from the event payload is added when `watch` fails
- nothing is added when `watch` fails and the event carried no channel
- both the payload and the watch response are applied on success

`:stream-chat-android-state:testDebugUnitTest`, `:stream-chat-android-state:detekt` and `:stream-chat-android-state:spotlessCheck` all pass.

Manual verification on device with a simulated `watch` failure (failing at the `Result` level, so the failure path is actually reached):
1. Create a channel for another user so a `notification.added_to_channel` arrives — the channel now appears in the list despite the failed `watch`. Previously it did not appear at all.
2. Send a message into it — the preview fills in on the following `notification.message_new`.

Note when reproducing: forcing the failure with a malformed cid does **not** exercise this path. `ChatClient.channel(cid)` calls `cidToTypeAndId()` eagerly, which `check()`s the format and throws, so the `Result.Failure` branch is never reached and the exception aborts the whole event batch.