### PR TITLE
Expose upload context with message id to FileUploader

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3720,15 +3720,29 @@ public abstract interface class io/getstream/chat/android/client/uploader/FileTr
 	public abstract fun transform (Ljava/io/File;)Ljava/io/File;
 }
 
+public final class io/getstream/chat/android/client/uploader/FileUploadContext {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getChannelType ()Ljava/lang/String;
+	public final fun getMessageId ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class io/getstream/chat/android/client/uploader/FileUploader {
 	public fun deleteFile (Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public fun deleteImage (Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public fun sendFile (Lio/getstream/chat/android/client/uploader/FileUploadContext;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public static synthetic fun sendFile$default (Lio/getstream/chat/android/client/uploader/FileUploader;Lio/getstream/chat/android/client/uploader/FileUploadContext;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/Result;
+	public fun sendImage (Lio/getstream/chat/android/client/uploader/FileUploadContext;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public static synthetic fun sendImage$default (Lio/getstream/chat/android/client/uploader/FileUploader;Lio/getstream/chat/android/client/uploader/FileUploadContext;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/Result;
 	public fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1026,7 +1026,33 @@ internal constructor(
         file: File,
         callback: ProgressCallback? = null,
     ): Call<UploadedFile> {
-        return api.sendFile(channelType, channelId, file, callback)
+        return sendFile(channelType, channelId, file, messageId = null, callback = callback)
+    }
+
+    /**
+     * Uploads a file that belongs to the message with [messageId], so the id can be propagated to the
+     * [FileUploader] as part of the upload context.
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param file The file that needs to be uploaded.
+     * @param messageId The id of the message the file belongs to, or null when the upload is not part of
+     * sending a message.
+     * @param callback The callback to track progress.
+     *
+     * @return Executable async [Call] which completes with [Result] containing an instance of [UploadedFile]
+     * if the file was successfully uploaded.
+     */
+    @CheckResult
+    @InternalStreamChatApi
+    public fun sendFile(
+        channelType: String,
+        channelId: String,
+        file: File,
+        messageId: String?,
+        callback: ProgressCallback?,
+    ): Call<UploadedFile> {
+        return api.sendFile(channelType, channelId, file, messageId, callback)
     }
 
     /**
@@ -1056,7 +1082,33 @@ internal constructor(
         file: File,
         callback: ProgressCallback? = null,
     ): Call<UploadedFile> {
-        return api.sendImage(channelType, channelId, file, callback)
+        return sendImage(channelType, channelId, file, messageId = null, callback = callback)
+    }
+
+    /**
+     * Uploads an image that belongs to the message with [messageId], so the id can be propagated to the
+     * [FileUploader] as part of the upload context.
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param file The image file that needs to be uploaded.
+     * @param messageId The id of the message the image belongs to, or null when the upload is not part of
+     * sending a message.
+     * @param callback The callback to track progress.
+     *
+     * @return Executable async [Call] which completes with [Result] containing an instance of [UploadedFile]
+     * if the image was successfully uploaded.
+     */
+    @CheckResult
+    @InternalStreamChatApi
+    public fun sendImage(
+        channelType: String,
+        channelId: String,
+        file: File,
+        messageId: String?,
+        callback: ProgressCallback?,
+    ): Call<UploadedFile> {
+        return api.sendImage(channelType, channelId, file, messageId, callback)
     }
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -87,6 +87,7 @@ internal interface ChatApi {
         channelType: String,
         channelId: String,
         file: File,
+        messageId: String?,
         callback: ProgressCallback? = null,
     ): Call<UploadedFile>
 
@@ -95,6 +96,7 @@ internal interface ChatApi {
         channelType: String,
         channelId: String,
         file: File,
+        messageId: String?,
         callback: ProgressCallback? = null,
     ): Call<UploadedFile>
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -119,6 +119,7 @@ import io.getstream.chat.android.client.helpers.CallPostponeHelper
 import io.getstream.chat.android.client.parser.toMap
 import io.getstream.chat.android.client.scope.UserScope
 import io.getstream.chat.android.client.uploader.FileTransformer
+import io.getstream.chat.android.client.uploader.FileUploadContext
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.models.AppSettings
@@ -598,59 +599,50 @@ constructor(
         channelType: String,
         channelId: String,
         file: File,
+        messageId: String?,
         callback: ProgressCallback?,
     ): Call<UploadedFile> = CoroutineCall(coroutineScope) {
-        fileTransformer.transform(file)
-            .let { transformedFile ->
-                if (callback != null) {
-                    fileUploader.sendFile(
-                        channelType = channelType,
-                        channelId = channelId,
-                        userId = userId,
-                        file = transformedFile,
-                        callback = callback,
-                    ).onSuccess { uploadedFile ->
-                        callback.onSuccess(url = uploadedFile.file)
-                    }.onError(callback::onError)
-                } else {
-                    fileUploader.sendFile(
-                        channelType = channelType,
-                        channelId = channelId,
-                        userId = userId,
-                        file = transformedFile,
-                    )
-                }
-            }
+        val transformedFile = fileTransformer.transform(file)
+        // Read userId only after the (potentially slow) file transform, so a connection established in the
+        // meantime is picked up.
+        val uploadContext = FileUploadContext(
+            channelType = channelType,
+            channelId = channelId,
+            userId = userId,
+            messageId = messageId,
+        )
+        fileUploader.sendFile(uploadContext, transformedFile, callback)
+            .notifyProgressCallback(callback)
     }
 
     override fun sendImage(
         channelType: String,
         channelId: String,
         file: File,
+        messageId: String?,
         callback: ProgressCallback?,
     ): Call<UploadedFile> = CoroutineCall(coroutineScope) {
-        fileTransformer.transform(file)
-            .let { transformedFile ->
-                if (callback != null) {
-                    fileUploader.sendImage(
-                        channelType = channelType,
-                        channelId = channelId,
-                        userId = userId,
-                        file = transformedFile,
-                        callback = callback,
-                    ).onSuccess { uploadedFile ->
-                        callback.onSuccess(url = uploadedFile.file)
-                    }.onError(callback::onError)
-                } else {
-                    fileUploader.sendImage(
-                        channelType = channelType,
-                        channelId = channelId,
-                        userId = userId,
-                        file = transformedFile,
-                    )
-                }
-            }
+        val transformedFile = fileTransformer.transform(file)
+        // Read userId only after the (potentially slow) file transform, so a connection established in the
+        // meantime is picked up.
+        val uploadContext = FileUploadContext(
+            channelType = channelType,
+            channelId = channelId,
+            userId = userId,
+            messageId = messageId,
+        )
+        fileUploader.sendImage(uploadContext, transformedFile, callback)
+            .notifyProgressCallback(callback)
     }
+
+    private fun Result<UploadedFile>.notifyProgressCallback(callback: ProgressCallback?): Result<UploadedFile> =
+        also { result ->
+            callback?.let { cb ->
+                result
+                    .onSuccess { uploadedFile -> cb.onSuccess(url = uploadedFile.file) }
+                    .onError(cb::onError)
+            }
+        }
 
     override fun deleteFile(channelType: String, channelId: String, url: String): Call<Unit> {
         return CoroutineCall(coroutineScope) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt
@@ -40,6 +40,8 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
      * @param channelType The type of the channel.
      * @param channelId The ID of the channel.
      * @param attachment The attachment to be uploaded.
+     * @param messageId The id of the message the attachment belongs to, or null when the upload is not part
+     * of sending a message.
      * @param progressCallback Used to listen to file upload
      * progress, success, and failure.
      *
@@ -50,6 +52,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
         channelType: String,
         channelId: String,
         attachment: Attachment,
+        messageId: String? = null,
         progressCallback: ProgressCallback? = null,
     ): Result<Attachment> {
         val file = checkNotNull(attachment.upload) { "An attachment needs to have a non null attachment.upload value" }
@@ -63,6 +66,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
             uploadImage(
                 channelType = channelType,
                 channelId = channelId,
+                messageId = messageId,
                 file = file,
                 progressCallback = progressCallback,
                 attachment = attachment,
@@ -74,6 +78,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
             uploadFile(
                 channelType = channelType,
                 channelId = channelId,
+                messageId = messageId,
                 file = file,
                 progressCallback = progressCallback,
                 attachment = attachment,
@@ -88,6 +93,8 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
      *
      * @param channelType The type of the channel.
      * @param channelId The ID of the channel.
+     * @param messageId The id of the message the attachment belongs to, or null when the upload is not part
+     * of sending a message.
      * @param file The file that will be uploaded.
      * @param attachment The attachment to be uploaded.
      * @param progressCallback Used to listen to file upload
@@ -102,6 +109,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
     private suspend fun uploadImage(
         channelType: String,
         channelId: String,
+        messageId: String?,
         file: File,
         progressCallback: ProgressCallback?,
         attachment: Attachment,
@@ -112,7 +120,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
             "[uploadImage] #uploader; mimeType: $mimeType, attachmentType: $attachmentType, " +
                 "file: $file, cid: $channelType:$$channelId, attachment: $attachment"
         }
-        val result = client.sendImage(channelType, channelId, file, progressCallback)
+        val result = client.sendImage(channelType, channelId, file, messageId, progressCallback)
             .await()
         logger.v { "[uploadImage] #uploader; result: $result" }
         return when (result) {
@@ -144,6 +152,8 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
      *
      * @param channelType The type of the channel.
      * @param channelId The ID of the channel.
+     * @param messageId The id of the message the attachment belongs to, or null when the upload is not part
+     * of sending a message.
      * @param file The file that will be uploaded.
      * @param attachment The attachment to be uploaded.
      * @param progressCallback Used to listen to file upload
@@ -158,6 +168,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
     private suspend fun uploadFile(
         channelType: String,
         channelId: String,
+        messageId: String?,
         file: File,
         progressCallback: ProgressCallback?,
         attachment: Attachment,
@@ -168,7 +179,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
             "[uploadFile] #uploader; mimeType: $mimeType, attachmentType: $attachmentType, " +
                 "file: $file, cid: $channelType:$$channelId, attachment: $attachment"
         }
-        val result = client.sendFile(channelType, channelId, file, progressCallback)
+        val result = client.sendFile(channelType, channelId, file, messageId, progressCallback)
             .await()
         logger.v { "[uploadFile] #uploader; result: $result" }
         return when (result) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/worker/UploadAttachmentsWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/worker/UploadAttachmentsWorker.kt
@@ -120,7 +120,8 @@ public class UploadAttachmentsWorker(
                         )
                     }
 
-                    attachmentUploader.uploadAttachment(channelType, channelId, attachment, progressCallback)
+                    attachmentUploader
+                        .uploadAttachment(channelType, channelId, attachment, message.id, progressCallback)
                         .recover { error -> attachment.copy(uploadState = Attachment.UploadState.Failed(error)) }
                         .value
                 } else {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploadContext.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploadContext.kt
@@ -24,9 +24,8 @@ package io.getstream.chat.android.client.uploader
  * @property channelId The id of the channel the file is uploaded to.
  * @property userId The id of the user uploading the file.
  * @property messageId The id of the message the uploaded file belongs to, or null when the upload is not part
- * of sending a message. For message attachments this is the id the message will be sent with, so a custom
- * [FileUploader] can link the uploaded file to the message on its own backend before the message reaches the
- * Stream API.
+ * of sending a message. For message attachments this is the id the message will be sent with, known before
+ * the message reaches the Stream API.
  */
 public class FileUploadContext internal constructor(
     public val channelType: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploadContext.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploadContext.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.uploader
+
+/**
+ * The context in which a file upload happens. Created by the SDK and handed to [FileUploader]
+ * implementations; new context properties can be added over time without breaking implementations.
+ *
+ * @property channelType The type of the channel the file is uploaded to.
+ * @property channelId The id of the channel the file is uploaded to.
+ * @property userId The id of the user uploading the file.
+ * @property messageId The id of the message the uploaded file belongs to, or null when the upload is not part
+ * of sending a message. For message attachments this is the id the message will be sent with, so a custom
+ * [FileUploader] can link the uploaded file to the message on its own backend before the message reaches the
+ * Stream API.
+ */
+public class FileUploadContext internal constructor(
+    public val channelType: String,
+    public val channelId: String,
+    public val userId: String,
+    public val messageId: String? = null,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FileUploadContext) return false
+        return channelType == other.channelType &&
+            channelId == other.channelId &&
+            userId == other.userId &&
+            messageId == other.messageId
+    }
+
+    override fun hashCode(): Int {
+        var result = channelType.hashCode()
+        result = 31 * result + channelId.hashCode()
+        result = 31 * result + userId.hashCode()
+        result = 31 * result + messageId.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "FileUploadContext(channelType='$channelType', channelId='$channelId', " +
+        "userId='$userId', messageId=$messageId)"
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -31,7 +31,7 @@ public interface FileUploader {
      * Uploads a file within the given [uploadContext]. Progress can be accessed via [callback].
      *
      * When the upload is part of sending a message, [FileUploadContext.messageId] carries the id the message
-     * will be sent with, allowing implementations to link the uploaded file to the message on their own backend.
+     * will be sent with.
      *
      * The default implementation ignores the extra context and delegates to the corresponding legacy
      * overload: `sendFile(channelType, channelId, userId, file, callback)` when [callback] is not null,
@@ -54,7 +54,7 @@ public interface FileUploader {
      * Uploads an image within the given [uploadContext]. Progress can be accessed via [callback].
      *
      * When the upload is part of sending a message, [FileUploadContext.messageId] carries the id the message
-     * will be sent with, allowing implementations to link the uploaded image to the message on their own backend.
+     * will be sent with.
      *
      * The default implementation ignores the extra context and delegates to the corresponding legacy
      * overload: `sendImage(channelType, channelId, userId, file, callback)` when [callback] is not null,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -24,6 +24,8 @@ import java.io.File
 /**
  * The FileUploader is responsible for sending and deleting files from given channel
  */
+// The context-aware and legacy overload sets must coexist: the context overloads delegate to the legacy
+// ones by default so that existing implementations keep working unchanged.
 @Suppress("TooManyFunctions")
 public interface FileUploader {
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -24,7 +24,54 @@ import java.io.File
 /**
  * The FileUploader is responsible for sending and deleting files from given channel
  */
+@Suppress("TooManyFunctions")
 public interface FileUploader {
+
+    /**
+     * Uploads a file within the given [uploadContext]. Progress can be accessed via [callback].
+     *
+     * When the upload is part of sending a message, [FileUploadContext.messageId] carries the id the message
+     * will be sent with, allowing implementations to link the uploaded file to the message on their own backend.
+     *
+     * The default implementation ignores the extra context and delegates to the corresponding legacy
+     * overload: `sendFile(channelType, channelId, userId, file, callback)` when [callback] is not null,
+     * `sendFile(channelType, channelId, userId, file)` otherwise.
+     *
+     * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
+     * or an exception if the upload had failed.
+     */
+    public fun sendFile(
+        uploadContext: FileUploadContext,
+        file: File,
+        callback: ProgressCallback? = null,
+    ): Result<UploadedFile> = if (callback != null) {
+        sendFile(uploadContext.channelType, uploadContext.channelId, uploadContext.userId, file, callback)
+    } else {
+        sendFile(uploadContext.channelType, uploadContext.channelId, uploadContext.userId, file)
+    }
+
+    /**
+     * Uploads an image within the given [uploadContext]. Progress can be accessed via [callback].
+     *
+     * When the upload is part of sending a message, [FileUploadContext.messageId] carries the id the message
+     * will be sent with, allowing implementations to link the uploaded image to the message on their own backend.
+     *
+     * The default implementation ignores the extra context and delegates to the corresponding legacy
+     * overload: `sendImage(channelType, channelId, userId, file, callback)` when [callback] is not null,
+     * `sendImage(channelType, channelId, userId, file)` otherwise.
+     *
+     * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
+     * or an exception if the upload had failed.
+     */
+    public fun sendImage(
+        uploadContext: FileUploadContext,
+        file: File,
+        callback: ProgressCallback? = null,
+    ): Result<UploadedFile> = if (callback != null) {
+        sendImage(uploadContext.channelType, uploadContext.channelId, uploadContext.userId, file, callback)
+    } else {
+        sendImage(uploadContext.channelType, uploadContext.channelId, uploadContext.userId, file)
+    }
 
     /**
      * Uploads a file for the given channel. Progress can be accessed via [callback].

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientChannelFileUploaderTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientChannelFileUploaderTests.kt
@@ -31,6 +31,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 /**
@@ -46,7 +49,7 @@ internal class ChatClientChannelFileUploaderTests : BaseChatClientTest() {
         val file = randomFile()
         val callback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
-        whenever(api.sendFile(any(), any(), any(), any()))
+        whenever(api.sendFile(any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(RetroSuccess(uploadedFile).toRetrofitCall())
         // when
         val result = chatClient.sendFile(channelType, channelId, file, callback).await()
@@ -62,7 +65,7 @@ internal class ChatClientChannelFileUploaderTests : BaseChatClientTest() {
         val file = randomFile()
         val callback = mock<ProgressCallback>()
         val errorCode = positiveRandomInt()
-        whenever(api.sendFile(any(), any(), any(), any()))
+        whenever(api.sendFile(any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(RetroError<UploadedFile>(errorCode).toRetrofitCall())
         // when
         val result = chatClient.sendFile(channelType, channelId, file, callback).await()
@@ -78,7 +81,7 @@ internal class ChatClientChannelFileUploaderTests : BaseChatClientTest() {
         val file = randomFile()
         val callback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
-        whenever(api.sendImage(any(), any(), any(), any()))
+        whenever(api.sendImage(any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(RetroSuccess(uploadedFile).toRetrofitCall())
         // when
         val result = chatClient.sendImage(channelType, channelId, file, callback).await()
@@ -94,12 +97,48 @@ internal class ChatClientChannelFileUploaderTests : BaseChatClientTest() {
         val file = randomFile()
         val callback = mock<ProgressCallback>()
         val errorCode = positiveRandomInt()
-        whenever(api.sendImage(any(), any(), any(), any()))
+        whenever(api.sendImage(any(), any(), any(), anyOrNull(), anyOrNull()))
             .thenReturn(RetroError<UploadedFile>(errorCode).toRetrofitCall())
         // when
         val result = chatClient.sendImage(channelType, channelId, file, callback).await()
         // then
         verifyNetworkError(result, errorCode)
+    }
+
+    @Test
+    fun sendFileForwardsMessageId() = runTest {
+        // given
+        val channelType = randomString()
+        val channelId = randomString()
+        val file = randomFile()
+        val messageId = randomString()
+        val callback = mock<ProgressCallback>()
+        val uploadedFile = randomUploadedFile()
+        whenever(api.sendFile(any(), any(), any(), anyOrNull(), anyOrNull()))
+            .thenReturn(RetroSuccess(uploadedFile).toRetrofitCall())
+        // when
+        val result = chatClient.sendFile(channelType, channelId, file, messageId, callback).await()
+        // then
+        verifySuccess(result, uploadedFile)
+        verify(api).sendFile(eq(channelType), eq(channelId), eq(file), eq(messageId), eq(callback))
+    }
+
+    @Test
+    fun sendImageForwardsMessageId() = runTest {
+        // given
+        val channelType = randomString()
+        val channelId = randomString()
+        val file = randomFile()
+        val messageId = randomString()
+        val callback = mock<ProgressCallback>()
+        val uploadedFile = randomUploadedFile()
+        whenever(api.sendImage(any(), any(), any(), anyOrNull(), anyOrNull()))
+            .thenReturn(RetroSuccess(uploadedFile).toRetrofitCall())
+        // when
+        val result = chatClient.sendImage(channelType, channelId, file, messageId, callback).await()
+        // then
+        verifySuccess(result, uploadedFile)
+        verify(api).sendImage(eq(channelType), eq(channelId), eq(file), eq(messageId), eq(callback))
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -128,6 +128,7 @@ import io.getstream.chat.android.client.parser.toMap
 import io.getstream.chat.android.client.scope.ClientScope
 import io.getstream.chat.android.client.scope.UserScope
 import io.getstream.chat.android.client.uploader.FileTransformer
+import io.getstream.chat.android.client.uploader.FileUploadContext
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.uploader.NoOpFileTransformer
 import io.getstream.chat.android.client.utils.ProgressCallback
@@ -180,7 +181,9 @@ import io.getstream.result.Result
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be instance of`
+import org.amshove.kluent.shouldBeNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -190,8 +193,10 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
@@ -694,7 +699,7 @@ internal class MoshiChatApiTest {
     fun testSendFileWithCallback(fileUploaderResult: Result<UploadedFile>, expected: KClass<*>) = runTest {
         // given
         val fileUploader = mock<FileUploader>()
-        whenever(fileUploader.sendFile(any(), any(), any(), any(), any())).doReturn(fileUploaderResult)
+        whenever(fileUploader.sendFile(any(), any(), anyOrNull())).doReturn(fileUploaderResult)
         val fileTransformer = spy<NoOpFileTransformer>()
         val sut = Fixture()
             .withFileUploader(fileUploader)
@@ -707,12 +712,20 @@ internal class MoshiChatApiTest {
         val channelId = randomString()
         val file = randomFile()
         val callback = mock<ProgressCallback>()
+        val messageId = randomString()
         sut.setConnection(userId = userId, connectionId = connectionId)
-        val result = sut.sendFile(channelType, channelId, file, callback).await()
+        val result = sut.sendFile(channelType, channelId, file, messageId, callback).await()
         // then
         result `should be instance of` expected
-        verify(fileUploader, times(1)).sendFile(channelType, channelId, userId, file, callback)
+        val contextCaptor = argumentCaptor<FileUploadContext>()
+        verify(fileUploader, times(1)).sendFile(contextCaptor.capture(), eq(file), eq(callback))
+        val uploadContext = contextCaptor.firstValue
+        uploadContext.channelType `should be equal to` channelType
+        uploadContext.channelId `should be equal to` channelId
+        uploadContext.userId `should be equal to` userId
+        uploadContext.messageId `should be equal to` messageId
         verify(fileUploader, never()).sendFile(any(), any(), any(), any())
+        verify(fileUploader, never()).sendFile(any(), any(), any(), any(), any())
         verify(fileTransformer, times(1)).transform(file)
     }
 
@@ -721,7 +734,7 @@ internal class MoshiChatApiTest {
     fun testSendFileWithoutCallback(fileUploaderResult: Result<UploadedFile>, expected: KClass<*>) = runTest {
         // given
         val fileUploader = mock<FileUploader>()
-        whenever(fileUploader.sendFile(any(), any(), any(), any())).doReturn(fileUploaderResult)
+        whenever(fileUploader.sendFile(any(), any(), anyOrNull())).doReturn(fileUploaderResult)
         val fileTransformer = spy<NoOpFileTransformer>()
         val sut = Fixture()
             .withFileUploader(fileUploader)
@@ -734,10 +747,17 @@ internal class MoshiChatApiTest {
         val channelId = randomString()
         val file = randomFile()
         sut.setConnection(userId = userId, connectionId = connectionId)
-        val result = sut.sendFile(channelType, channelId, file).await()
+        val result = sut.sendFile(channelType, channelId, file, messageId = null).await()
         // then
         result `should be instance of` expected
-        verify(fileUploader, times(1)).sendFile(channelType, channelId, userId, file)
+        val contextCaptor = argumentCaptor<FileUploadContext>()
+        verify(fileUploader, times(1)).sendFile(contextCaptor.capture(), eq(file), isNull())
+        val uploadContext = contextCaptor.firstValue
+        uploadContext.channelType `should be equal to` channelType
+        uploadContext.channelId `should be equal to` channelId
+        uploadContext.userId `should be equal to` userId
+        uploadContext.messageId.shouldBeNull()
+        verify(fileUploader, never()).sendFile(any(), any(), any(), any())
         verify(fileUploader, never()).sendFile(any(), any(), any(), any(), any())
         verify(fileTransformer, times(1)).transform(file)
     }
@@ -747,7 +767,7 @@ internal class MoshiChatApiTest {
     fun testSendImageWithCallback(fileUploaderResult: Result<UploadedFile>, expected: KClass<*>) = runTest {
         // given
         val fileUploader = mock<FileUploader>()
-        whenever(fileUploader.sendImage(any(), any(), any(), any(), any())).doReturn(fileUploaderResult)
+        whenever(fileUploader.sendImage(any(), any(), anyOrNull())).doReturn(fileUploaderResult)
         val fileTransformer = spy<NoOpFileTransformer>()
         val sut = Fixture()
             .withFileUploader(fileUploader)
@@ -760,12 +780,20 @@ internal class MoshiChatApiTest {
         val channelId = randomString()
         val file = randomFile()
         val callback = mock<ProgressCallback>()
+        val messageId = randomString()
         sut.setConnection(userId = userId, connectionId = connectionId)
-        val result = sut.sendImage(channelType, channelId, file, callback).await()
+        val result = sut.sendImage(channelType, channelId, file, messageId, callback).await()
         // then
         result `should be instance of` expected
-        verify(fileUploader, times(1)).sendImage(channelType, channelId, userId, file, callback)
+        val contextCaptor = argumentCaptor<FileUploadContext>()
+        verify(fileUploader, times(1)).sendImage(contextCaptor.capture(), eq(file), eq(callback))
+        val uploadContext = contextCaptor.firstValue
+        uploadContext.channelType `should be equal to` channelType
+        uploadContext.channelId `should be equal to` channelId
+        uploadContext.userId `should be equal to` userId
+        uploadContext.messageId `should be equal to` messageId
         verify(fileUploader, never()).sendImage(any(), any(), any(), any())
+        verify(fileUploader, never()).sendImage(any(), any(), any(), any(), any())
         verify(fileTransformer, times(1)).transform(file)
     }
 
@@ -774,7 +802,7 @@ internal class MoshiChatApiTest {
     fun testSendImageWithoutCallback(fileUploaderResult: Result<UploadedFile>, expected: KClass<*>) = runTest {
         // given
         val fileUploader = mock<FileUploader>()
-        whenever(fileUploader.sendImage(any(), any(), any(), any())).doReturn(fileUploaderResult)
+        whenever(fileUploader.sendImage(any(), any(), anyOrNull())).doReturn(fileUploaderResult)
         val fileTransformer = spy<NoOpFileTransformer>()
         val sut = Fixture()
             .withFileUploader(fileUploader)
@@ -787,10 +815,17 @@ internal class MoshiChatApiTest {
         val channelId = randomString()
         val file = randomFile()
         sut.setConnection(userId = userId, connectionId = connectionId)
-        val result = sut.sendImage(channelType, channelId, file).await()
+        val result = sut.sendImage(channelType, channelId, file, messageId = null).await()
         // then
         result `should be instance of` expected
-        verify(fileUploader, times(1)).sendImage(channelType, channelId, userId, file)
+        val contextCaptor = argumentCaptor<FileUploadContext>()
+        verify(fileUploader, times(1)).sendImage(contextCaptor.capture(), eq(file), isNull())
+        val uploadContext = contextCaptor.firstValue
+        uploadContext.channelType `should be equal to` channelType
+        uploadContext.channelId `should be equal to` channelId
+        uploadContext.userId `should be equal to` userId
+        uploadContext.messageId.shouldBeNull()
+        verify(fileUploader, never()).sendImage(any(), any(), any(), any())
         verify(fileUploader, never()).sendImage(any(), any(), any(), any(), any())
         verify(fileTransformer, times(1)).transform(file)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/attachment/AttachmentUploaderTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/attachment/AttachmentUploaderTests.kt
@@ -41,6 +41,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
@@ -58,6 +59,34 @@ internal class AttachmentUploaderTests {
     fun setup() {
         Shadows.shadowOf(MimeTypeMap.getSingleton())
             .addExtensionMimeTypMapping("jpg", "image/jpeg")
+    }
+
+    @Test
+    fun `Should forward the message id to the client when uploading an attachment`() = runTest {
+        val messageId = randomString()
+        val attachment = randomAttachments(size = 1).first()
+        val clientMock = mock<ChatClient>()
+        whenever(
+            clientMock.sendFile(any(), any(), any(), anyOrNull(), anyOrNull()),
+        ) doReturn TestCall(Result.Success(UploadedFile(file = "url")))
+
+        AttachmentUploader(clientMock).uploadAttachment(channelType, channelId, attachment, messageId = messageId)
+
+        verify(clientMock).sendFile(eq(channelType), eq(channelId), any(), eq(messageId), anyOrNull())
+    }
+
+    @Test
+    fun `Should forward the message id to the client when uploading an image attachment`() = runTest {
+        val messageId = randomString()
+        val attachment = randomAttachments(size = 1).first().copy(upload = randomFile(extension = "jpg"))
+        val clientMock = mock<ChatClient>()
+        whenever(
+            clientMock.sendImage(any(), any(), any(), anyOrNull(), anyOrNull()),
+        ) doReturn TestCall(Result.Success(UploadedFile(file = "url")))
+
+        AttachmentUploader(clientMock).uploadAttachment(channelType, channelId, attachment, messageId = messageId)
+
+        verify(clientMock).sendImage(eq(channelType), eq(channelId), any(), eq(messageId), anyOrNull())
     }
 
     @Test
@@ -184,6 +213,7 @@ internal class AttachmentUploaderTests {
                     eq(channelId),
                     any(),
                     anyOrNull(),
+                    anyOrNull(),
                 ),
             ) doReturn TestCall(result)
         }
@@ -198,6 +228,7 @@ internal class AttachmentUploaderTests {
                         eq(channelId),
                         same(file),
                         anyOrNull(),
+                        anyOrNull(),
                     ),
                 ) doReturn TestCall(fileResult)
                 whenever(
@@ -205,6 +236,7 @@ internal class AttachmentUploaderTests {
                         eq(channelType),
                         eq(channelId),
                         same(file),
+                        anyOrNull(),
                         anyOrNull(),
                     ),
                 ) doReturn TestCall(fileResult)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/FileUploadContextTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/FileUploadContextTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.uploader
+
+import io.getstream.chat.android.randomString
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.junit.jupiter.api.Test
+
+internal class FileUploadContextTest {
+
+    private val channelType = randomString()
+    private val channelId = randomString()
+    private val userId = randomString()
+    private val messageId = randomString()
+    private val context = FileUploadContext(channelType, channelId, userId, messageId)
+
+    @Test
+    fun `contexts with the same values are equal with the same hash code`() {
+        val other = FileUploadContext(channelType, channelId, userId, messageId)
+
+        context shouldBeEqualTo context
+        context shouldBeEqualTo other
+        context.hashCode() shouldBeEqualTo other.hashCode()
+    }
+
+    @Test
+    fun `contexts differing in any value are not equal`() {
+        context shouldNotBeEqualTo FileUploadContext(randomString(), channelId, userId, messageId)
+        context shouldNotBeEqualTo FileUploadContext(channelType, randomString(), userId, messageId)
+        context shouldNotBeEqualTo FileUploadContext(channelType, channelId, randomString(), messageId)
+        context shouldNotBeEqualTo FileUploadContext(channelType, channelId, userId, randomString())
+        context shouldNotBeEqualTo FileUploadContext(channelType, channelId, userId, messageId = null)
+    }
+
+    @Test
+    fun `a context is not equal to a different type or null`() {
+        val differentType: Any = randomString()
+        val nullValue: Any? = null
+
+        (context == differentType) shouldBeEqualTo false
+        (context == nullValue) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `the message id defaults to null`() {
+        FileUploadContext(channelType, channelId, userId).messageId shouldBeEqualTo null
+    }
+
+    @Test
+    fun `toString contains all values`() {
+        val string = context.toString()
+
+        string shouldBeEqualTo
+            "FileUploadContext(channelType='$channelType', channelId='$channelId', " +
+            "userId='$userId', messageId=$messageId)"
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/FileUploaderTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/FileUploaderTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.uploader
+
+import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.chat.android.models.UploadedFile
+import io.getstream.chat.android.randomFile
+import io.getstream.chat.android.randomString
+import io.getstream.result.Result
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.io.File
+
+/**
+ * Verifies that the default bodies of the [FileUploadContext]-aware overloads delegate to the legacy
+ * overloads, so existing [FileUploader] implementations keep working unchanged.
+ */
+internal class FileUploaderTest {
+
+    private val channelType = randomString()
+    private val channelId = randomString()
+    private val userId = randomString()
+    private val file = randomFile()
+    private val uploadContext = FileUploadContext(
+        channelType = channelType,
+        channelId = channelId,
+        userId = userId,
+        messageId = randomString(),
+    )
+
+    @Test
+    fun `sendFile with upload context and callback delegates to the legacy callback overload`() {
+        val uploader = LegacyFileUploader()
+        val callback = mock<ProgressCallback>()
+
+        val result = uploader.sendFile(uploadContext, file, callback)
+
+        (result as Result.Success).value.file shouldBeEqualTo "sendFile-with-callback"
+        uploader.recordedArgs shouldBeEqualTo listOf(channelType, channelId, userId, file, callback)
+    }
+
+    @Test
+    fun `sendFile with upload context and no callback delegates to the legacy overload`() {
+        val uploader = LegacyFileUploader()
+
+        val result = uploader.sendFile(uploadContext, file)
+
+        (result as Result.Success).value.file shouldBeEqualTo "sendFile-without-callback"
+        uploader.recordedArgs shouldBeEqualTo listOf(channelType, channelId, userId, file)
+    }
+
+    @Test
+    fun `sendImage with upload context and callback delegates to the legacy callback overload`() {
+        val uploader = LegacyFileUploader()
+        val callback = mock<ProgressCallback>()
+
+        val result = uploader.sendImage(uploadContext, file, callback)
+
+        (result as Result.Success).value.file shouldBeEqualTo "sendImage-with-callback"
+        uploader.recordedArgs shouldBeEqualTo listOf(channelType, channelId, userId, file, callback)
+    }
+
+    @Test
+    fun `sendImage with upload context and no callback delegates to the legacy overload`() {
+        val uploader = LegacyFileUploader()
+
+        val result = uploader.sendImage(uploadContext, file)
+
+        (result as Result.Success).value.file shouldBeEqualTo "sendImage-without-callback"
+        uploader.recordedArgs shouldBeEqualTo listOf(channelType, channelId, userId, file)
+    }
+
+    /**
+     * A [FileUploader] implementing only the legacy overloads, recording which one is invoked and with
+     * which arguments.
+     */
+    private class LegacyFileUploader : FileUploader {
+
+        var recordedArgs: List<Any?>? = null
+
+        override fun sendFile(
+            channelType: String,
+            channelId: String,
+            userId: String,
+            file: File,
+            callback: ProgressCallback,
+        ): Result<UploadedFile> {
+            recordedArgs = listOf(channelType, channelId, userId, file, callback)
+            return Result.Success(UploadedFile(file = "sendFile-with-callback"))
+        }
+
+        override fun sendFile(
+            channelType: String,
+            channelId: String,
+            userId: String,
+            file: File,
+        ): Result<UploadedFile> {
+            recordedArgs = listOf(channelType, channelId, userId, file)
+            return Result.Success(UploadedFile(file = "sendFile-without-callback"))
+        }
+
+        override fun sendImage(
+            channelType: String,
+            channelId: String,
+            userId: String,
+            file: File,
+            callback: ProgressCallback,
+        ): Result<UploadedFile> {
+            recordedArgs = listOf(channelType, channelId, userId, file, callback)
+            return Result.Success(UploadedFile(file = "sendImage-with-callback"))
+        }
+
+        override fun sendImage(
+            channelType: String,
+            channelId: String,
+            userId: String,
+            file: File,
+        ): Result<UploadedFile> {
+            recordedArgs = listOf(channelType, channelId, userId, file)
+            return Result.Success(UploadedFile(file = "sendImage-without-callback"))
+        }
+
+        override fun deleteFile(
+            channelType: String,
+            channelId: String,
+            userId: String,
+            url: String,
+        ): Result<Unit> = Result.Success(Unit)
+
+        override fun deleteImage(
+            channelType: String,
+            channelId: String,
+            userId: String,
+            url: String,
+        ): Result<Unit> = Result.Success(Unit)
+    }
+}

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/helpers/MyFileUploader.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/helpers/MyFileUploader.java
@@ -19,8 +19,7 @@ public class MyFileUploader implements FileUploader {
     @Override
     public Result<UploadedFile> sendFile(@NotNull FileUploadContext uploadContext, @NotNull File file, @Nullable ProgressCallback callback) {
         try {
-            // uploadContext.getMessageId() is the id of the message this file belongs to. Use it to link
-            // the upload to the message on your own backend before the message is sent.
+            // uploadContext.getMessageId() is the id the message containing this file will be sent with.
             return new Result.Success<>(new UploadedFile("file url", "thumb url"));
         } catch (Exception e) {
             return new Result.Failure(new Error.ThrowableError("Could not send file.", e));
@@ -31,8 +30,7 @@ public class MyFileUploader implements FileUploader {
     @Override
     public Result<UploadedFile> sendImage(@NotNull FileUploadContext uploadContext, @NotNull File file, @Nullable ProgressCallback callback) {
         try {
-            // uploadContext.getMessageId() is the id of the message this image belongs to. Use it to link
-            // the upload to the message on your own backend before the message is sent.
+            // uploadContext.getMessageId() is the id the message containing this image will be sent with.
             return new Result.Success<>(new UploadedFile("url", null));
         } catch (Exception e) {
             return new Result.Failure(new Error.ThrowableError("Could not send image.", e));

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/helpers/MyFileUploader.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/helpers/MyFileUploader.java
@@ -29,6 +29,18 @@ public class MyFileUploader implements FileUploader {
 
     @Nullable
     @Override
+    public Result<UploadedFile> sendImage(@NotNull FileUploadContext uploadContext, @NotNull File file, @Nullable ProgressCallback callback) {
+        try {
+            // uploadContext.getMessageId() is the id of the message this image belongs to. Use it to link
+            // the upload to the message on your own backend before the message is sent.
+            return new Result.Success<>(new UploadedFile("url", null));
+        } catch (Exception e) {
+            return new Result.Failure(new Error.ThrowableError("Could not send image.", e));
+        }
+    }
+
+    @Nullable
+    @Override
     public Result<UploadedFile> sendFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull File file, @NotNull ProgressCallback callback) {
         try {
             return new Result.Success<>(new UploadedFile("file url", "thumb url"));

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/helpers/MyFileUploader.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/helpers/MyFileUploader.java
@@ -8,12 +8,25 @@ import java.io.File;
 
 import io.getstream.result.Error;
 import io.getstream.chat.android.models.UploadedFile;
+import io.getstream.chat.android.client.uploader.FileUploadContext;
 import io.getstream.chat.android.client.uploader.FileUploader;
 import io.getstream.chat.android.client.utils.ProgressCallback;
 import io.getstream.result.Result;
 import kotlin.Unit;
 
 public class MyFileUploader implements FileUploader {
+    @Nullable
+    @Override
+    public Result<UploadedFile> sendFile(@NotNull FileUploadContext uploadContext, @NotNull File file, @Nullable ProgressCallback callback) {
+        try {
+            // uploadContext.getMessageId() is the id of the message this file belongs to. Use it to link
+            // the upload to the message on your own backend before the message is sent.
+            return new Result.Success<>(new UploadedFile("file url", "thumb url"));
+        } catch (Exception e) {
+            return new Result.Failure(new Error.ThrowableError("Could not send file.", e));
+        }
+    }
+
     @Nullable
     @Override
     public Result<UploadedFile> sendFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull File file, @NotNull ProgressCallback callback) {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/helpers/MyFileUploader.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/helpers/MyFileUploader.kt
@@ -23,6 +23,20 @@ class MyFileUploader : FileUploader {
         }
     }
 
+    override fun sendImage(
+        uploadContext: FileUploadContext,
+        file: File,
+        callback: ProgressCallback?,
+    ): Result<UploadedFile> {
+        // uploadContext.messageId is the id of the message this image belongs to. Use it to link the upload
+        // to the message on your own backend before the message is sent.
+        return try {
+            Result.Success(UploadedFile(file = "url"))
+        } catch (e: Exception) {
+            Result.Failure(Error.ThrowableError(message = "Could not send image.", cause = e))
+        }
+    }
+
     override fun sendFile(
         channelType: String,
         channelId: String,

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/helpers/MyFileUploader.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/helpers/MyFileUploader.kt
@@ -14,8 +14,7 @@ class MyFileUploader : FileUploader {
         file: File,
         callback: ProgressCallback?,
     ): Result<UploadedFile> {
-        // uploadContext.messageId is the id of the message this file belongs to. Use it to link the upload
-        // to the message on your own backend before the message is sent.
+        // uploadContext.messageId is the id the message containing this file will be sent with.
         return try {
             Result.Success(UploadedFile(file = "file url", thumbUrl = "thumb url"))
         } catch (e: Exception) {
@@ -28,8 +27,7 @@ class MyFileUploader : FileUploader {
         file: File,
         callback: ProgressCallback?,
     ): Result<UploadedFile> {
-        // uploadContext.messageId is the id of the message this image belongs to. Use it to link the upload
-        // to the message on your own backend before the message is sent.
+        // uploadContext.messageId is the id the message containing this image will be sent with.
         return try {
             Result.Success(UploadedFile(file = "url"))
         } catch (e: Exception) {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/helpers/MyFileUploader.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/helpers/MyFileUploader.kt
@@ -2,12 +2,27 @@ package io.getstream.chat.docs.kotlin.client.helpers
 
 import io.getstream.result.Error
 import io.getstream.chat.android.models.UploadedFile
+import io.getstream.chat.android.client.uploader.FileUploadContext
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.result.Result
 import java.io.File
 
 class MyFileUploader : FileUploader {
+    override fun sendFile(
+        uploadContext: FileUploadContext,
+        file: File,
+        callback: ProgressCallback?,
+    ): Result<UploadedFile> {
+        // uploadContext.messageId is the id of the message this file belongs to. Use it to link the upload
+        // to the message on your own backend before the message is sent.
+        return try {
+            Result.Success(UploadedFile(file = "file url", thumbUrl = "thumb url"))
+        } catch (e: Exception) {
+            Result.Failure(Error.ThrowableError(message = "Could not send file.", cause = e))
+        }
+    }
+
     override fun sendFile(
         channelType: String,
         channelId: String,

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -56,6 +56,8 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.Shadows
 import java.io.File
@@ -116,7 +118,7 @@ internal class UploadAttachmentsIntegrationTests {
     @Test
     fun `Given a message with attachments When upload fails Should store the correct upload state`(): Unit =
         runTest {
-            whenever(uploader!!.uploadAttachment(any(), any(), any(), any())) doThrow IllegalStateException("Error")
+            whenever(uploader!!.uploadAttachment(any(), any(), any(), anyOrNull(), anyOrNull())) doThrow IllegalStateException("Error")
 
             val attachments = randomAttachmentsWithFile().map {
                 it.copy(uploadState = Attachment.UploadState.Idle)
@@ -137,7 +139,7 @@ internal class UploadAttachmentsIntegrationTests {
     @Test
     fun `Given a message with attachments When upload succeeds Should store the correct upload state`(): Unit =
         runTest {
-            whenever(uploader!!.uploadAttachment(any(), any(), any(), any()))
+            whenever(uploader!!.uploadAttachment(any(), any(), any(), anyOrNull(), anyOrNull()))
                 .doAnswer { invocation ->
                     val attachment = invocation.arguments[2] as Attachment
                     Result.Success(attachment.copy(uploadState = Attachment.UploadState.Success))
@@ -154,6 +156,8 @@ internal class UploadAttachmentsIntegrationTests {
 
             uploadAttachmentsWorker.uploadAttachmentsForMessage(message.id)
 
+            verify(uploader!!, times(attachments.size))
+                .uploadAttachment(eq(channelType), eq(channelId), any(), eq(message.id), anyOrNull())
             val persistedMessage = messageRepository.selectMessage(message.id)!!
             persistedMessage.attachments.size shouldBeEqualTo attachments.size
 
@@ -171,6 +175,7 @@ internal class UploadAttachmentsIntegrationTests {
                     eq(channelId),
                     same(file),
                     anyOrNull(),
+                    anyOrNull(),
                 ),
             ) doReturn TestCall(fileResult)
             whenever(
@@ -178,6 +183,7 @@ internal class UploadAttachmentsIntegrationTests {
                     eq(channelType),
                     eq(channelId),
                     same(file),
+                    anyOrNull(),
                     anyOrNull(),
                 ),
             ) doReturn TestCall(imageResult)
@@ -194,6 +200,7 @@ internal class UploadAttachmentsIntegrationTests {
                     eq(channelId),
                     any(),
                     anyOrNull(),
+                    anyOrNull(),
                 ),
             ) doReturn TestCall(fileResult)
             whenever(
@@ -201,6 +208,7 @@ internal class UploadAttachmentsIntegrationTests {
                     eq(channelType),
                     eq(channelId),
                     any(),
+                    anyOrNull(),
                     anyOrNull(),
                 ),
             ) doReturn TestCall(fileResult)

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/WhenUploadAttachmentsTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/WhenUploadAttachmentsTests.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -128,7 +129,7 @@ internal class WhenUploadAttachmentsTests {
     fun `Given exception when upload Should insert message with failed sync status to repo`() = runTest {
         val attachmentUploader =
             mock<AttachmentUploader> {
-                on(it.uploadAttachment(any(), any(), any(), any())) doThrow IllegalStateException("Error")
+                on(it.uploadAttachment(any(), any(), any(), anyOrNull(), anyOrNull())) doThrow IllegalStateException("Error")
             }
         val repository = mock<MessageRepository>()
         val message = randomMessage(
@@ -160,7 +161,7 @@ internal class WhenUploadAttachmentsTests {
         runTest {
             val attachmentUploader =
                 mock<AttachmentUploader> {
-                    on(it.uploadAttachment(any(), any(), any(), any())) doThrow IllegalStateException("Error")
+                    on(it.uploadAttachment(any(), any(), any(), anyOrNull(), anyOrNull())) doThrow IllegalStateException("Error")
                 }
             val repository = mock<MessageRepository>()
             val message = randomMessage(
@@ -205,7 +206,8 @@ internal class WhenUploadAttachmentsTests {
                             any(),
                             any(),
                             any(),
-                            any(),
+                            anyOrNull(),
+                            anyOrNull(),
                         ),
                     ) doReturn Result.Failure(
                         Error.ThrowableError(
@@ -252,7 +254,7 @@ internal class WhenUploadAttachmentsTests {
         runTest {
             val attachmentUploader =
                 mock<AttachmentUploader> {
-                    on(it.uploadAttachment(any(), any(), any(), any())) doAnswer { invocation ->
+                    on(it.uploadAttachment(any(), any(), any(), anyOrNull(), anyOrNull())) doAnswer { invocation ->
                         val attachment = invocation.arguments[2] as Attachment
                         Result.Success(attachment.copy(uploadState = Attachment.UploadState.Success))
                     }


### PR DESCRIPTION
<!-- pr:new-feature -->

### Goal

Expose the id of the message an attachment belongs to to custom `FileUploader` implementations, so apps uploading to their own CDN can link the uploaded file to the message on their side before the message reaches the Stream API.

Closes [AND-1453](https://linear.app/stream/issue/AND-1453/expose-the-message-id-to-custom-fileuploader-implementations-at-upload)

### Implementation

- Add `FileUploadContext`, a read-only, SDK-constructed context (channel type/id, user id, message id). Its constructor is internal so new properties can be added later without breaking implementers.
- Add `FileUploader.sendFile`/`sendImage` overloads receiving the context. They delegate to the existing overloads by default and compile as JVM default methods (`-Xjvm-default=all`), so current `FileUploader` implementations, Kotlin or Java, keep working unchanged. The API diff is purely additive.
- Thread the message id from `UploadAttachmentsWorker` through `AttachmentUploader` and internal `ChatClient`/`ChatApi` overloads down to `MoshiChatApi`, which builds the context and calls the new overloads. Direct (non-message) uploads pass a null message id.

### Testing

- `MoshiChatApiTest` asserts the uploader receives the context with the right channel/user/message id, null message id for plain uploads, and that the legacy overloads are no longer called directly.
- `AttachmentUploaderTests` covers the message id being forwarded to the client call.
- Manually verified in the compose sample with a custom uploader: the id logged at upload time matches the message id stored server-side, for single and multiple attachments, including the offline → WorkManager retry path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File and image uploads can now be associated with a specific message.
  * Custom uploaders receive consolidated upload context, including channel, user, and message details.
  * Existing uploader implementations remain supported through compatibility overloads.
* **Documentation**
  * Updated Java and Kotlin uploader examples to demonstrate message-linked uploads.
* **Tests**
  * Added coverage verifying message ID propagation and context-aware uploader behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->