### PR TITLE
Deduplicate queryGroupedChannels calls in DistinctChatApi

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/internal/DistinctChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/internal/DistinctChatApi.kt
@@ -27,11 +27,14 @@ import io.getstream.chat.android.client.api2.optimisation.hash.GetPinnedMessages
 import io.getstream.chat.android.client.api2.optimisation.hash.GetReactionsHash
 import io.getstream.chat.android.client.api2.optimisation.hash.GetRepliesHash
 import io.getstream.chat.android.client.api2.optimisation.hash.QueryBanedUsersHash
+import io.getstream.chat.android.client.api2.optimisation.hash.QueryGroupedChannelsHash
 import io.getstream.chat.android.client.api2.optimisation.hash.QueryMembersHash
 import io.getstream.chat.android.models.BannedUser
 import io.getstream.chat.android.models.BannedUsersSort
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.FilterObject
+import io.getstream.chat.android.models.GroupedChannels
+import io.getstream.chat.android.models.GroupedChannelsGroupQuery
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.PendingMessage
@@ -139,6 +142,22 @@ internal class DistinctChatApi(
         StreamLog.d(TAG) { "[queryChannels] query: $query, uniqueKey: $uniqueKey" }
         return getOrCreate(uniqueKey) {
             delegate.queryChannels(query)
+        }
+    }
+
+    override fun queryGroupedChannels(
+        limit: Int?,
+        groups: Map<String, GroupedChannelsGroupQuery>?,
+        watch: Boolean,
+        presence: Boolean,
+    ): Call<GroupedChannels> {
+        val uniqueKey = QueryGroupedChannelsHash(limit, groups, watch, presence).hashCode()
+        StreamLog.d(TAG) {
+            "[queryGroupedChannels] limit: $limit, groups: $groups, watch: $watch, " +
+                "presence: $presence, uniqueKey: $uniqueKey"
+        }
+        return getOrCreate(uniqueKey) {
+            delegate.queryGroupedChannels(limit, groups, watch, presence)
         }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/internal/DistinctChatApiEnabler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/internal/DistinctChatApiEnabler.kt
@@ -25,6 +25,8 @@ import io.getstream.chat.android.models.BannedUser
 import io.getstream.chat.android.models.BannedUsersSort
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.FilterObject
+import io.getstream.chat.android.models.GroupedChannels
+import io.getstream.chat.android.models.GroupedChannelsGroupQuery
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.PendingMessage
@@ -80,6 +82,15 @@ internal class DistinctChatApiEnabler(
 
     override fun queryChannels(query: QueryChannelsRequest): Call<QueryChannelsResult> {
         return getApi().queryChannels(query)
+    }
+
+    override fun queryGroupedChannels(
+        limit: Int?,
+        groups: Map<String, GroupedChannelsGroupQuery>?,
+        watch: Boolean,
+        presence: Boolean,
+    ): Call<GroupedChannels> {
+        return getApi().queryGroupedChannels(limit, groups, watch, presence)
     }
 
     override fun queryBannedUsers(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/optimisation/hash/QueryGroupedChannelsHash.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/optimisation/hash/QueryGroupedChannelsHash.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api2.optimisation.hash
+
+import io.getstream.chat.android.models.GroupedChannelsGroupQuery
+
+internal data class QueryGroupedChannelsHash(
+    val limit: Int?,
+    val groups: Map<String, GroupedChannelsGroupQuery>?,
+    val watch: Boolean,
+    val presence: Boolean,
+)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiEnablerTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiEnablerTest.kt
@@ -32,6 +32,7 @@ import io.getstream.chat.android.randomString
 import kotlinx.coroutines.test.TestScope
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
@@ -98,6 +99,7 @@ internal class DistinctChatApiEnablerTest {
             members = members,
         )
         enabler.queryChannel(channelType, channelId, channelRequest)
+        enabler.queryGroupedChannels(limit, null, watch = true, presence = false)
         // then
         verify(distinctApi, times(1)).getRepliesMore(messageId, firstId, limit)
         verify(distinctApi, times(1)).getReplies(messageId, limit)
@@ -133,6 +135,7 @@ internal class DistinctChatApiEnablerTest {
             members = members,
         )
         verify(distinctApi, times(1)).queryChannel(channelType, channelId, channelRequest)
+        verify(distinctApi, times(1)).queryGroupedChannels(limit, null, watch = true, presence = false)
         verifyNoInteractions(api)
     }
 
@@ -173,6 +176,7 @@ internal class DistinctChatApiEnablerTest {
             members = members,
         )
         enabler.queryChannel(channelType, channelId, channelRequest)
+        enabler.queryGroupedChannels(limit, null, watch = true, presence = false)
 
         // then
         verify(api, times(1)).getRepliesMore(messageId, firstId, limit)
@@ -203,6 +207,7 @@ internal class DistinctChatApiEnablerTest {
             members = members,
         )
         verify(api, times(1)).queryChannel(channelType, channelId, channelRequest)
+        verify(api, times(1)).queryGroupedChannels(limit, null, watch = true, presence = false)
         verify(distinctApi, times(0)).getRepliesMore(any(), any(), any())
         verify(distinctApi, times(0)).getReplies(any(), any())
         verify(distinctApi, times(0)).getNewerReplies(any(), any(), any())
@@ -214,5 +219,6 @@ internal class DistinctChatApiEnablerTest {
         verify(distinctApi, times(0)).queryBannedUsers(any(), any(), any(), any(), any(), any(), any(), any())
         verify(distinctApi, times(0)).queryMembers(any(), any(), any(), any(), any(), any(), any())
         verify(distinctApi, times(0)).queryChannel(any(), any(), any())
+        verify(distinctApi, times(0)).queryGroupedChannels(anyOrNull(), anyOrNull(), any(), any())
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiTest.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.randomMember
 import io.getstream.chat.android.randomString
 import io.getstream.chat.android.test.TestCall
 import io.getstream.result.Result
+import io.getstream.result.call.DistinctCall
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -491,7 +492,8 @@ internal class DistinctChatApiTest {
         val call1 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
         val call2 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
         // then
-        // verify same instance of call is reused
+        // verify the override wraps the call and reuses the same instance
+        Assert.assertTrue(call1 is DistinctCall)
         Assert.assertTrue(call1 === call2)
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiTest.kt
@@ -484,6 +484,46 @@ internal class DistinctChatApiTest {
     }
 
     @Test
+    fun `When calling queryGroupedChannels with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
+        val call2 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryGroupedChannels with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.queryGroupedChannels(any(), anyOrNull(), any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
+            call1.await()
+            val call2 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling queryGroupedChannels with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryGroupedChannels(limit = 30, groups = null, watch = true, presence = false)
+        val call2 = distinctChatApi.queryGroupedChannels(limit = 60, groups = null, watch = true, presence = false)
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
     fun `When calling queryBannedUsers with same arguments, Then same instance of Call is returned`() {
         // given
         val distinctChatApi = DistinctChatApi(TestScope(), mock())


### PR DESCRIPTION
<!-- pr:improvement -->

### Goal

`DistinctChatApi` deduplicates in-flight `queryChannels` calls but not `queryGroupedChannels`, so identical concurrent grouped queries fire redundant network calls. Deduplicate them the same way.

Closes [AND-1504](https://linear.app/stream/issue/AND-1504/distinctchatapi-does-not-deduplicate-querygroupedchannels-calls)

### Implementation

- Override `queryGroupedChannels` in `DistinctChatApi`, keyed off a new `QueryGroupedChannelsHash(limit, groups, watch, presence)` and routed through the same `getOrCreate` dedup as `queryChannels`.
- Override `queryGroupedChannels` in `DistinctChatApiEnabler` so it goes through `getApi()` and respects the distinct-calls toggle.

All three classes are `internal`, so no public API change.

### Testing

- `DistinctChatApiTest`: same arguments reuse the `Call`, a finished call is not reused, and different arguments get separate calls.
- `DistinctChatApiEnablerTest`: the grouped call routes to the distinct API when enabled and to the original API when disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved grouped-channel queries by preventing duplicate simultaneous requests with identical parameters.
  - Repeated requests now share an in-progress result when appropriate, reducing unnecessary network traffic.

- **Bug Fixes**
  - Ensured completed requests and requests with different options continue to receive independent results.
  - Grouped-channel queries now consistently follow the configured API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->