### PR TITLE
Migrate the message moderation and reaction groups to the generated models

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -34,13 +34,11 @@ import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberInfoDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDetailsDto
-import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMuteDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPendingMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPollDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPushPreferenceDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionDto
-import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionGroupDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReminderDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReminderInfoDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamThreadDto
@@ -135,6 +133,7 @@ import io.getstream.chat.android.network.models.DeviceResponse
 import io.getstream.chat.android.network.models.FullUserResponse
 import io.getstream.chat.android.network.models.GetApplicationResponse
 import io.getstream.chat.android.network.models.GetOGResponse
+import io.getstream.chat.android.network.models.ModerationV2Response
 import io.getstream.chat.android.network.models.PollOptionResponseData
 import io.getstream.chat.android.network.models.PollResponseData
 import io.getstream.chat.android.network.models.PollVoteResponseData
@@ -142,6 +141,7 @@ import io.getstream.chat.android.network.models.PollVotesResponse
 import io.getstream.chat.android.network.models.PrivacySettingsResponse
 import io.getstream.chat.android.network.models.PushPreferencesResponse
 import io.getstream.chat.android.network.models.QueryPollsResponse
+import io.getstream.chat.android.network.models.ReactionGroupResponse
 import io.getstream.chat.android.network.models.ReactionResponse
 import io.getstream.chat.android.network.models.UnreadCountsChannel
 import io.getstream.chat.android.network.models.UnreadCountsChannelType
@@ -520,15 +520,15 @@ internal class DomainMapping(
         )
 
     /**
-     * Transforms [DownstreamReactionGroupDto] to [ReactionGroup].
+     * Transforms [ReactionGroupResponse] to [ReactionGroup].
      */
-    internal fun DownstreamReactionGroupDto.toDomain(type: String): ReactionGroup =
+    internal fun ReactionGroupResponse.toDomain(type: String): ReactionGroup =
         ReactionGroup(
             type = type,
             count = count,
-            sumScore = sum_scores,
-            firstReactionAt = first_reaction_at,
-            lastReactionAt = last_reaction_at,
+            sumScore = sumScores,
+            firstReactionAt = firstReactionAt,
+            lastReactionAt = lastReactionAt,
         )
 
     /**
@@ -1092,16 +1092,16 @@ internal class DomainMapping(
     )
 
     /**
-     * Maps the network [DownstreamModerationDto] to the domain model [Moderation].
+     * Maps the network [ModerationV2Response] to the domain model [Moderation].
      */
-    internal fun DownstreamModerationDto.toDomain() = Moderation(
-        action = ModerationAction.fromValue(this.action),
-        originalText = this.original_text,
-        textHarms = this.text_harms.orEmpty(),
-        imageHarms = this.image_harms.orEmpty(),
-        blocklistMatched = this.blocklist_matched,
-        semanticFilterMatched = this.semantic_filter_matched,
-        platformCircumvented = this.platform_circumvented ?: false,
+    internal fun ModerationV2Response.toDomain() = Moderation(
+        action = ModerationAction.fromValue(action),
+        originalText = originalText,
+        textHarms = textHarms.orEmpty(),
+        imageHarms = imageHarms.orEmpty(),
+        blocklistMatched = blocklistMatched,
+        semanticFilterMatched = semanticFilterMatched,
+        platformCircumvented = platformCircumvented ?: false,
     )
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/DownstreamReactionDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/DownstreamReactionDto.kt
@@ -43,11 +43,3 @@ internal data class DownstreamReactionDto(
     val emoji_code: String?,
     val extraData: Map<String, Any>,
 ) : ExtraDataDto
-
-@JsonClass(generateAdapter = true)
-internal data class DownstreamReactionGroupDto(
-    val count: Int,
-    val sum_scores: Int,
-    val first_reaction_at: Date,
-    val last_reaction_at: Date,
-)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
@@ -19,7 +19,9 @@ package io.getstream.chat.android.client.api2.model.dto
 import com.squareup.moshi.JsonClass
 import io.getstream.chat.android.core.internal.StreamHandsOff
 import io.getstream.chat.android.network.models.Attachment
+import io.getstream.chat.android.network.models.ModerationV2Response
 import io.getstream.chat.android.network.models.PollResponseData
+import io.getstream.chat.android.network.models.ReactionGroupResponse
 import io.getstream.chat.android.network.models.ReactionResponse
 import java.util.Date
 
@@ -59,7 +61,7 @@ internal data class DownstreamMessageDto(
     val quoted_message_id: String?,
     val reaction_counts: Map<String, Int>?,
     val reaction_scores: Map<String, Int>?,
-    val reaction_groups: Map<String, DownstreamReactionGroupDto>?,
+    val reaction_groups: Map<String, ReactionGroupResponse>?,
     val reply_count: Int,
     val deleted_reply_count: Int,
     val shadowed: Boolean = false,
@@ -71,7 +73,7 @@ internal data class DownstreamMessageDto(
     val updated_at: Date,
     val user: DownstreamUserDto,
     val moderation_details: DownstreamModerationDetailsDto? = null, // Used for Moderation V1
-    val moderation: DownstreamModerationDto? = null, // Used for Moderation V2
+    val moderation: ModerationV2Response? = null, // Used for Moderation V2
     val poll: PollResponseData? = null,
     val reminder: DownstreamReminderInfoDto? = null,
     val shared_location: DownstreamLocationDto? = null,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ModerationV2Response.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ModerationV2Response.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ *
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class ModerationV2Response(
+    @Json(name = "action")
+    internal val action: String,
+
+    @Json(name = "original_text")
+    internal val originalText: String,
+
+    @Json(name = "blocklist_matched")
+    internal val blocklistMatched: String? = null,
+
+    @Json(name = "platform_circumvented")
+    internal val platformCircumvented: Boolean? = null,
+
+    @Json(name = "semantic_filter_matched")
+    internal val semanticFilterMatched: String? = null,
+
+    @Json(name = "blocklists_matched")
+    internal val blocklistsMatched: List<String>? = emptyList(),
+
+    @Json(name = "image_harms")
+    internal val imageHarms: List<String>? = emptyList(),
+
+    @Json(name = "text_harms")
+    internal val textHarms: List<String>? = emptyList(),
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ReactionGroupResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ReactionGroupResponse.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
+
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
+
+/**
+ * ReactionGroupResponse contains all information about a reaction of the same type.
+ */
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class ReactionGroupResponse(
+    @Json(name = "count")
+    internal val count: Int,
+
+    @Json(name = "first_reaction_at")
+    internal val firstReactionAt: java.util.Date,
+
+    @Json(name = "last_reaction_at")
+    internal val lastReactionAt: java.util.Date,
+
+    @Json(name = "sum_scores")
+    internal val sumScores: Int,
+
+    @Json(name = "latest_reactions_by")
+    internal val latestReactionsBy: List<io.getstream.chat.android.network.models.ReactionGroupUserResponse> = emptyList(),
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ReactionGroupUserResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/network/models/ReactionGroupUserResponse.kt
@@ -14,20 +14,28 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.client.api2.model.dto
+@file:Suppress(
+    "ArrayInDataClass",
+    "EnumEntryName",
+    "RemoveRedundantQualifierName",
+    "UnusedImport",
+)
 
-import com.squareup.moshi.JsonClass
+package io.getstream.chat.android.network.models
+
+import com.squareup.moshi.Json
 
 /**
- * Downstream JSON holding the data related to Moderation V2.
+ * Contains information about a user who reacted with this reaction type.
  */
-@JsonClass(generateAdapter = true)
-internal data class DownstreamModerationDto(
-    val action: String,
-    val original_text: String,
-    val text_harms: List<String>?,
-    val image_harms: List<String>?,
-    val blocklist_matched: String?,
-    val semantic_filter_matched: String?,
-    val platform_circumvented: Boolean?,
+@com.squareup.moshi.JsonClass(generateAdapter = true)
+internal data class ReactionGroupUserResponse(
+    @Json(name = "created_at")
+    internal val createdAt: java.util.Date,
+
+    @Json(name = "user_id")
+    internal val userId: String,
+
+    @Json(name = "user")
+    internal val user: io.getstream.chat.android.network.models.UserResponse? = null,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -36,13 +36,11 @@ import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberInfoDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDetailsDto
-import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMuteDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPendingMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPollDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamPushPreferenceDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionDto
-import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionGroupDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReminderDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamThreadDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamThreadInfoDto
@@ -99,11 +97,13 @@ import io.getstream.chat.android.network.models.FileUploadResponse
 import io.getstream.chat.android.network.models.FullUserResponse
 import io.getstream.chat.android.network.models.GetApplicationResponse
 import io.getstream.chat.android.network.models.GetOGResponse
+import io.getstream.chat.android.network.models.ModerationV2Response
 import io.getstream.chat.android.network.models.PollOptionResponseData
 import io.getstream.chat.android.network.models.PollResponseData
 import io.getstream.chat.android.network.models.PollVoteResponseData
 import io.getstream.chat.android.network.models.PollVotesResponse
 import io.getstream.chat.android.network.models.QueryPollsResponse
+import io.getstream.chat.android.network.models.ReactionGroupResponse
 import io.getstream.chat.android.network.models.ReactionResponse
 import io.getstream.chat.android.network.models.ThreadParticipant
 import io.getstream.chat.android.network.models.UnblockUsersResponse
@@ -319,7 +319,7 @@ internal object Mother {
         quoted_message_id: String? = randomString(),
         reaction_counts: Map<String, Int>? = emptyMap(),
         reaction_scores: Map<String, Int>? = emptyMap(),
-        reaction_groups: Map<String, DownstreamReactionGroupDto>? = emptyMap(),
+        reaction_groups: Map<String, ReactionGroupResponse>? = emptyMap(),
         reply_count: Int = randomInt(),
         deleted_reply_count: Int = randomInt(),
         shadowed: Boolean = randomBoolean(),
@@ -331,7 +331,7 @@ internal object Mother {
         updated_at: Date = randomDate(),
         user: DownstreamUserDto = randomDownstreamUserDto(),
         moderation_details: DownstreamModerationDetailsDto? = null,
-        moderation: DownstreamModerationDto? = null,
+        moderation: ModerationV2Response? = null,
         poll: PollResponseData? = null,
         member: DownstreamMemberInfoDto? = randomDownstreamMemberInfoDto(),
         deleted_for_me: Boolean? = null,
@@ -697,16 +697,16 @@ internal object Mother {
         expires = expires,
     )
 
-    fun randomDownstreamReactionGroupDto(
+    fun randomReactionGroupResponse(
         count: Int = randomInt(),
         sumScores: Int = randomInt(),
         firstReactionAt: Date = randomDate(),
         lastReactionAt: Date = randomDate(),
-    ): DownstreamReactionGroupDto = DownstreamReactionGroupDto(
+    ): ReactionGroupResponse = ReactionGroupResponse(
         count = count,
-        sum_scores = sumScores,
-        first_reaction_at = firstReactionAt,
-        last_reaction_at = lastReactionAt,
+        sumScores = sumScores,
+        firstReactionAt = firstReactionAt,
+        lastReactionAt = lastReactionAt,
     )
 
     fun randomChannelMemberResponse(
@@ -941,7 +941,7 @@ internal object Mother {
         extraData = extraData,
     )
 
-    fun randomDownstreamModerationDto(
+    fun randomModerationV2Response(
         action: String = randomString(),
         originalText: String = randomString(),
         textHarms: List<String> = listOf(randomString()),
@@ -949,14 +949,14 @@ internal object Mother {
         blocklistMatched: String = randomString(),
         semanticFilterMatched: String = randomString(),
         platformCircumvented: Boolean = randomBoolean(),
-    ): DownstreamModerationDto = DownstreamModerationDto(
+    ): ModerationV2Response = ModerationV2Response(
         action = action,
-        original_text = originalText,
-        text_harms = textHarms,
-        image_harms = imageHarms,
-        blocklist_matched = blocklistMatched,
-        semantic_filter_matched = semanticFilterMatched,
-        platform_circumvented = platformCircumvented,
+        originalText = originalText,
+        textHarms = textHarms,
+        imageHarms = imageHarms,
+        blocklistMatched = blocklistMatched,
+        semanticFilterMatched = semanticFilterMatched,
+        platformCircumvented = platformCircumvented,
     )
 
     fun randomPrivacySettingsDto(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -40,12 +40,10 @@ import io.getstream.chat.android.client.Mother.randomDownstreamFlagDto
 import io.getstream.chat.android.client.Mother.randomDownstreamMemberDto
 import io.getstream.chat.android.client.Mother.randomDownstreamMessageDto
 import io.getstream.chat.android.client.Mother.randomDownstreamModerationDetailsDto
-import io.getstream.chat.android.client.Mother.randomDownstreamModerationDto
 import io.getstream.chat.android.client.Mother.randomDownstreamMuteDto
 import io.getstream.chat.android.client.Mother.randomDownstreamPendingMessageDto
 import io.getstream.chat.android.client.Mother.randomDownstreamPollDto
 import io.getstream.chat.android.client.Mother.randomDownstreamReactionDto
-import io.getstream.chat.android.client.Mother.randomDownstreamReactionGroupDto
 import io.getstream.chat.android.client.Mother.randomDownstreamReminderDto
 import io.getstream.chat.android.client.Mother.randomDownstreamThreadDto
 import io.getstream.chat.android.client.Mother.randomDownstreamThreadInfoDto
@@ -53,6 +51,7 @@ import io.getstream.chat.android.client.Mother.randomDownstreamUserDto
 import io.getstream.chat.android.client.Mother.randomDownstreamUserGroupDto
 import io.getstream.chat.android.client.Mother.randomFileUploadConfig
 import io.getstream.chat.android.client.Mother.randomFullUserResponse
+import io.getstream.chat.android.client.Mother.randomModerationV2Response
 import io.getstream.chat.android.client.Mother.randomPollOptionResponseData
 import io.getstream.chat.android.client.Mother.randomPollResponseData
 import io.getstream.chat.android.client.Mother.randomPollVoteResponseData
@@ -60,6 +59,7 @@ import io.getstream.chat.android.client.Mother.randomPollVotesResponse
 import io.getstream.chat.android.client.Mother.randomPrivacySettingsDto
 import io.getstream.chat.android.client.Mother.randomQueryPollsResponse
 import io.getstream.chat.android.client.Mother.randomQueryRemindersResponse
+import io.getstream.chat.android.client.Mother.randomReactionGroupResponse
 import io.getstream.chat.android.client.Mother.randomReactionResponse
 import io.getstream.chat.android.client.Mother.randomRoleDto
 import io.getstream.chat.android.client.Mother.randomSearchWarningDto
@@ -216,7 +216,7 @@ internal class DomainMappingTest {
                 pinned_by = randomDownstreamUserDto(),
                 quoted_message = randomDownstreamMessageDto(),
                 moderation_details = randomDownstreamModerationDetailsDto(),
-                moderation = randomDownstreamModerationDto(),
+                moderation = randomModerationV2Response(),
                 poll = randomPollResponseData(),
                 deleted_for_me = randomBoolean(),
             ).toDomain()
@@ -655,19 +655,19 @@ internal class DomainMappingTest {
     }
 
     @Test
-    fun `DownstreamReactionGroupDto is correctly mapped to ReactionGroup`() {
-        val downstreamReactionGroupDto = randomDownstreamReactionGroupDto()
+    fun `ReactionGroupResponse is correctly mapped to ReactionGroup`() {
+        val reactionGroupResponse = randomReactionGroupResponse()
         val sut = Fixture().get()
         val type = randomString()
         val reactionGroup = with(sut) {
-            downstreamReactionGroupDto.toDomain(type)
+            reactionGroupResponse.toDomain(type)
         }
         val expected = ReactionGroup(
             type = type,
-            count = downstreamReactionGroupDto.count,
-            sumScore = downstreamReactionGroupDto.sum_scores,
-            firstReactionAt = downstreamReactionGroupDto.first_reaction_at,
-            lastReactionAt = downstreamReactionGroupDto.last_reaction_at,
+            count = reactionGroupResponse.count,
+            sumScore = reactionGroupResponse.sumScores,
+            firstReactionAt = reactionGroupResponse.firstReactionAt,
+            lastReactionAt = reactionGroupResponse.lastReactionAt,
         )
         assertEquals(expected, reactionGroup)
     }
@@ -1310,18 +1310,18 @@ internal class DomainMappingTest {
     }
 
     @Test
-    fun `DownstreamModerationDto is correctly mapped to Moderation`() {
-        val downstreamModerationDto = randomDownstreamModerationDto()
+    fun `ModerationV2Response is correctly mapped to Moderation`() {
+        val moderationResponse = randomModerationV2Response()
         val sut = Fixture().get()
-        val moderation = with(sut) { downstreamModerationDto.toDomain() }
+        val moderation = with(sut) { moderationResponse.toDomain() }
         val expected = Moderation(
-            action = ModerationAction(downstreamModerationDto.action),
-            originalText = downstreamModerationDto.original_text,
-            textHarms = downstreamModerationDto.text_harms ?: emptyList(),
-            imageHarms = downstreamModerationDto.image_harms ?: emptyList(),
-            blocklistMatched = downstreamModerationDto.blocklist_matched,
-            semanticFilterMatched = downstreamModerationDto.semantic_filter_matched,
-            platformCircumvented = downstreamModerationDto.platform_circumvented ?: false,
+            action = ModerationAction(moderationResponse.action),
+            originalText = moderationResponse.originalText,
+            textHarms = moderationResponse.textHarms ?: emptyList(),
+            imageHarms = moderationResponse.imageHarms ?: emptyList(),
+            blocklistMatched = moderationResponse.blocklistMatched,
+            semanticFilterMatched = moderationResponse.semanticFilterMatched,
+            platformCircumvented = moderationResponse.platformCircumvented ?: false,
         )
         assertEquals(expected, moderation)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/ModerationParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/ModerationParsingTest.kt
@@ -18,12 +18,12 @@ package io.getstream.chat.android.client.parser2
 
 import com.squareup.moshi.JsonDataException
 import io.getstream.chat.android.client.api2.mapping.DomainMapping
-import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDto
 import io.getstream.chat.android.client.parser2.direct.ModerationAdapter
 import io.getstream.chat.android.client.parser2.testdata.ModerationTestData
 import io.getstream.chat.android.models.NoOpChannelTransformer
 import io.getstream.chat.android.models.NoOpMessageTransformer
 import io.getstream.chat.android.models.NoOpUserTransformer
+import io.getstream.chat.android.network.models.ModerationV2Response
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -41,18 +41,18 @@ internal class ModerationParsingTest {
 
     private val adapter = ModerationAdapter()
 
-    // region DTO path (JSON → DownstreamModerationDto → Moderation)
+    // region Generated path (JSON → ModerationV2Response → Moderation)
 
     @Test
-    fun `DTO path - deserializes all fields`() {
-        val dto = parser.fromJson(ModerationTestData.jsonAllFields, DownstreamModerationDto::class.java)
+    fun `Generated path - deserializes all fields`() {
+        val dto = parser.fromJson(ModerationTestData.jsonAllFields, ModerationV2Response::class.java)
         val domain = with(domainMapping) { dto.toDomain() }
         assertEquals(ModerationTestData.expectedAllFields, domain)
     }
 
     @Test
-    fun `DTO path - deserializes with optional fields missing`() {
-        val dto = parser.fromJson(ModerationTestData.jsonOptionalFieldsMissing, DownstreamModerationDto::class.java)
+    fun `Generated path - deserializes with optional fields missing`() {
+        val dto = parser.fromJson(ModerationTestData.jsonOptionalFieldsMissing, ModerationV2Response::class.java)
         val domain = with(domainMapping) { dto.toDomain() }
         assertEquals(ModerationTestData.expectedOptionalFieldsMissing, domain)
     }
@@ -78,8 +78,8 @@ internal class ModerationParsingTest {
     // region Explicit null values
 
     @Test
-    fun `DTO path - deserializes with explicit null values`() {
-        val dto = parser.fromJson(ModerationTestData.jsonWithExplicitNulls, DownstreamModerationDto::class.java)
+    fun `Generated path - deserializes with explicit null values`() {
+        val dto = parser.fromJson(ModerationTestData.jsonWithExplicitNulls, ModerationV2Response::class.java)
         val domain = with(domainMapping) { dto.toDomain() }
         assertEquals(ModerationTestData.expectedWithExplicitNulls, domain)
     }
@@ -95,9 +95,9 @@ internal class ModerationParsingTest {
     // region Error message parity
 
     @Test
-    fun `DTO path - throws on missing action`() {
+    fun `Generated path - throws on missing action`() {
         assertThrows<JsonDataException> {
-            parser.fromJson(ModerationTestData.jsonMissingAction, DownstreamModerationDto::class.java)
+            parser.fromJson(ModerationTestData.jsonMissingAction, ModerationV2Response::class.java)
         }
     }
 
@@ -109,9 +109,9 @@ internal class ModerationParsingTest {
     }
 
     @Test
-    fun `DTO path - throws on missing original_text`() {
+    fun `Generated path - throws on missing original_text`() {
         assertThrows<JsonDataException> {
-            parser.fromJson(ModerationTestData.jsonMissingOriginalText, DownstreamModerationDto::class.java)
+            parser.fromJson(ModerationTestData.jsonMissingOriginalText, ModerationV2Response::class.java)
         }
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/ReactionGroupParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/ReactionGroupParsingTest.kt
@@ -19,14 +19,15 @@ package io.getstream.chat.android.client.parser2
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import io.getstream.chat.android.client.api2.mapping.DomainMapping
-import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionGroupDto
 import io.getstream.chat.android.client.parser2.direct.ReactionGroupAdapter
 import io.getstream.chat.android.client.parser2.testdata.ReactionGroupTestData
 import io.getstream.chat.android.models.NoOpChannelTransformer
 import io.getstream.chat.android.models.NoOpMessageTransformer
 import io.getstream.chat.android.models.NoOpUserTransformer
 import io.getstream.chat.android.network.infrastructure.IsoDateAdapter
+import io.getstream.chat.android.network.models.ReactionGroupResponse
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.Date
@@ -48,11 +49,11 @@ internal class ReactionGroupParsingTest {
 
     private val testType = "like"
 
-    // region DTO path (JSON → DownstreamReactionGroupDto → ReactionGroup)
+    // region Generated path (JSON → ReactionGroupResponse → ReactionGroup)
 
     @Test
-    fun `DTO path - deserializes all fields`() {
-        val dto = parser.fromJson(ReactionGroupTestData.jsonAllFields, DownstreamReactionGroupDto::class.java)
+    fun `Generated path - deserializes all fields`() {
+        val dto = parser.fromJson(ReactionGroupTestData.jsonAllFields, ReactionGroupResponse::class.java)
         val reactionGroup = with(domainMapping) { dto.toDomain(testType) }
         assertEquals(ReactionGroupTestData.expectedReactionGroupAllFields, reactionGroup)
     }
@@ -90,8 +91,9 @@ internal class ReactionGroupParsingTest {
 
     @Test
     fun `Both paths - same error on missing count`() {
+        val field = "count"
         val dtoException = assertThrows<JsonDataException> {
-            parser.fromJson(ReactionGroupTestData.jsonMissingCount, DownstreamReactionGroupDto::class.java)
+            parser.fromJson(ReactionGroupTestData.jsonMissingCount, ReactionGroupResponse::class.java)
         }
         val directException = assertThrows<JsonDataException> {
             reactionGroupAdapter.parseWithType(
@@ -101,13 +103,17 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        assertEquals(dtoException.message, directException.message)
+        // Both paths must fail on the same wire field. The wording differs by design: the generated model
+        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
+        assertTrue(dtoException.message.orEmpty().contains(field))
+        assertTrue(directException.message.orEmpty().contains(field))
     }
 
     @Test
     fun `Both paths - same error on missing sum_scores`() {
+        val field = "sum_scores"
         val dtoException = assertThrows<JsonDataException> {
-            parser.fromJson(ReactionGroupTestData.jsonMissingSumScores, DownstreamReactionGroupDto::class.java)
+            parser.fromJson(ReactionGroupTestData.jsonMissingSumScores, ReactionGroupResponse::class.java)
         }
         val directException = assertThrows<JsonDataException> {
             reactionGroupAdapter.parseWithType(
@@ -117,13 +123,17 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        assertEquals(dtoException.message, directException.message)
+        // Both paths must fail on the same wire field. The wording differs by design: the generated model
+        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
+        assertTrue(dtoException.message.orEmpty().contains(field))
+        assertTrue(directException.message.orEmpty().contains(field))
     }
 
     @Test
     fun `Both paths - same error on missing first_reaction_at`() {
+        val field = "first_reaction_at"
         val dtoException = assertThrows<JsonDataException> {
-            parser.fromJson(ReactionGroupTestData.jsonMissingFirstReactionAt, DownstreamReactionGroupDto::class.java)
+            parser.fromJson(ReactionGroupTestData.jsonMissingFirstReactionAt, ReactionGroupResponse::class.java)
         }
         val directException = assertThrows<JsonDataException> {
             reactionGroupAdapter.parseWithType(
@@ -133,13 +143,17 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        assertEquals(dtoException.message, directException.message)
+        // Both paths must fail on the same wire field. The wording differs by design: the generated model
+        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
+        assertTrue(dtoException.message.orEmpty().contains(field))
+        assertTrue(directException.message.orEmpty().contains(field))
     }
 
     @Test
     fun `Both paths - same error on missing last_reaction_at`() {
+        val field = "last_reaction_at"
         val dtoException = assertThrows<JsonDataException> {
-            parser.fromJson(ReactionGroupTestData.jsonMissingLastReactionAt, DownstreamReactionGroupDto::class.java)
+            parser.fromJson(ReactionGroupTestData.jsonMissingLastReactionAt, ReactionGroupResponse::class.java)
         }
         val directException = assertThrows<JsonDataException> {
             reactionGroupAdapter.parseWithType(
@@ -149,7 +163,10 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        assertEquals(dtoException.message, directException.message)
+        // Both paths must fail on the same wire field. The wording differs by design: the generated model
+        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
+        assertTrue(dtoException.message.orEmpty().contains(field))
+        assertTrue(directException.message.orEmpty().contains(field))
     }
 
     // endregion

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/ReactionGroupParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/ReactionGroupParsingTest.kt
@@ -87,10 +87,49 @@ internal class ReactionGroupParsingTest {
 
     // endregion
 
-    // region Error message parity
+    // region latest_reactions_by
+    //
+    // The generated model declares this key and the direct adapter skips it, so the two paths differ on
+    // it. Neither reaches the domain, since `ReactionGroup` has nowhere to put it.
 
     @Test
-    fun `Both paths - same error on missing count`() {
+    fun `Both paths - a group carrying latest_reactions_by maps to the same ReactionGroup`() {
+        val json = ReactionGroupTestData.jsonWithLatestReactionsBy
+
+        val fromResponse = parser.fromJson(json, ReactionGroupResponse::class.java)
+        val direct = reactionGroupAdapter.parseWithType(
+            com.squareup.moshi.JsonReader.of(okio.Buffer().writeUtf8(json)),
+            testType,
+        )
+
+        assertEquals(1, fromResponse.latestReactionsBy.size)
+        assertEquals("user-1", fromResponse.latestReactionsBy.first().userId)
+        assertEquals(with(domainMapping) { fromResponse.toDomain(testType) }, direct)
+    }
+
+    @Test
+    fun `Both paths - a null latest_reactions_by is coerced to empty rather than throwing`() {
+        val json = ReactionGroupTestData.jsonWithNullLatestReactionsBy
+
+        val fromResponse = parser.fromJson(json, ReactionGroupResponse::class.java)
+        val direct = reactionGroupAdapter.parseWithType(
+            com.squareup.moshi.JsonReader.of(okio.Buffer().writeUtf8(json)),
+            testType,
+        )
+
+        assertEquals(emptyList<Any>(), fromResponse.latestReactionsBy)
+        assertEquals(with(domainMapping) { fromResponse.toDomain(testType) }, direct)
+    }
+
+    // endregion
+
+    // region Failure parity
+    //
+    // Both paths must fail on the same wire field. The wording differs by design: the generated model
+    // names the Kotlin property and its @Json name, the direct adapter names the wire key.
+
+    @Test
+    fun `Both paths - both fail on missing count`() {
         val field = "count"
         val dtoException = assertThrows<JsonDataException> {
             parser.fromJson(ReactionGroupTestData.jsonMissingCount, ReactionGroupResponse::class.java)
@@ -103,14 +142,12 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        // Both paths must fail on the same wire field. The wording differs by design: the generated model
-        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
         assertTrue(dtoException.message.orEmpty().contains(field))
         assertTrue(directException.message.orEmpty().contains(field))
     }
 
     @Test
-    fun `Both paths - same error on missing sum_scores`() {
+    fun `Both paths - both fail on missing sum_scores`() {
         val field = "sum_scores"
         val dtoException = assertThrows<JsonDataException> {
             parser.fromJson(ReactionGroupTestData.jsonMissingSumScores, ReactionGroupResponse::class.java)
@@ -123,14 +160,12 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        // Both paths must fail on the same wire field. The wording differs by design: the generated model
-        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
         assertTrue(dtoException.message.orEmpty().contains(field))
         assertTrue(directException.message.orEmpty().contains(field))
     }
 
     @Test
-    fun `Both paths - same error on missing first_reaction_at`() {
+    fun `Both paths - both fail on missing first_reaction_at`() {
         val field = "first_reaction_at"
         val dtoException = assertThrows<JsonDataException> {
             parser.fromJson(ReactionGroupTestData.jsonMissingFirstReactionAt, ReactionGroupResponse::class.java)
@@ -143,14 +178,12 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        // Both paths must fail on the same wire field. The wording differs by design: the generated model
-        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
         assertTrue(dtoException.message.orEmpty().contains(field))
         assertTrue(directException.message.orEmpty().contains(field))
     }
 
     @Test
-    fun `Both paths - same error on missing last_reaction_at`() {
+    fun `Both paths - both fail on missing last_reaction_at`() {
         val field = "last_reaction_at"
         val dtoException = assertThrows<JsonDataException> {
             parser.fromJson(ReactionGroupTestData.jsonMissingLastReactionAt, ReactionGroupResponse::class.java)
@@ -163,8 +196,6 @@ internal class ReactionGroupParsingTest {
                 testType,
             )
         }
-        // Both paths must fail on the same wire field. The wording differs by design: the generated model
-        // names the Kotlin property and its @Json name, the direct adapter names the wire key.
         assertTrue(dtoException.message.orEmpty().contains(field))
         assertTrue(directException.message.orEmpty().contains(field))
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
@@ -18,9 +18,9 @@ package io.getstream.chat.android.client.parser2.testdata
 
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamModerationDetailsDto
-import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionGroupDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserGroupDto
 import io.getstream.chat.android.network.models.MessageRequest
+import io.getstream.chat.android.network.models.ReactionGroupResponse
 import org.intellij.lang.annotations.Language
 import java.util.Date
 
@@ -151,11 +151,11 @@ internal object MessageDtoTestData {
         reaction_scores = mapOf("like" to 10),
         reaction_groups = mapOf(
             "like" to
-                DownstreamReactionGroupDto(
+                ReactionGroupResponse(
                     count = 2,
-                    sum_scores = 10,
-                    first_reaction_at = Date(1591787071588),
-                    last_reaction_at = Date(1591787071588),
+                    sumScores = 10,
+                    firstReactionAt = Date(1591787071588),
+                    lastReactionAt = Date(1591787071588),
                 ),
         ),
         latest_reactions = listOf(ReactionDtoTestData.reactionResponse),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/ReactionGroupTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/ReactionGroupTestData.kt
@@ -26,6 +26,19 @@ internal object ReactionGroupTestData {
     val jsonAllFields =
         """{"count":5,"sum_scores":10,"first_reaction_at":"2020-01-01T00:00:00.000Z","last_reaction_at":"2020-01-02T00:00:00.000Z"}"""
 
+    /** `latest_reactions_by` is a key the generated model declares and the direct adapter skips. */
+    @Language("JSON")
+    val jsonWithLatestReactionsBy =
+        """{"count":5,"sum_scores":10,"first_reaction_at":"2020-01-01T00:00:00.000Z",""" +
+            """"last_reaction_at":"2020-01-02T00:00:00.000Z","latest_reactions_by":[""" +
+            """{"user_id":"user-1","created_at":"2020-01-02T00:00:00.000Z"}]}"""
+
+    /** The wire sends an explicit null for a message that predates the backfill. */
+    @Language("JSON")
+    val jsonWithNullLatestReactionsBy =
+        """{"count":5,"sum_scores":10,"first_reaction_at":"2020-01-01T00:00:00.000Z",""" +
+            """"last_reaction_at":"2020-01-02T00:00:00.000Z","latest_reactions_by":null}"""
+
     @Language("JSON")
     val jsonMissingCount =
         """{"sum_scores":10,"first_reaction_at":"2020-01-01T00:00:00.000Z","last_reaction_at":"2020-01-02T00:00:00.000Z"}"""


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Adopt the generated `ModerationV2Response` and `ReactionGroupResponse` for the last two nested leaves of
`DownstreamMessageDto`.

Part of [AND-1291](https://linear.app/stream/issue/AND-1291/migrate-models-to-generated-openapi-types)

### Implementation

- Point `DownstreamMessageDto.moderation` and `reaction_groups` at the generated models and follow the
  field renames in both mappers. `DownstreamModerationDto` and `DownstreamReactionGroupDto` go away;
  `ReactionDtos.kt` becomes `DownstreamReactionDto.kt`, since that is all it still holds.
- Vendor `ModerationV2Response`, `ReactionGroupResponse` and `ReactionGroupUserResponse`, which the former
  references as a field type.

### Notes

Neither swap changes strictness. `ReactionGroupResponse` requires the same four fields the hand-written DTO
declared non-null, and `ModerationV2Response` requires `action` and `original_text` and leaves the rest
nullable, exactly as before.

Neither mapping can diverge, because of how the backend tags the struct. `action` and `original_text` are
plain tags and always serialized, and every other field is `omitempty` on a non-pointer type, so it is
either a real value or absent and can never arrive as JSON `null`. That is the only input that would tell
the old "nullable, no default" fields apart from the generated "nullable with default" ones, so an absent
key produces the same `Moderation` through both: `.orEmpty()` for the harm lists, null for the two strings,
`?: false` for `platform_circumvented`.

`ReactionGroupResponse.latest_reactions_by` has no home on the domain and is read then dropped, like the
config fields in
[AND-1498](https://linear.app/stream/issue/AND-1498/surface-the-channel-config-fields-the-generated-model-parses-but).
`blocklists_matched` is also parsed and dropped, but it is a different problem: the backend deprecates the
singular `blocklist_matched` that `Moderation.blocklistMatched` maps, in favour of exactly that plural.
Tracked as
[AND-1502](https://linear.app/stream/issue/AND-1502/moderationblocklistmatched-reads-a-field-the-backend-deprecated-in).

`latest_reactions_by` is the one key where the two paths now differ: the generated model declares it, so
it is parsed and its entries are validated, while `ReactionGroupAdapter` still skips it. Neither reaches
the domain. It also makes `NullCollectionsAsEmptyFactory` match `ReactionGroupResponse`, which is
load-bearing rather than incidental: the field is a non-null list against a plain non-`omitempty` Go tag,
so a message that predates the `latest_reactions_by` backfill sends an explicit null that would otherwise
throw. Both cases are pinned by tests.

### Testing

- `ModerationParsingTest` and `ReactionGroupParsingTest` retargeted to the generated models, and
  `DomainMappingTest` covers both mappings.
- Mutation sweep over both mappers: `ReactionGroupResponse.toDomain` has all five assignments caught, and
  every field of `ModerationV2Response.toDomain` is compile-guaranteed, since `Moderation` defaults none of
  them.
- Device-probed `reaction_groups` on the wire across the four shapes that carry it: `getMessage`,
  `queryChannels`, `reaction.new` and `reaction.deleted`. Every `ReactionGroup` field asserted, with two
  reaction types at different scores so `count` and `sumScore` cannot be confused.
- `ReactionGroupParsingTest` covers a group carrying `latest_reactions_by` and one carrying an explicit
  null, asserting both paths still produce an identical `ReactionGroup`.
- `moderation` is covered by unit tests only. The server sets it only when moderation blocks a message, so
  reaching it needs a channel type whose automod behaviour blocks or bounces rather than flags, and that is
  server-side app config the demo app does not have.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling for moderation results and reaction-group data.
  * Updated parsing to support the latest response field formats, including optional moderation details and reaction-group users.

* **Tests**
  * Expanded validation for complete, partial, null, and invalid moderation and reaction-group responses.
  * Improved parsing error checks to identify the affected response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
