### PR TITLE
Deprecate the unflag APIs since the backend endpoint is no longer supported

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -4289,6 +4289,11 @@ internal constructor(
      *
      * @param userId The ID of the user to un-flag.
      */
+    @Deprecated(
+        message = "The backend no longer supports un-flagging. This call does nothing and will be removed " +
+            "in the next major version.",
+        level = DeprecationLevel.WARNING,
+    )
     @CheckResult
     public fun unflagUser(userId: String): Call<Flag> = api.unflagUser(userId)
 
@@ -4315,6 +4320,11 @@ internal constructor(
      *
      * @param messageId The ID of the message to un-flag.
      */
+    @Deprecated(
+        message = "The backend no longer supports un-flagging. This call does nothing and will be removed " +
+            "in the next major version.",
+        level = DeprecationLevel.WARNING,
+    )
     @CheckResult
     public fun unflagMessage(messageId: String): Call<Flag> = api.unflagMessage(messageId)
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientModerationApiTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientModerationApiTests.kt
@@ -44,6 +44,7 @@ import org.mockito.kotlin.whenever
 /**
  * Tests for the moderation functionalities of the [ChatClient].
  */
+@Suppress("DEPRECATION")
 internal class ChatClientModerationApiTests : BaseChatClientTest() {
 
     @Test

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -410,6 +410,12 @@ public class MessageListViewModel(
      *
      * @param userId The ID of the user to un-flag.
      */
+    @Deprecated(
+        message = "The backend no longer supports un-flagging. This call does nothing and will be removed " +
+            "in the next major version.",
+        level = DeprecationLevel.WARNING,
+    )
+    @Suppress("DEPRECATION")
     public fun unflagUser(userId: String) {
         messageListController.unflagUser(userId)
     }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -2246,6 +2246,12 @@ public class MessageListController(
      *
      * @param userId The ID of the user to un-flag.
      */
+    @Deprecated(
+        message = "The backend no longer supports un-flagging. This call does nothing and will be removed " +
+            "in the next major version.",
+        level = DeprecationLevel.WARNING,
+    )
+    @Suppress("DEPRECATION")
     public fun unflagUser(userId: String) {
         chatClient
             .unflagUser(userId = userId)
@@ -2610,6 +2616,11 @@ public class MessageListController(
          *
          * @param streamError Contains the original [Throwable] along with a message.
          */
+        @Deprecated(
+            message = "The backend no longer supports un-flagging. This call does nothing and will be removed " +
+                "in the next major version.",
+            level = DeprecationLevel.WARNING,
+        )
         public data class UnflagUserError(override val streamError: Error) : ErrorEvent(streamError)
 
         /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -301,6 +301,7 @@ public class MessageListView : ConstraintLayout {
         }
     }
 
+    @Suppress("DEPRECATION")
     private var errorEventHandler = ErrorEventHandler { error ->
         when (error) {
             is MessageListController.ErrorEvent.MuteUserError -> R.string.stream_ui_message_list_error_mute_user

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -213,7 +213,7 @@ public class MessageListViewModel(
     /**
      * Handles an [Event] coming from the View layer.
      */
-    @Suppress("LongMethod", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod", "DEPRECATION")
     public fun onEvent(event: Event) {
         logger.v { "[onEvent] event: $event" }
         when (event) {
@@ -735,6 +735,11 @@ public class MessageListViewModel(
          *
          * @param userId The ID of the user to un-flag.
          */
+        @Deprecated(
+            message = "The backend no longer supports un-flagging. This call does nothing and will be removed " +
+                "in the next major version.",
+            level = DeprecationLevel.WARNING,
+        )
         public data class UnflagUser(val userId: String) : Event()
 
         /**


### PR DESCRIPTION
### Goal

The backend endpoint `POST /moderation/unflag` is deprecated and is a no-op. The SDK still exposes public APIs that call it, so an integrator can call something that silently does nothing.

This PR marks those APIs as deprecated. The removal happens in the next major version.

Resolves AND-1448

### Implementation

Added `@Deprecated` (WARNING level) to the public APIs that reach the endpoint:

- `ChatClient.unflagUser` and `ChatClient.unflagMessage`
- `MessageListController.unflagUser` and `MessageListController.ErrorEvent.UnflagUserError`
- Compose `MessageListViewModel.unflagUser`
- XML `MessageListViewModel.Event.UnflagUser`

Added `@Suppress("DEPRECATION")` where the SDK itself still routes through them, so the build stays free of new warnings: `MessageListController.unflagUser`, Compose `MessageListViewModel.unflagUser`, XML `MessageListViewModel.onEvent`, the `errorEventHandler` in `MessageListView`, and `ChatClientModerationApiTests`.

`ChatApi`, `MoshiChatApi` and `ModerationApi` are internal, so they are left as they are. They get removed together with the public APIs.

No behaviour changes. The `.api` dumps are unchanged, since the validator does not record annotations.

### Testing

- `./gradlew spotlessApply apiDump` (no `.api` changes)
- `./gradlew detekt`
- `./gradlew :stream-chat-android-client:testDebugUnitTest --tests '*ChatClientModerationApiTests*' --tests '*MoshiChatApiTest*'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that unflagging users and messages is no longer supported by the backend.
  * Existing unflag actions remain available but have no effect.

* **Deprecations**
  * Added deprecation warnings across moderation and message-list APIs.
  * Unflagging functionality is planned for removal in the next major release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->