### PR TITLE
Migrate the message poll to the generated PollResponseData model

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -404,7 +404,7 @@ internal class DomainMapping(
 
     private fun DownstreamMessageDto.lastUpdateTime(): Date = listOfNotNull(
         updated_at,
-        poll?.updated_at,
+        poll?.updatedAt,
     ).maxBy { it.time }
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.client.api2.model.dto
 import com.squareup.moshi.JsonClass
 import io.getstream.chat.android.core.internal.StreamHandsOff
 import io.getstream.chat.android.network.models.Attachment
+import io.getstream.chat.android.network.models.PollResponseData
 import java.util.Date
 
 /**
@@ -108,7 +109,7 @@ internal data class DownstreamMessageDto(
     val user: DownstreamUserDto,
     val moderation_details: DownstreamModerationDetailsDto? = null, // Used for Moderation V1
     val moderation: DownstreamModerationDto? = null, // Used for Moderation V2
-    val poll: DownstreamPollDto? = null,
+    val poll: PollResponseData? = null,
     val reminder: DownstreamReminderInfoDto? = null,
     val shared_location: DownstreamLocationDto? = null,
     val member: DownstreamMemberInfoDto? = null,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -333,7 +333,7 @@ internal object Mother {
         user: DownstreamUserDto = randomDownstreamUserDto(),
         moderation_details: DownstreamModerationDetailsDto? = null,
         moderation: DownstreamModerationDto? = null,
-        poll: DownstreamPollDto? = null,
+        poll: PollResponseData? = null,
         member: DownstreamMemberInfoDto? = randomDownstreamMemberInfoDto(),
         deleted_for_me: Boolean? = null,
         extraData: Map<String, Any> = emptyMap(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -186,6 +186,21 @@ internal class DomainMappingTest {
     }
 
     @Test
+    fun `PollResponseData carries its custom data into the domain poll`() {
+        // The helper defaults `custom` to empty, so nothing else in the suite notices if the mapper
+        // stops carrying it. Every other field of Poll is required, so the compiler guards those.
+        val response = randomPollResponseData(
+            custom = mapOf("pollKey" to "pollValue", "absent" to null),
+        )
+        val sut = Fixture().get()
+
+        val poll = with(sut) { response.toDomain() }
+
+        // `absent` is dropped: the domain map does not hold null values.
+        assertEquals(mapOf("pollKey" to "pollValue"), poll.extraData)
+    }
+
+    @Test
     fun `Message should be transformed with optionals properties after it is mapped`() {
         val transformedMessage = randomMessage()
         val messageTransformer = MessageTransformer { transformedMessage }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -57,6 +57,7 @@ import io.getstream.chat.android.client.Mother.randomDownstreamUserGroupDto
 import io.getstream.chat.android.client.Mother.randomDownstreamVoteDto
 import io.getstream.chat.android.client.Mother.randomFileUploadConfig
 import io.getstream.chat.android.client.Mother.randomFullUserResponse
+import io.getstream.chat.android.client.Mother.randomPollResponseData
 import io.getstream.chat.android.client.Mother.randomPollVotesResponse
 import io.getstream.chat.android.client.Mother.randomPrivacySettingsDto
 import io.getstream.chat.android.client.Mother.randomQueryPollsResponse
@@ -199,7 +200,7 @@ internal class DomainMappingTest {
                 quoted_message = randomDownstreamMessageDto(),
                 moderation_details = randomDownstreamModerationDetailsDto(),
                 moderation = randomDownstreamModerationDto(),
-                poll = randomDownstreamPollDto(),
+                poll = randomPollResponseData(),
                 deleted_for_me = randomBoolean(),
             ).toDomain()
         }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/MessageParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/MessageParsingTest.kt
@@ -416,6 +416,18 @@ internal class MessageParsingTest {
     }
 
     @Test
+    fun `Both paths - poll and option custom inlined by the API land on the domain fields`() {
+        val result = assertBothPaths(MessageTestData.jsonAllFields)
+
+        assertEquals(mapOf("poll_custom_key" to "poll-custom-value"), result.poll?.extraData)
+        assertEquals(
+            mapOf("option_custom_key" to "option-custom-value"),
+            result.poll?.options?.first { it.id == "option-1" }?.extraData,
+        )
+        assertEquals(emptyMap<String, Any>(), result.poll?.options?.first { it.id == "option-2" }?.extraData)
+    }
+
+    @Test
     fun `Both paths - member absent yields a null member`() {
         val result = assertBothPaths(MessageTestData.jsonOptionalFieldsMissing)
         assertEquals(null, result.member)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageTestData.kt
@@ -141,7 +141,7 @@ internal object MessageTestData {
                         "option_id": "option-1",
                         "created_at": "2020-01-01T02:00:00.000Z",
                         "updated_at": "2020-01-01T02:00:00.000Z",
-                        "user": {"id": "user-1", "role": "user", "banned": false, "online": true},
+                        "user": {"id": "user-1", "role": "user", "banned": false, "online": true, "created_at": "2020-01-01T00:00:00.000Z", "updated_at": "2020-01-01T00:00:00.000Z", "language": "en"},
                         "is_answer": false
                     }
                 ],
@@ -152,7 +152,7 @@ internal object MessageTestData {
                         "option_id": "option-2",
                         "created_at": "2020-01-01T02:00:00.000Z",
                         "updated_at": "2020-01-01T02:00:00.000Z",
-                        "user": {"id": "user-2", "role": "user", "banned": false, "online": true},
+                        "user": {"id": "user-2", "role": "user", "banned": false, "online": true, "created_at": "2020-01-01T00:00:00.000Z", "updated_at": "2020-01-01T00:00:00.000Z", "language": "en"},
                         "is_answer": false
                     }
                 ]
@@ -164,7 +164,7 @@ internal object MessageTestData {
                     "option_id": "option-1",
                     "created_at": "2020-01-01T02:00:00.000Z",
                     "updated_at": "2020-01-01T02:00:00.000Z",
-                    "user": {"id": "user-1", "role": "user", "banned": false, "online": true},
+                    "user": {"id": "user-1", "role": "user", "banned": false, "online": true, "created_at": "2020-01-01T00:00:00.000Z", "updated_at": "2020-01-01T00:00:00.000Z", "language": "en"},
                     "is_answer": false
                 }
             ],
@@ -180,11 +180,11 @@ internal object MessageTestData {
                     "answer_text": "Purple",
                     "created_at": "2020-01-01T02:30:00.000Z",
                     "updated_at": "2020-01-01T02:30:00.000Z",
-                    "user": {"id": "user-3", "role": "user", "banned": false, "online": true},
+                    "user": {"id": "user-3", "role": "user", "banned": false, "online": true, "created_at": "2020-01-01T00:00:00.000Z", "updated_at": "2020-01-01T00:00:00.000Z", "language": "en"},
                     "is_answer": true
                 }
             ],
-            "created_by": {"id": "user-1", "role": "user", "banned": false, "online": true},
+            "created_by": {"id": "user-1", "role": "user", "banned": false, "online": true, "created_at": "2020-01-01T00:00:00.000Z", "updated_at": "2020-01-01T00:00:00.000Z", "language": "en"},
             "created_by_id": "user-1"
         },
         "created_at": "2020-01-01T00:00:00.000Z",

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageTestData.kt
@@ -123,7 +123,7 @@ internal object MessageTestData {
             "name": "Favorite color",
             "description": "Choose your favorite color",
             "options": [
-                {"id": "option-1", "text": "Red"},
+                {"id": "option-1", "text": "Red", "option_custom_key": "option-custom-value"},
                 {"id": "option-2", "text": "Blue"}
             ],
             "voting_visibility": "public",
@@ -185,7 +185,9 @@ internal object MessageTestData {
                 }
             ],
             "created_by": {"id": "user-1", "role": "user", "banned": false, "online": true, "created_at": "2020-01-01T00:00:00.000Z", "updated_at": "2020-01-01T00:00:00.000Z", "language": "en"},
-            "created_by_id": "user-1"
+            "created_by_id": "user-1",
+            "poll_custom_key": "poll-custom-value",
+            "poll_null_key": null
         },
         "created_at": "2020-01-01T00:00:00.000Z",
         "updated_at": "2020-01-01T03:00:00.000Z",


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Parse the poll embedded in a message with the generated `PollResponseData`.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Point `DownstreamMessageDto.poll` at `PollResponseData`, the model the poll endpoints already use, and follow the field rename in `lastUpdateTime()`. `PollResponseData.toDomain()` was already in place, so no mapping code is added.
- Enrich the nested vote, answer and creator users in the message fixture. The generated `UserResponse` requires `created_at`, `updated_at` and `language`, and the fixture carried only `id`, `role`, `banned` and `online`.

`DownstreamPollDto` stays for the poll events, which still parse it.

### Notes

The message carries `Poll *commonpayloads.PollResponseData`, the same struct the poll endpoints return, and `created_at`, `updated_at` and `language` are non-`omitempty` on `UserResponseCommonFields`. So the wire always sends them for a nested poll user and the old fixture was the unrealistic part.

The two paths swap strictness on three keys. `voting_visibility` was `String?` and defaulted to `PUBLIC`; it is required on `PollResponseData`, so a poll that omits it now throws on the DTO path while `PollAdapter` still defaults it. `options` and `own_votes` go the other way, defaulting to empty on the DTO path while `PollAdapter` still throws. None can fire in practice: all three are plain non-`omitempty` tags on the Go response struct.

A custom key with a null value no longer reaches `Poll.extraData`. The DTO path used to keep it and the direct path already dropped it, so this aligns them.

### Testing

- Device probe: created a poll with custom data on the poll and on one option, sent it, cast a vote and an answer, then read the message back through `getMessage` and `queryChannels`. Both custom values round-tripped, config was preserved, and every nested user (creator, votes, own votes, answers) carried the three required fields.
- Mutation checks: nulling `message.poll`, and dropping `poll.updatedAt` from `lastUpdateTime`, each fail 6 tests.
- `MessageParsingTest` gains a case for poll and option custom data inlined on the message, which also pins the null-valued key being dropped on both paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Poll messages now correctly reflect the poll’s latest update time.
  * Poll data is mapped consistently, preserving custom poll information in message details.
  * Poll-related user information, including creator, voters, and respondents, is handled more completely.
* **Tests**
  * Expanded coverage for poll custom data, optional message properties, timestamps, and user metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
