### PR TITLE
Keep the loader up while a grouped channel list fetches its first page

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,6 @@ android.suppressUnsupportedCompileSdk=34
 
 # Project version
 version=6.42.1
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,3 @@ android.suppressUnsupportedCompileSdk=34
 
 # Project version
 version=6.42.1
-
-# Enabled parallel sync for Gradle 9.4+
-org.gradle.tooling.parallel=true

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
@@ -43,16 +43,36 @@ internal class QueryGroupedChannelsListenerState(
         // parameters. When `groups == null` the caller is relying on the server's default group
         // set — we don't know the keys until the response, so we defer to the result-side capture
         // (which only fires on success, but in that case there is no failure to recover from).
+        // Only named groups get a loader: with `groups == null` the keys are unknown until the response.
         groups?.forEach { (key, groupQuery) ->
-            logic.queryChannels(QueryChannelsIdentifier.Grouped(key))
-                .setGroupedQueryConfig(
-                    GroupedQueryConfig(
-                        limit = limit,
-                        pageSize = groupQuery.limit,
-                        watch = watch,
-                        presence = presence,
-                    ),
-                )
+            val queryLogic = logic.queryChannels(QueryChannelsIdentifier.Grouped(key))
+            queryLogic.setGroupedQueryConfig(
+                GroupedQueryConfig(
+                    limit = limit,
+                    pageSize = groupQuery.limit,
+                    watch = watch,
+                    presence = presence,
+                ),
+            )
+            // The only point that knows a fetch is starting: grouped state is initialised separately
+            // from the query, so the offline load cannot tell an in-flight first page from no fetch.
+            if (groupQuery.isFirstPage()) {
+                queryLogic.startLoadingFirstPageIfNeverLoaded()
+            }
+        }
+    }
+
+    private fun GroupedChannelsGroupQuery.isFirstPage(): Boolean = next == null && prev == null
+
+    /** Ends the first-page load for every [keys] entry that was requested as a first page. */
+    private suspend fun finishFirstPageLoads(
+        keys: Set<String>,
+        groups: Map<String, GroupedChannelsGroupQuery>?,
+    ) {
+        keys.forEach { key ->
+            if (groups?.get(key)?.isFirstPage() == true) {
+                logic.queryChannels(QueryChannelsIdentifier.Grouped(key)).finishFirstPageLoad()
+            }
         }
     }
 
@@ -63,10 +83,14 @@ internal class QueryGroupedChannelsListenerState(
         watch: Boolean,
         presence: Boolean,
     ) {
-        if (result !is Result.Success) return
+        if (result !is Result.Success) {
+            // The success path ends the load while applying the result, so failures must do it here.
+            finishFirstPageLoads(groups.orEmpty().keys, groups)
+            return
+        }
 
         // Only the first page carries initial unread counts.
-        val isFirstPageRequest = groups.orEmpty().values.none { it.next != null || it.prev != null }
+        val isFirstPageRequest = groups.orEmpty().values.all { it.isFirstPage() }
         if (isFirstPageRequest) {
             val next = groupedUnreadChannelsUpdater.calculateUpdatedCounts(
                 current = globalState.groupedUnreadChannels.value,
@@ -78,11 +102,14 @@ internal class QueryGroupedChannelsListenerState(
         // Route each returned group's channels into the per-group state. The captured config lets
         // both ChannelListViewModel.loadMoreGroupedChannels and SyncManager.updateGroupedQueryChannels
         // reuse the caller's original parameters on paginated and recovery calls respectively.
+        // A requested group the response omits never reaches applyGroupedResult, so end it here.
+        finishFirstPageLoads(groups.orEmpty().keys - result.value.groups.keys, groups)
+
         result.value.groups.forEach { (key, group) ->
             // A request without `next`/`prev` cursors for this key (or no per-group query at all)
             // is a first-page request → replace channels. With a cursor → paginated → append.
             val perGroupQuery = groups?.get(key)
-            val isFirstPage = perGroupQuery?.let { it.next == null && it.prev == null } ?: true
+            val isFirstPage = perGroupQuery?.isFirstPage() ?: true
             val perGroupLimit = perGroupQuery?.limit
             val queryLogic = logic.queryChannels(QueryChannelsIdentifier.Grouped(key))
             queryLogic.setGroupedQueryConfig(

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
@@ -67,10 +67,11 @@ internal class QueryGroupedChannelsListenerState(
     private suspend fun finishFirstPageLoads(
         keys: Set<String>,
         groups: Map<String, GroupedChannelsGroupQuery>?,
+        completed: Boolean,
     ) {
         keys.forEach { key ->
             if (groups?.get(key)?.isFirstPage() == true) {
-                logic.queryChannels(QueryChannelsIdentifier.Grouped(key)).finishFirstPageLoad()
+                logic.queryChannels(QueryChannelsIdentifier.Grouped(key)).finishFirstPageLoad(completed)
             }
         }
     }
@@ -84,7 +85,7 @@ internal class QueryGroupedChannelsListenerState(
     ) {
         if (result !is Result.Success) {
             // The success path ends the load while applying the result, so failures must do it here.
-            finishFirstPageLoads(groups.orEmpty().keys, groups)
+            finishFirstPageLoads(groups.orEmpty().keys, groups, completed = false)
             return
         }
 
@@ -102,7 +103,7 @@ internal class QueryGroupedChannelsListenerState(
         // both ChannelListViewModel.loadMoreGroupedChannels and SyncManager.updateGroupedQueryChannels
         // reuse the caller's original parameters on paginated and recovery calls respectively.
         // A requested group the response omits never reaches applyGroupedResult, so end it here.
-        finishFirstPageLoads(groups.orEmpty().keys - result.value.groups.keys, groups)
+        finishFirstPageLoads(groups.orEmpty().keys - result.value.groups.keys, groups, completed = true)
 
         result.value.groups.forEach { (key, group) ->
             // A request without `next`/`prev` cursors for this key (or no per-group query at all)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
@@ -99,12 +99,15 @@ internal class QueryGroupedChannelsListenerState(
             globalState.setGroupedUnreadChannels(next)
         }
 
+        // Defensive: today the server answers every requested group, with an empty channel list
+        // when the group has nothing, so this is expected to be a no-op. It stays because a group
+        // the response left out would never reach applyGroupedResult, and the loader it raised
+        // would never come down.
+        finishFirstPageLoads(groups.orEmpty().keys - result.value.groups.keys, groups, completed = true)
+
         // Route each returned group's channels into the per-group state. The captured config lets
         // both ChannelListViewModel.loadMoreGroupedChannels and SyncManager.updateGroupedQueryChannels
         // reuse the caller's original parameters on paginated and recovery calls respectively.
-        // A requested group the response omits never reaches applyGroupedResult, so end it here.
-        finishFirstPageLoads(groups.orEmpty().keys - result.value.groups.keys, groups, completed = true)
-
         result.value.groups.forEach { (key, group) ->
             // A request without `next`/`prev` cursors for this key (or no per-group query at all)
             // is a first-page request → replace channels. With a cursor → paginated → append.

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerState.kt
@@ -43,7 +43,6 @@ internal class QueryGroupedChannelsListenerState(
         // parameters. When `groups == null` the caller is relying on the server's default group
         // set — we don't know the keys until the response, so we defer to the result-side capture
         // (which only fires on success, but in that case there is no failure to recover from).
-        // Only named groups get a loader: with `groups == null` the keys are unknown until the response.
         groups?.forEach { (key, groupQuery) ->
             val queryLogic = logic.queryChannels(QueryChannelsIdentifier.Grouped(key))
             queryLogic.setGroupedQueryConfig(

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -186,9 +186,14 @@ internal class QueryChannelsLogic(
      *
      * Both steps are needed to leave `Loading`, which [ChannelsStateData] reports while the flag is
      * set *or* while channels are still null.
+     *
+     * [completed] tells the two apart. A group the response omits has been answered, so it settles
+     * and a later request leaves it on the empty state. A failure has not, so the group stays
+     * never-loaded and a retry raises the loader again, which is what `queryOffline` does for a
+     * standard list after a failed empty first page.
      */
-    internal suspend fun finishFirstPageLoad() {
-        hasCompletedAQuery = true
+    internal suspend fun finishFirstPageLoad(completed: Boolean) {
+        if (completed) hasCompletedAQuery = true
         groupedResultMutex.withLock {
             queryChannelsStateLogic.initializeChannelsIfNeeded()
             queryChannelsStateLogic.setLoadingFirstPage(false)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -31,6 +31,7 @@ import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.state.event.handler.chat.EventHandlingResult
 import io.getstream.chat.android.state.model.querychannels.pagination.internal.toOfflinePaginationRequest
+import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
 import io.getstream.chat.android.state.plugin.state.querychannels.GroupedQueryConfig
 import io.getstream.log.taggedLogger
 import io.getstream.result.Result
@@ -102,12 +103,17 @@ internal class QueryChannelsLogic(
         val cachedChannels = fetchChannelsFromCache(pagination)
         groupedResultMutex.withLock {
             val existing = queryChannelsStateLogic.getChannels()
-            if (existing.isNullOrEmpty() && !cachedChannels.isNullOrEmpty()) {
+            val hasCachedChannels = !cachedChannels.isNullOrEmpty()
+            if (existing.isNullOrEmpty() && hasCachedChannels) {
                 logger.d { "[loadOfflineGroupedChannels] showing ${cachedChannels.size} cached channels" }
                 queryChannelsStateLogic.addChannelsState(cachedChannels)
             }
             queryChannelsStateLogic.initializeChannelsIfNeeded()
-            queryChannelsStateLogic.setLoadingFirstPage(false)
+            // Only stop loading once there is something to show. On a miss the flag is left as it
+            // is: raised if a request is in flight, false if none is coming.
+            if (hasCachedChannels || !existing.isNullOrEmpty()) {
+                queryChannelsStateLogic.setLoadingFirstPage(false)
+            }
         }
     }
 
@@ -144,6 +150,37 @@ internal class QueryChannelsLogic(
             queryChannelsStateLogic.setLoadingMore(isLoading)
         } else {
             queryChannelsStateLogic.setLoadingFirstPage(isLoading)
+        }
+    }
+
+    /**
+     * Marks a grouped first page as loading, but only for a group that has never loaded.
+     *
+     * The guard is `== null` rather than `isNullOrEmpty()`: a group that loaded and came back empty
+     * holds a non-null empty map, and re-raising for it would put every settled empty tab back into
+     * a spinner on each reconnect, since `SyncManager` recovers grouped lists through this listener.
+     *
+     * Shares [groupedResultMutex] so the check cannot read a half-applied update.
+     */
+    internal suspend fun startLoadingFirstPageIfNeverLoaded() {
+        groupedResultMutex.withLock {
+            if (queryChannelsStateLogic.getChannels() == null) {
+                queryChannelsStateLogic.setLoadingFirstPage(true)
+            }
+        }
+    }
+
+    /**
+     * Ends a grouped first-page load that produced no channels of its own: a failed request, or a
+     * requested group the response left out.
+     *
+     * Both steps are needed to leave `Loading`, which [ChannelsStateData] reports while the flag is
+     * set *or* while channels are still null.
+     */
+    internal suspend fun finishFirstPageLoad() {
+        groupedResultMutex.withLock {
+            queryChannelsStateLogic.initializeChannelsIfNeeded()
+            loadingPerPage(isLoading = false, hasOffset = false)
         }
     }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -59,6 +59,14 @@ internal class QueryChannelsLogic(
     private val groupedResultMutex = Mutex()
 
     /**
+     * Whether a grouped query has ever finished for this group, successfully or not. Distinguishes
+     * a group that has never loaded from one that loaded and is genuinely empty, which state alone
+     * cannot express: both hold an empty channel map.
+     */
+    @Volatile
+    private var hasCompletedAQuery = false
+
+    /**
      * Sets the current request and optimistically loads any cached channels for the given
      * [request] from the local database. The cached channels are added to the in-memory state.
      * No remote API call is made.
@@ -154,17 +162,19 @@ internal class QueryChannelsLogic(
     }
 
     /**
-     * Marks a grouped first page as loading, but only for a group that has never loaded.
+     * Marks a grouped first page as loading, for a group that has nothing to show and has never had
+     * a query finish.
      *
-     * The guard is `== null` rather than `isNullOrEmpty()`: a group that loaded and came back empty
-     * holds a non-null empty map, and re-raising for it would put every settled empty tab back into
-     * a spinner on each reconnect, since `SyncManager` recovers grouped lists through this listener.
+     * Both halves are needed. Without [hasCompletedAQuery] a settled empty group would go back to a
+     * spinner on every reconnect, since `SyncManager` recovers grouped lists through this listener.
+     * Without the emptiness check a request would hide cached channels behind a spinner, because
+     * [ChannelsStateData] reports `Loading` whenever the flag is set, regardless of content.
      *
      * Shares [groupedResultMutex] so the check cannot read a half-applied update.
      */
     internal suspend fun startLoadingFirstPageIfNeverLoaded() {
         groupedResultMutex.withLock {
-            if (queryChannelsStateLogic.getChannels() == null) {
+            if (!hasCompletedAQuery && queryChannelsStateLogic.getChannels().isNullOrEmpty()) {
                 queryChannelsStateLogic.setLoadingFirstPage(true)
             }
         }
@@ -178,6 +188,7 @@ internal class QueryChannelsLogic(
      * set *or* while channels are still null.
      */
     internal suspend fun finishFirstPageLoad() {
+        hasCompletedAQuery = true
         groupedResultMutex.withLock {
             queryChannelsStateLogic.initializeChannelsIfNeeded()
             queryChannelsStateLogic.setLoadingFirstPage(false)
@@ -301,6 +312,7 @@ internal class QueryChannelsLogic(
             queryChannelsStateLogic.setLoadingFirstPage(false)
             queryChannelsStateLogic.setLoadingMore(false)
             queryChannelsStateLogic.setRecoveryNeeded(false)
+            hasCompletedAQuery = true
 
             // Persist
             queryChannelsDatabaseLogic.insertQueryChannels(queryChannelsStateLogic.getQuerySpecs())

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -171,6 +171,11 @@ internal class QueryChannelsLogic(
      * [ChannelsStateData] reports `Loading` whenever the flag is set, regardless of content.
      *
      * Shares [groupedResultMutex] so the check cannot read a half-applied update.
+     *
+     * The raise is undone by the matching result, so an explicit `Call.cancel()` between the two
+     * leaves the group on the loader until a later grouped query finishes. Cancelling the calling
+     * coroutine or its scope is fine, the result listener still runs, and nothing in the SDK
+     * cancels this call.
      */
     internal suspend fun startLoadingFirstPageIfNeverLoaded() {
         groupedResultMutex.withLock {
@@ -181,8 +186,8 @@ internal class QueryChannelsLogic(
     }
 
     /**
-     * Ends a grouped first-page load that produced no channels of its own: a failed request, or a
-     * requested group the response left out.
+     * Ends a grouped first-page load that produced no channels of its own: a failed request, or the
+     * defensive case of a requested group the response left out.
      *
      * Both steps are needed to leave `Loading`, which [ChannelsStateData] reports while the flag is
      * set *or* while channels are still null.
@@ -193,8 +198,9 @@ internal class QueryChannelsLogic(
      * standard list after a failed empty first page.
      */
     internal suspend fun finishFirstPageLoad(completed: Boolean) {
-        if (completed) hasCompletedAQuery = true
         groupedResultMutex.withLock {
+            // Set with the clear, matching applyGroupedResult, so both writers hold the lock.
+            if (completed) hasCompletedAQuery = true
             queryChannelsStateLogic.initializeChannelsIfNeeded()
             queryChannelsStateLogic.setLoadingFirstPage(false)
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -180,7 +180,7 @@ internal class QueryChannelsLogic(
     internal suspend fun finishFirstPageLoad() {
         groupedResultMutex.withLock {
             queryChannelsStateLogic.initializeChannelsIfNeeded()
-            loadingPerPage(isLoading = false, hasOffset = false)
+            queryChannelsStateLogic.setLoadingFirstPage(false)
         }
     }
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerStateTest.kt
@@ -107,7 +107,7 @@ internal class QueryGroupedChannelsListenerStateTest {
 
         // then — the success path ends it while applying the result, so a failure that skipped
         // that path would otherwise leave a permanent spinner.
-        verify(logicFor("support")).finishFirstPageLoad()
+        verify(logicFor("support")).finishFirstPageLoad(completed = false)
     }
 
     @Test
@@ -136,8 +136,8 @@ internal class QueryGroupedChannelsListenerStateTest {
         )
 
         // then — the omitted group never reaches applyGroupedResult, so its loader is ended here.
-        verify(logicFor("direct")).finishFirstPageLoad()
-        verify(logicFor("support"), never()).finishFirstPageLoad()
+        verify(logicFor("direct")).finishFirstPageLoad(completed = true)
+        verify(logicFor("support"), never()).finishFirstPageLoad(any())
     }
 
     @Test
@@ -152,7 +152,7 @@ internal class QueryGroupedChannelsListenerStateTest {
         )
 
         // then
-        verify(logicFor("support"), never()).finishFirstPageLoad()
+        verify(logicFor("support"), never()).finishFirstPageLoad(any())
     }
 
     @Test

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryGroupedChannelsListenerStateTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -43,9 +44,14 @@ import org.mockito.kotlin.whenever
 
 internal class QueryGroupedChannelsListenerStateTest {
 
-    private val queryChannelsLogic: QueryChannelsLogic = mock()
+    // One mock per group key: a single shared mock cannot tell "routed to the right group" from
+    // "routed anywhere", which is exactly the class of bug the omitted-group handling guards against.
+    private val groupLogics = mutableMapOf<String, QueryChannelsLogic>()
+    private fun logicFor(key: String): QueryChannelsLogic = groupLogics.getOrPut(key) { mock() }
     private val logic: LogicRegistry = mock {
-        on(it.queryChannels(any<QueryChannelsIdentifier>())) doReturn queryChannelsLogic
+        on(it.queryChannels(any<QueryChannelsIdentifier>())) doAnswer { invocation ->
+            logicFor((invocation.arguments[0] as QueryChannelsIdentifier.Grouped).groupKey)
+        }
     }
     private val globalState: MutableGlobalState = mock()
     private val stateRegistry: StateRegistry = mock()
@@ -54,6 +60,100 @@ internal class QueryGroupedChannelsListenerStateTest {
         currentUserId = "test-user",
     )
     private val listener = QueryGroupedChannelsListenerState(logic, globalState, groupedUnreadChannelsUpdater)
+
+    @Test
+    fun `first-page request raises the loading flag for each named group`() = runTest {
+        // when
+        listener.onQueryGroupedChannelsRequest(
+            limit = 10,
+            groups = mapOf(
+                "support" to GroupedChannelsGroupQuery(limit = 5),
+                "direct" to GroupedChannelsGroupQuery(limit = 5),
+            ),
+            watch = true,
+            presence = false,
+        )
+
+        // then — the offline read cannot tell an in-flight first page from one that never comes,
+        // so the loader has to be raised here, where we know a fetch is starting.
+        verify(logicFor("support")).startLoadingFirstPageIfNeverLoaded()
+        verify(logicFor("direct")).startLoadingFirstPageIfNeverLoaded()
+    }
+
+    @Test
+    fun `paginated request does not raise the loading flag`() = runTest {
+        // when — a cursor means the list already has content and is appending to it.
+        listener.onQueryGroupedChannelsRequest(
+            limit = 10,
+            groups = mapOf("support" to GroupedChannelsGroupQuery(limit = 5, next = "cursor")),
+            watch = true,
+            presence = false,
+        )
+
+        // then
+        verify(logicFor("support"), never()).startLoadingFirstPageIfNeverLoaded()
+    }
+
+    @Test
+    fun `failed first-page result clears the loading flag`() = runTest {
+        // when
+        listener.onQueryGroupedChannelsResult(
+            result = Result.Failure(Error.GenericError("boom")),
+            limit = 10,
+            groups = mapOf("support" to GroupedChannelsGroupQuery(limit = 5)),
+            watch = true,
+            presence = false,
+        )
+
+        // then — the success path ends it while applying the result, so a failure that skipped
+        // that path would otherwise leave a permanent spinner.
+        verify(logicFor("support")).finishFirstPageLoad()
+    }
+
+    @Test
+    fun `successful result ends the load for a requested group the response left out`() = runTest {
+        // given — two groups requested, only one echoed back.
+        whenever(globalState.groupedUnreadChannels) doReturn MutableStateFlow(emptyMap())
+        doNothing().`when`(globalState).setGroupedUnreadChannels(any())
+        val result = Result.Success(
+            GroupedChannels(
+                groups = mapOf(
+                    "support" to GroupedChannelsGroup(groupKey = "support", channels = emptyList(), next = null, prev = null),
+                ),
+            ),
+        )
+
+        // when
+        listener.onQueryGroupedChannelsResult(
+            result = result,
+            limit = 10,
+            groups = mapOf(
+                "support" to GroupedChannelsGroupQuery(limit = 5),
+                "direct" to GroupedChannelsGroupQuery(limit = 5),
+            ),
+            watch = true,
+            presence = false,
+        )
+
+        // then — the omitted group never reaches applyGroupedResult, so its loader is ended here.
+        verify(logicFor("direct")).finishFirstPageLoad()
+        verify(logicFor("support"), never()).finishFirstPageLoad()
+    }
+
+    @Test
+    fun `failed paginated result leaves the first-page flag alone`() = runTest {
+        // when
+        listener.onQueryGroupedChannelsResult(
+            result = Result.Failure(Error.GenericError("boom")),
+            limit = 10,
+            groups = mapOf("support" to GroupedChannelsGroupQuery(limit = 5, next = "cursor")),
+            watch = true,
+            presence = false,
+        )
+
+        // then
+        verify(logicFor("support"), never()).finishFirstPageLoad()
+    }
 
     @Test
     fun `successful first-page result merges returned unread counts into existing global state`() = runTest {
@@ -244,8 +344,8 @@ internal class QueryGroupedChannelsListenerStateTest {
             // then
             verify(logic).queryChannels(eq(QueryChannelsIdentifier.Grouped("direct")))
             verify(logic).queryChannels(eq(QueryChannelsIdentifier.Grouped("support")))
-            verify(queryChannelsLogic).applyGroupedResult(groupDirect, isFirstPage = true)
-            verify(queryChannelsLogic).applyGroupedResult(groupSupport, isFirstPage = true)
+            verify(logicFor("direct")).applyGroupedResult(groupDirect, isFirstPage = true)
+            verify(logicFor("support")).applyGroupedResult(groupSupport, isFirstPage = true)
         }
 
     @Test
@@ -261,10 +361,10 @@ internal class QueryGroupedChannelsListenerStateTest {
             presence = false,
         )
         // then - per-group override captured for "a", request-level only for "b"
-        verify(queryChannelsLogic).setGroupedQueryConfig(
+        verify(logicFor("a")).setGroupedQueryConfig(
             GroupedQueryConfig(limit = 20, pageSize = 5, watch = true, presence = false),
         )
-        verify(queryChannelsLogic).setGroupedQueryConfig(
+        verify(logicFor("b")).setGroupedQueryConfig(
             GroupedQueryConfig(limit = 20, pageSize = null, watch = true, presence = false),
         )
         verify(logic).queryChannels(eq(QueryChannelsIdentifier.Grouped("a")))
@@ -280,8 +380,10 @@ internal class QueryGroupedChannelsListenerStateTest {
             watch = true,
             presence = false,
         )
-        // then - no per-group keys to write to; defer to result-side capture
-        verify(queryChannelsLogic, never()).setGroupedQueryConfig(any())
+        // then - no per-group keys to write to; defer to result-side capture. Asserted on the
+        // registry rather than on a group's logic: with groups = null nothing resolves a logic, so
+        // logicFor() would mint a fresh mock and never() would pass for free.
+        verify(logic, never()).queryChannels(any<QueryChannelsIdentifier>())
     }
 
     @Test
@@ -304,10 +406,10 @@ internal class QueryGroupedChannelsListenerStateTest {
                 presence = false,
             )
             // then - per-group override captured for "a", request-level only for "b"
-            verify(queryChannelsLogic).setGroupedQueryConfig(
+            verify(logicFor("a")).setGroupedQueryConfig(
                 GroupedQueryConfig(limit = 20, pageSize = 5, watch = true, presence = false),
             )
-            verify(queryChannelsLogic).setGroupedQueryConfig(
+            verify(logicFor("b")).setGroupedQueryConfig(
                 GroupedQueryConfig(limit = 20, pageSize = null, watch = true, presence = false),
             )
         }
@@ -328,7 +430,7 @@ internal class QueryGroupedChannelsListenerStateTest {
             presence = true,
         )
         // then - config still written so subsequent pagination knows the watch/presence flags
-        verify(queryChannelsLogic).setGroupedQueryConfig(
+        verify(logicFor("direct")).setGroupedQueryConfig(
             GroupedQueryConfig(limit = null, pageSize = null, watch = true, presence = true),
         )
     }
@@ -357,7 +459,7 @@ internal class QueryGroupedChannelsListenerStateTest {
             presence = false,
         )
         // then
-        verify(queryChannelsLogic).applyGroupedResult(groupSupport, isFirstPage = false)
+        verify(logicFor("support")).applyGroupedResult(groupSupport, isFirstPage = false)
     }
 
     @Test
@@ -384,6 +486,6 @@ internal class QueryGroupedChannelsListenerStateTest {
             presence = false,
         )
         // then
-        verify(queryChannelsLogic).applyGroupedResult(groupSupport, isFirstPage = false)
+        verify(logicFor("support")).applyGroupedResult(groupSupport, isFirstPage = false)
     }
 }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
@@ -381,15 +381,6 @@ internal class QueryChannelsLogicGroupedTest {
     }
 
     @Test
-    fun `startLoadingFirstPageIfNeverLoaded does not hide an already populated list behind a loader`() = runTest {
-        whenever(queryChannelsStateLogic.getChannels()) doReturn mapOf("messaging:ch1" to randomChannel(id = "ch1"))
-
-        logic.startLoadingFirstPageIfNeverLoaded()
-
-        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
-    }
-
-    @Test
     fun `cached channels are not hidden behind a loader before the first query finishes`() = runTest {
         // Given — the offline read populated the list; no query has completed yet.
         whenever(queryChannelsStateLogic.getChannels()) doReturn mapOf("messaging:ch1" to randomChannel(id = "ch1"))

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
@@ -405,7 +405,7 @@ internal class QueryChannelsLogicGroupedTest {
         // Given — a query finished and the group came back empty. This is the shape SyncManager
         // recovery hits on every reconnect.
         whenever(queryChannelsStateLogic.getChannels()) doReturn emptyMap()
-        logic.finishFirstPageLoad()
+        logic.finishFirstPageLoad(completed = true)
 
         // When
         logic.startLoadingFirstPageIfNeverLoaded()
@@ -415,12 +415,23 @@ internal class QueryChannelsLogicGroupedTest {
     }
 
     @Test
+    fun `a failed first page stays retryable, so a later request raises the loader again`() = runTest {
+        whenever(queryChannelsStateLogic.getChannels()) doReturn emptyMap()
+        logic.finishFirstPageLoad(completed = false)
+
+        logic.startLoadingFirstPageIfNeverLoaded()
+
+        // A retry after a failure shows the loader, matching queryOffline for a standard list.
+        verify(queryChannelsStateLogic).setLoadingFirstPage(true)
+    }
+
+    @Test
     fun `finishFirstPageLoad ends Loading even when the request failed before the offline read`() = runTest {
         // Given — nothing has initialised channels yet, so rawChannels is still null.
         whenever(queryChannelsStateLogic.getChannels()) doReturn null
 
         // When
-        logic.finishFirstPageLoad()
+        logic.finishFirstPageLoad(completed = false)
 
         // Then — clearing the flag alone is not enough: ChannelsStateData reports Loading while
         // channels are null, so the state has to be initialised too or the spinner never ends.
@@ -511,7 +522,7 @@ internal class QueryChannelsLogicGroupedTest {
         assertEquals(ChannelsStateData.Loading, mutableState.channelsStateData.value)
 
         // And when the request fails, the load ends rather than leaving the list spinning.
-        realLogic.finishFirstPageLoad()
+        realLogic.finishFirstPageLoad(completed = false)
         assertEquals(ChannelsStateData.OfflineNoResults, mutableState.channelsStateData.value)
     }
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
@@ -389,16 +389,29 @@ internal class QueryChannelsLogicGroupedTest {
     }
 
     @Test
+    fun `cached channels are not hidden behind a loader before the first query finishes`() = runTest {
+        // Given — the offline read populated the list; no query has completed yet.
+        whenever(queryChannelsStateLogic.getChannels()) doReturn mapOf("messaging:ch1" to randomChannel(id = "ch1"))
+
+        // When
+        logic.startLoadingFirstPageIfNeverLoaded()
+
+        // Then
+        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+    }
+
+    @Test
     fun `a settled empty group is not put back into the loader by a later request`() = runTest {
-        // Given — a group that loaded and came back empty holds a non-null empty map. This is the
-        // shape SyncManager recovery hits on every reconnect.
+        // Given — a query finished and the group came back empty. This is the shape SyncManager
+        // recovery hits on every reconnect.
         whenever(queryChannelsStateLogic.getChannels()) doReturn emptyMap()
+        logic.finishFirstPageLoad()
 
         // When
         logic.startLoadingFirstPageIfNeverLoaded()
 
         // Then — no spinner over a tab the user has already seen settle as empty.
-        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(true)
     }
 
     @Test
@@ -500,6 +513,42 @@ internal class QueryChannelsLogicGroupedTest {
         // And when the request fails, the load ends rather than leaving the list spinning.
         realLogic.finishFirstPageLoad()
         assertEquals(ChannelsStateData.OfflineNoResults, mutableState.channelsStateData.value)
+    }
+
+    @Test
+    fun `a request after the offline read still raises the loader`() = runTest {
+        // Given — the offline read runs first and misses, so the channel map is already non-null.
+        val mutableState = QueryChannelsMutableState(
+            identifier = QueryChannelsIdentifier.Grouped(GROUP_KEY),
+            scope = testCoroutines.scope,
+            latestUsers = MutableStateFlow(emptyMap()),
+            activeLiveLocations = MutableStateFlow(emptyList()),
+        )
+        val realLogic = QueryChannelsLogic(
+            identifier = QueryChannelsIdentifier.Grouped(GROUP_KEY),
+            client = client,
+            queryChannelsStateLogic = QueryChannelsStateLogic(
+                mutableState = mutableState,
+                stateRegistry = mock(),
+                logicRegistry = mock(),
+                coroutineScope = testCoroutines.scope,
+            ),
+            queryChannelsDatabaseLogic = queryChannelsDatabaseLogic,
+        )
+        whenever(
+            queryChannelsDatabaseLogic.fetchChannelsFromCache(
+                any<AnyChannelPaginationRequest>(),
+                any<QueryChannelsIdentifier>(),
+            ),
+        ) doReturn null
+        realLogic.loadOfflineGroupedChannels()
+        assertEquals(ChannelsStateData.OfflineNoResults, mutableState.channelsStateData.value)
+
+        // When
+        realLogic.startLoadingFirstPageIfNeverLoaded()
+
+        // Then — a non-null empty map no longer blocks the raise; only a finished query does.
+        assertEquals(ChannelsStateData.Loading, mutableState.channelsStateData.value)
     }
 
     // endregion

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
@@ -26,11 +26,14 @@ import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.GroupedChannelsGroup
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.randomChannel
+import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
+import io.getstream.chat.android.state.plugin.state.querychannels.internal.QueryChannelsMutableState
 import io.getstream.chat.android.test.TestCoroutineRule
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -341,9 +344,92 @@ internal class QueryChannelsLogicGroupedTest {
         // When
         logic.loadOfflineGroupedChannels()
 
-        // Then — no channels to add, but state is initialized and loading flag reset.
+        // Then — no channels to add, state is initialized, and the loading flag is left alone so an
+        // in-flight first page keeps its loader instead of falling through to the empty state.
         verify(queryChannelsStateLogic, never()).addChannelsState(any())
         verify(queryChannelsStateLogic).initializeChannelsIfNeeded()
+        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+    }
+
+    @Test
+    fun `loadOfflineGroupedChannels leaves the loading flag alone when the cache is empty`() = runTest {
+        // Given — a spec exists but its channels are gone, which reads the same as a miss.
+        whenever(queryChannelsStateLogic.getChannels()) doReturn null
+        whenever(
+            queryChannelsDatabaseLogic.fetchChannelsFromCache(
+                any<AnyChannelPaginationRequest>(),
+                any<QueryChannelsIdentifier>(),
+            ),
+        ) doReturn CachedQueryChannels(spec = queryChannelsSpec, channels = emptyList())
+
+        // When
+        logic.loadOfflineGroupedChannels()
+
+        // Then
+        verify(queryChannelsStateLogic, never()).addChannelsState(any())
+        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+    }
+
+    @Test
+    fun `startLoadingFirstPageIfNeverLoaded raises the flag for a group that never loaded`() = runTest {
+        whenever(queryChannelsStateLogic.getChannels()) doReturn null
+
+        logic.startLoadingFirstPageIfNeverLoaded()
+
+        verify(queryChannelsStateLogic).setLoadingFirstPage(true)
+    }
+
+    @Test
+    fun `startLoadingFirstPageIfNeverLoaded does not hide an already populated list behind a loader`() = runTest {
+        whenever(queryChannelsStateLogic.getChannels()) doReturn mapOf("messaging:ch1" to randomChannel(id = "ch1"))
+
+        logic.startLoadingFirstPageIfNeverLoaded()
+
+        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+    }
+
+    @Test
+    fun `a settled empty group is not put back into the loader by a later request`() = runTest {
+        // Given — a group that loaded and came back empty holds a non-null empty map. This is the
+        // shape SyncManager recovery hits on every reconnect.
+        whenever(queryChannelsStateLogic.getChannels()) doReturn emptyMap()
+
+        // When
+        logic.startLoadingFirstPageIfNeverLoaded()
+
+        // Then — no spinner over a tab the user has already seen settle as empty.
+        verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+    }
+
+    @Test
+    fun `finishFirstPageLoad ends Loading even when the request failed before the offline read`() = runTest {
+        // Given — nothing has initialised channels yet, so rawChannels is still null.
+        whenever(queryChannelsStateLogic.getChannels()) doReturn null
+
+        // When
+        logic.finishFirstPageLoad()
+
+        // Then — clearing the flag alone is not enough: ChannelsStateData reports Loading while
+        // channels are null, so the state has to be initialised too or the spinner never ends.
+        verify(queryChannelsStateLogic).initializeChannelsIfNeeded()
+        verify(queryChannelsStateLogic).setLoadingFirstPage(false)
+    }
+
+    @Test
+    fun `loadOfflineGroupedChannels stops loading when a concurrent result already populated state`() = runTest {
+        // Given — applyGroupedResult landed during the DB read; the cache itself has nothing.
+        whenever(queryChannelsStateLogic.getChannels()) doReturn mapOf("messaging:ch1" to randomChannel(id = "ch1"))
+        whenever(
+            queryChannelsDatabaseLogic.fetchChannelsFromCache(
+                any<AnyChannelPaginationRequest>(),
+                any<QueryChannelsIdentifier>(),
+            ),
+        ) doReturn null
+
+        // When
+        logic.loadOfflineGroupedChannels()
+
+        // Then — there are channels on screen, so the loader must not stay up over them.
         verify(queryChannelsStateLogic).setLoadingFirstPage(false)
     }
 
@@ -368,6 +454,48 @@ internal class QueryChannelsLogicGroupedTest {
         verify(queryChannelsStateLogic, never()).addChannelsState(any())
         verify(queryChannelsStateLogic, never()).initializeChannelsIfNeeded()
         verify(queryChannelsStateLogic, never()).setLoadingFirstPage(any())
+    }
+
+    // endregion
+
+    // region channelsStateData contract
+
+    @Test
+    fun `an in-flight first page never emits the empty state on a cache miss`() = runTest {
+        // Given — real state rather than a mock, so the assertion is the sequence the UI sees
+        // rather than which setters happened to be called.
+        val mutableState = QueryChannelsMutableState(
+            identifier = QueryChannelsIdentifier.Grouped(GROUP_KEY),
+            scope = testCoroutines.scope,
+            latestUsers = MutableStateFlow(emptyMap()),
+            activeLiveLocations = MutableStateFlow(emptyList()),
+        )
+        val stateLogic = QueryChannelsStateLogic(
+            mutableState = mutableState,
+            stateRegistry = mock(),
+            logicRegistry = mock(),
+            coroutineScope = testCoroutines.scope,
+        )
+        val realLogic = QueryChannelsLogic(
+            identifier = QueryChannelsIdentifier.Grouped(GROUP_KEY),
+            client = client,
+            queryChannelsStateLogic = stateLogic,
+            queryChannelsDatabaseLogic = queryChannelsDatabaseLogic,
+        )
+        whenever(
+            queryChannelsDatabaseLogic.fetchChannelsFromCache(
+                any<AnyChannelPaginationRequest>(),
+                any<QueryChannelsIdentifier>(),
+            ),
+        ) doReturn null
+
+        // When — the request starts, then the offline read misses
+        realLogic.startLoadingFirstPageIfNeverLoaded()
+        realLogic.loadOfflineGroupedChannels()
+
+        // Then — still Loading. Reinstating the unconditional clear in loadOfflineGroupedChannels
+        // turns this into OfflineNoResults, which is the flash this change removes.
+        assertEquals(ChannelsStateData.Loading, mutableState.channelsStateData.value)
     }
 
     // endregion

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.GroupedChannelsGroup
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.randomChannel
+import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.chat.android.state.plugin.state.querychannels.internal.QueryChannelsMutableState
@@ -560,6 +561,67 @@ internal class QueryChannelsLogicGroupedTest {
 
         // Then — a non-null empty map no longer blocks the raise; only a finished query does.
         assertEquals(ChannelsStateData.Loading, mutableState.channelsStateData.value)
+    }
+
+    @Test
+    fun `two overlapping first pages, the earlier one failing, end on the later result`() = runTest {
+        // Given — nothing dedupes concurrent grouped requests, so two first pages for one group can
+        // be in flight together: an app query and a SyncManager recovery, for instance.
+        val mutableState = QueryChannelsMutableState(
+            identifier = QueryChannelsIdentifier.Grouped(GROUP_KEY),
+            scope = testCoroutines.scope,
+            latestUsers = MutableStateFlow(emptyMap()),
+            activeLiveLocations = MutableStateFlow(emptyList()),
+        )
+        // applyGroupedResult writes through to per-channel logic, so the registry needs to answer.
+        val logicRegistry = mock<LogicRegistry>()
+        whenever(logicRegistry.channelState(any(), any())) doReturn mock()
+        val realLogic = QueryChannelsLogic(
+            identifier = QueryChannelsIdentifier.Grouped(GROUP_KEY),
+            client = client,
+            queryChannelsStateLogic = QueryChannelsStateLogic(
+                mutableState = mutableState,
+                stateRegistry = mock(),
+                logicRegistry = logicRegistry,
+                coroutineScope = testCoroutines.scope,
+            ),
+            queryChannelsDatabaseLogic = queryChannelsDatabaseLogic,
+        )
+        whenever(
+            queryChannelsDatabaseLogic.fetchChannelsFromCache(
+                any<AnyChannelPaginationRequest>(),
+                any<QueryChannelsIdentifier>(),
+            ),
+        ) doReturn null
+
+        // When — both requests start and the offline read misses
+        realLogic.startLoadingFirstPageIfNeverLoaded()
+        realLogic.startLoadingFirstPageIfNeverLoaded()
+        realLogic.loadOfflineGroupedChannels()
+        assertEquals(ChannelsStateData.Loading, mutableState.channelsStateData.value)
+
+        // And the first request fails while the second is still running
+        realLogic.finishFirstPageLoad(completed = false)
+
+        // Then — the loader drops for the rest of the second request. The flag is shared, so the
+        // earlier completion ends it; this is the pre-fix empty state, narrowed to that window.
+        // Gating the clear on an in-flight count would avoid it, but a count that leaks a start
+        // never returns to zero and the loader would never drop again.
+        assertEquals(ChannelsStateData.OfflineNoResults, mutableState.channelsStateData.value)
+
+        // And when the second request answers, its channels land. The list recovers on its own,
+        // which is what keeps the window above acceptable rather than a stuck spinner.
+        val channels = listOf(randomChannel(id = "ch1"))
+        realLogic.applyGroupedResult(
+            group = GroupedChannelsGroup(
+                groupKey = GROUP_KEY,
+                channels = channels,
+                next = null,
+                prev = null,
+            ),
+            isFirstPage = true,
+        )
+        assertEquals(ChannelsStateData.Result(channels), mutableState.channelsStateData.value)
     }
 
     // endregion

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsLogicGroupedTest.kt
@@ -461,7 +461,7 @@ internal class QueryChannelsLogicGroupedTest {
     // region channelsStateData contract
 
     @Test
-    fun `an in-flight first page never emits the empty state on a cache miss`() = runTest {
+    fun `an in-flight first page holds Loading on a cache miss and ends on failure`() = runTest {
         // Given — real state rather than a mock, so the assertion is the sequence the UI sees
         // rather than which setters happened to be called.
         val mutableState = QueryChannelsMutableState(
@@ -496,6 +496,10 @@ internal class QueryChannelsLogicGroupedTest {
         // Then — still Loading. Reinstating the unconditional clear in loadOfflineGroupedChannels
         // turns this into OfflineNoResults, which is the flash this change removes.
         assertEquals(ChannelsStateData.Loading, mutableState.channelsStateData.value)
+
+        // And when the request fails, the load ends rather than leaving the list spinning.
+        realLogic.finishFirstPageLoad()
+        assertEquals(ChannelsStateData.OfflineNoResults, mutableState.channelsStateData.value)
     }
 
     // endregion


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

A grouped channel list with nothing cached for a group showed the empty state ("no channels") for the whole first `queryGroupedChannels` round trip instead of the loader. Standard channel lists do not behave this way: they hold the loader until the network answers.

Closes [AND-1460](https://linear.app/stream/issue/AND-1460/grouped-channel-list-shows-the-empty-state-instead-of-the-loader-while)

Targets `v6`.

### Implementation

- `loadOfflineGroupedChannels` cleared the first-page loading flag unconditionally, so a cache miss moved `channelsStateData` from `Loading` to `OfflineNoResults` while the request was still in flight, and nothing raised it again: `onQueryGroupedChannelsRequest` only captured the query config.
- Raise the flag in the request listener, the point that knows a fetch started, for each named first-page group. The guard is `!hasCompletedAQuery && getChannels().isNullOrEmpty()` and both halves are load-bearing. Without the marker a settled empty tab returns to a spinner on every reconnect, since `SyncManager` recovers grouped lists through a cursor-less request that reaches this listener. Without the emptiness check a request hides channels the offline read just loaded from cache, because `ChannelsStateData` reports `Loading` whenever the flag is set regardless of content.
- `hasCompletedAQuery` is needed because state alone cannot express the difference: a group that has never loaded and one that loaded and is genuinely empty both hold an empty channel map.
- A failure does not count as completion, so a retry raises the loader again, matching `queryOffline` for a standard list. An omitted group would count, since the server answered, but that branch is a guard rather than a live path: the server returns every requested group, with an empty channel list when the group has nothing. It stays because such a group would never reach `applyGroupedResult` and the loader it raised would never come down.
- Clear the flag only once there is something to show, otherwise the offline read immediately undoes the raise. End the load on failure, and defensively for a group the response left out, neither of which reaches `applyGroupedResult`; ending it initialises the channel map as well as clearing the flag, because `ChannelsStateData` reports `Loading` while channels are still null.

Scope is limited to grouped lists: the new methods are called only from `QueryGroupedChannelsListenerState`, and `loadOfflineGroupedChannels` returns early for non-grouped identifiers.

Two behaviours worth calling out. Recovery of a group whose first page *failed* raises the loader on grouped, where standard recovery never does, because `queryFirstPage` bypasses the listener entirely. That is deliberate: a spinner while the retry runs is more accurate than a stale empty state. And a request with `groups = null` keeps today's behaviour, since the keys are unknown until the response, so the mechanism is inert rather than half-engaged and cannot leave a list loading.

### Testing

- Unit tests over a real `QueryChannelsMutableState` assert the emitted `ChannelsStateData` rather than setter calls: an in-flight first page on a cache miss stays `Loading`, a request arriving after the offline read still raises, and a failed load ends on `OfflineNoResults`. Reinstating the unconditional clear, or the earlier `== null` guard, fails them.
- Mock tests cover the raise per first-page group, no raise while paginating, no raise over cached channels or a settled empty group, a failed page staying retryable, and the load being ended on failure and for an omitted group.
- Verified on a grouped-channels sample built against this branch, cold start with an empty database on a throttled network:
  - before: `OfflineNoResults -> Result(10) -> Result(20)`
  - after: `Loading -> Result(10) -> Result(20)`

  Also ran the sample with the ordering flipped so the offline read runs before the query, which is the case the completion marker adds: `Loading -> Result`, so the new raise clears. A warm start still renders straight from cache.

