### PR TITLE
Migrate the push preference chat preferences to the generated model

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -28,7 +28,6 @@ import io.getstream.chat.android.client.api2.model.dto.DeviceDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChannelDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChannelMuteDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChannelUserRead
-import io.getstream.chat.android.client.api2.model.dto.DownstreamChatPreferencesDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamDraftDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamFlagDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamLocationDto
@@ -1363,16 +1362,6 @@ internal class DomainMapping(
         level = PushPreferenceLevel.fromValue(chat_level),
         disabledUntil = disabled_until,
         chatPreferences = chat_preferences?.toDomain(),
-    )
-
-    internal fun DownstreamChatPreferencesDto.toDomain(): ChatPreferences = ChatPreferences(
-        directMentions = ChatPreferenceToggle.fromValue(direct_mentions),
-        roleMentions = ChatPreferenceToggle.fromValue(role_mentions),
-        groupMentions = ChatPreferenceToggle.fromValue(group_mentions),
-        hereMentions = ChatPreferenceToggle.fromValue(here_mentions),
-        channelMentions = ChatPreferenceToggle.fromValue(channel_mentions),
-        threadReplies = ChatPreferenceToggle.fromValue(thread_replies),
-        defaultPreference = ChatPreferenceToggle.fromValue(default_preference),
     )
 
     internal fun PushPreferencesResponse.toDomain(): PushPreference = PushPreference(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/DownstreamPushPreferenceDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/DownstreamPushPreferenceDto.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.api2.model.dto
 
 import com.squareup.moshi.JsonClass
+import io.getstream.chat.android.network.models.ChatPreferencesResponse
 import java.util.Date
 
 /**
@@ -30,16 +31,5 @@ import java.util.Date
 internal data class DownstreamPushPreferenceDto(
     val chat_level: String?,
     val disabled_until: Date?,
-    val chat_preferences: DownstreamChatPreferencesDto? = null,
-)
-
-@JsonClass(generateAdapter = true)
-internal data class DownstreamChatPreferencesDto(
-    val direct_mentions: String? = null,
-    val role_mentions: String? = null,
-    val group_mentions: String? = null,
-    val here_mentions: String? = null,
-    val channel_mentions: String? = null,
-    val thread_replies: String? = null,
-    val default_preference: String? = null,
+    val chat_preferences: ChatPreferencesResponse? = null,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -73,6 +73,7 @@ import io.getstream.chat.android.client.Mother.randomUserGroupMemberDto
 import io.getstream.chat.android.client.Mother.randomUserGroupResponse
 import io.getstream.chat.android.client.Mother.randomUserResponse
 import io.getstream.chat.android.client.api2.mapping.DomainMappingTest.Companion.toSortDomainArguments
+import io.getstream.chat.android.client.api2.model.dto.DownstreamPushPreferenceDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserGroupDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserGroupMemberDto
 import io.getstream.chat.android.client.api2.model.response.MessageResponse
@@ -89,6 +90,7 @@ import io.getstream.chat.android.models.ChannelMute
 import io.getstream.chat.android.models.ChannelTransformer
 import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.ChatPreferenceToggle
+import io.getstream.chat.android.models.ChatPreferences
 import io.getstream.chat.android.models.Command
 import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.Device
@@ -109,6 +111,7 @@ import io.getstream.chat.android.models.NoOpUserTransformer
 import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.PendingMessage
 import io.getstream.chat.android.models.Poll
+import io.getstream.chat.android.models.PushPreference
 import io.getstream.chat.android.models.PushPreferenceLevel
 import io.getstream.chat.android.models.PushProvider
 import io.getstream.chat.android.models.QueryPollVotesResult
@@ -1681,6 +1684,42 @@ internal class DomainMappingTest {
                 descByName<Channel>("created_at").ascByName("name"),
             ),
         )
+    }
+
+    @Test
+    fun `DownstreamPushPreferenceDto keeps every chat preference toggle`() {
+        val sut = Fixture().get()
+
+        val result = with(sut) {
+            DownstreamPushPreferenceDto(
+                chat_level = "all",
+                disabled_until = Date(1000),
+                chat_preferences = ChatPreferencesResponse(
+                    directMentions = "all",
+                    roleMentions = "none",
+                    groupMentions = "all",
+                    hereMentions = "none",
+                    channelMentions = "all",
+                    threadReplies = "none",
+                    defaultPreference = "all",
+                ),
+            ).toDomain()
+        }
+
+        val expected = PushPreference(
+            level = PushPreferenceLevel.all,
+            disabledUntil = Date(1000),
+            chatPreferences = ChatPreferences(
+                directMentions = ChatPreferenceToggle.all,
+                roleMentions = ChatPreferenceToggle.none,
+                groupMentions = ChatPreferenceToggle.all,
+                hereMentions = ChatPreferenceToggle.none,
+                channelMentions = ChatPreferenceToggle.all,
+                threadReplies = ChatPreferenceToggle.none,
+                defaultPreference = ChatPreferenceToggle.all,
+            ),
+        )
+        assertEquals(expected, result)
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.client.api2.model.dto.PrivacySettingsDto
 import io.getstream.chat.android.client.api2.model.dto.ReadReceiptsDto
 import io.getstream.chat.android.client.api2.model.dto.TypingIndicatorsDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamUserDto
+import io.getstream.chat.android.network.models.ChatPreferencesResponse
 import io.getstream.chat.android.network.models.UserResponse
 import org.intellij.lang.annotations.Language
 import java.util.Date
@@ -191,7 +192,16 @@ internal object UserDtoTestData {
             "avg_response_time": 1000,
             "push_preferences": {
                 "chat_level": "default",
-                "disabled_until": "2020-06-10T11:04:31.588Z"
+                "disabled_until": "2020-06-10T11:04:31.588Z",
+                "chat_preferences": {
+                  "direct_mentions": "all",
+                  "role_mentions": "none",
+                  "group_mentions": "all",
+                  "here_mentions": "none",
+                  "channel_mentions": "all",
+                  "thread_replies": "none",
+                  "default_preference": "all"
+                }
             }
          }"""
     const val userResponseJson =
@@ -275,6 +285,16 @@ internal object UserDtoTestData {
             push_preferences = DownstreamPushPreferenceDto(
                 chat_level = "default",
                 disabled_until = Date(1591787071588),
+                // Toggles alternate so a key read into the wrong property cannot look correct.
+                chat_preferences = ChatPreferencesResponse(
+                    directMentions = "all",
+                    roleMentions = "none",
+                    groupMentions = "all",
+                    hereMentions = "none",
+                    channelMentions = "all",
+                    threadReplies = "none",
+                    defaultPreference = "all",
+                ),
             ),
             extraData = emptyMap(),
         )


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Parse a push preference's chat preferences with the generated `ChatPreferencesResponse` and delete the hand-written `DownstreamChatPreferencesDto`.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Point `DownstreamPushPreferenceDto.chat_preferences` at `ChatPreferencesResponse` and drop `DownstreamChatPreferencesDto`. Its mapper was identical field for field to the existing `ChatPreferencesResponse.toDomain()`, already used by `PushPreferencesResponse` and `ChannelPushPreferencesResponse`, so the duplicate goes with it and no new mapping code is needed.
- Rename `PushPreferenceDtos.kt` to `DownstreamPushPreferenceDto.kt`, since removing the class leaves a single declaration.
- Add a mapping test over the whole `PushPreference`, with the seven toggles alternating so a preference read from the wrong field cannot pass. `chat_preferences` had no coverage on this path before: neither `Mother.randomDownstreamPushPreferenceDto` nor `UserDtoTestData` populated it, and the closest existing test covered a different model while asserting two of the seven toggles.

The generated `ChatPreferences` model is a different, 8-field type belonging to channel config, not the push preference payload. `ChatPreferencesResponse` matches the removed DTO exactly, so no field is gained or lost.

### Testing

- Device probe: set channel chat preferences with the toggles alternating, then re-read through the channel query, which is the path that parses this field. All seven toggles round-tripped on both the write response and the re-read, with a populated `chatPreferences`.
- Mutation checks: dropping `chat_preferences` from the mapping, and reading one toggle from the wrong source field, each fail the new test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved push preference handling by consistently applying chat preference settings.
  - Preserved push levels, disabled-until dates, and individual notification toggles when converting preferences for app use.
- **Tests**
  - Added coverage to verify all chat preference options are correctly retained during push preference processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->