### PR TITLE
Fix flaky isLaterThanDays date test

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -112,7 +112,7 @@ import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.extensions.extractBaseUrl
 import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.client.extensions.internal.hasPendingAttachments
-import io.getstream.chat.android.client.extensions.internal.isLaterThanDays
+import io.getstream.chat.android.client.extensions.internal.isOlderThanDays
 import io.getstream.chat.android.client.header.VersionPrefixHeader
 import io.getstream.chat.android.client.helpers.AppSettingManager
 import io.getstream.chat.android.client.helpers.CallPostponeHelper
@@ -4770,7 +4770,7 @@ internal constructor(
                 Result.Failure(Error.GenericError("channelsIds must contain at least 1 id."))
             }
 
-            lastSyncAt.isLaterThanDays(THIRTY_DAYS_IN_MILLISECONDS) -> {
+            lastSyncAt.isOlderThanDays(THIRTY_DAYS_IN_MILLISECONDS) -> {
                 Result.Failure(Error.GenericError("lastSyncAt cannot by later than 30 days."))
             }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Date.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Date.kt
@@ -21,6 +21,6 @@ import java.util.Date
 /**
  * Checks if the Date is older than [daysInMillis], measured against [now].
  */
-internal fun Date.isLaterThanDays(daysInMillis: Long, now: Date = Date()): Boolean {
+internal fun Date.isOlderThanDays(daysInMillis: Long, now: Date = Date()): Boolean {
     return now.time - time > daysInMillis
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Date.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Date.kt
@@ -19,9 +19,8 @@ package io.getstream.chat.android.client.extensions.internal
 import java.util.Date
 
 /**
- * Checks if the Date is later than [daysInMillis].
+ * Checks if the Date is older than [daysInMillis], measured against [now].
  */
-internal fun Date.isLaterThanDays(daysInMillis: Long): Boolean {
-    val now = Date()
+internal fun Date.isLaterThanDays(daysInMillis: Long, now: Date = Date()): Boolean {
     return now.time - time > daysInMillis
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/DateExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/DateExtensionsTests.kt
@@ -27,74 +27,74 @@ internal class DateExtensionsTests {
     private val fiveDaysInMillis = TimeUnit.DAYS.toMillis(5)
 
     @Test
-    fun `isLaterThanDays should return true when date is older than specified days`() {
+    fun `isOlderThanDays should return true when date is older than specified days`() {
         // given
         val sixDaysAgo = Date(now.time - TimeUnit.DAYS.toMillis(6))
 
         // when
-        val result = sixDaysAgo.isLaterThanDays(fiveDaysInMillis, now)
+        val result = sixDaysAgo.isOlderThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo true
     }
 
     @Test
-    fun `isLaterThanDays should return false when date is exactly as old as specified days`() {
+    fun `isOlderThanDays should return false when date is exactly as old as specified days`() {
         // given
         val fiveDaysAgo = Date(now.time - fiveDaysInMillis)
 
         // when
-        val result = fiveDaysAgo.isLaterThanDays(fiveDaysInMillis, now)
+        val result = fiveDaysAgo.isOlderThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo false
     }
 
     @Test
-    fun `isLaterThanDays should return false when date is newer than specified days`() {
+    fun `isOlderThanDays should return false when date is newer than specified days`() {
         // given
         val threeDaysAgo = Date(now.time - TimeUnit.DAYS.toMillis(3))
 
         // when
-        val result = threeDaysAgo.isLaterThanDays(fiveDaysInMillis, now)
+        val result = threeDaysAgo.isOlderThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo false
     }
 
     @Test
-    fun `isLaterThanDays should return false when date is in the future`() {
+    fun `isOlderThanDays should return false when date is in the future`() {
         // given
         val twoDaysInFuture = Date(now.time + TimeUnit.DAYS.toMillis(2))
 
         // when
-        val result = twoDaysInFuture.isLaterThanDays(fiveDaysInMillis, now)
+        val result = twoDaysInFuture.isOlderThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo false
     }
 
     @Test
-    fun `isLaterThanDays should handle zero day threshold correctly`() {
+    fun `isOlderThanDays should handle zero day threshold correctly`() {
         // given
         val zeroDaysInMillis = TimeUnit.DAYS.toMillis(0)
         val oneMillisAgo = Date(now.time - 1)
 
         // when
-        val result = oneMillisAgo.isLaterThanDays(zeroDaysInMillis, now)
+        val result = oneMillisAgo.isOlderThanDays(zeroDaysInMillis, now)
 
         // then
         result shouldBeEqualTo true
     }
 
     @Test
-    fun `isLaterThanDays should handle large time differences correctly`() {
+    fun `isOlderThanDays should handle large time differences correctly`() {
         // given
         val oneYearInMillis = TimeUnit.DAYS.toMillis(365)
         val twoYearsAgo = Date(now.time - TimeUnit.DAYS.toMillis(365 * 2))
 
         // when
-        val result = twoYearsAgo.isLaterThanDays(oneYearInMillis, now)
+        val result = twoYearsAgo.isOlderThanDays(oneYearInMillis, now)
 
         // then
         result shouldBeEqualTo true

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/DateExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/DateExtensionsTests.kt
@@ -23,14 +23,16 @@ import java.util.concurrent.TimeUnit
 
 internal class DateExtensionsTests {
 
+    private val now = Date()
+    private val fiveDaysInMillis = TimeUnit.DAYS.toMillis(5)
+
     @Test
     fun `isLaterThanDays should return true when date is older than specified days`() {
         // given
-        val fiveDaysInMillis = TimeUnit.DAYS.toMillis(5)
-        val sixDaysAgo = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(6))
+        val sixDaysAgo = Date(now.time - TimeUnit.DAYS.toMillis(6))
 
         // when
-        val result = sixDaysAgo.isLaterThanDays(fiveDaysInMillis)
+        val result = sixDaysAgo.isLaterThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo true
@@ -39,11 +41,10 @@ internal class DateExtensionsTests {
     @Test
     fun `isLaterThanDays should return false when date is exactly as old as specified days`() {
         // given
-        val fiveDaysInMillis = TimeUnit.DAYS.toMillis(5)
-        val fiveDaysAgo = Date(System.currentTimeMillis() - fiveDaysInMillis)
+        val fiveDaysAgo = Date(now.time - fiveDaysInMillis)
 
         // when
-        val result = fiveDaysAgo.isLaterThanDays(fiveDaysInMillis)
+        val result = fiveDaysAgo.isLaterThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo false
@@ -52,11 +53,10 @@ internal class DateExtensionsTests {
     @Test
     fun `isLaterThanDays should return false when date is newer than specified days`() {
         // given
-        val fiveDaysInMillis = TimeUnit.DAYS.toMillis(5)
-        val threeDaysAgo = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3))
+        val threeDaysAgo = Date(now.time - TimeUnit.DAYS.toMillis(3))
 
         // when
-        val result = threeDaysAgo.isLaterThanDays(fiveDaysInMillis)
+        val result = threeDaysAgo.isLaterThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo false
@@ -65,11 +65,10 @@ internal class DateExtensionsTests {
     @Test
     fun `isLaterThanDays should return false when date is in the future`() {
         // given
-        val fiveDaysInMillis = TimeUnit.DAYS.toMillis(5)
-        val twoDaysInFuture = Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(2))
+        val twoDaysInFuture = Date(now.time + TimeUnit.DAYS.toMillis(2))
 
         // when
-        val result = twoDaysInFuture.isLaterThanDays(fiveDaysInMillis)
+        val result = twoDaysInFuture.isLaterThanDays(fiveDaysInMillis, now)
 
         // then
         result shouldBeEqualTo false
@@ -79,10 +78,10 @@ internal class DateExtensionsTests {
     fun `isLaterThanDays should handle zero day threshold correctly`() {
         // given
         val zeroDaysInMillis = TimeUnit.DAYS.toMillis(0)
-        val justNow = Date(System.currentTimeMillis() - 1) // 1 millisecond ago
+        val oneMillisAgo = Date(now.time - 1)
 
         // when
-        val result = justNow.isLaterThanDays(zeroDaysInMillis)
+        val result = oneMillisAgo.isLaterThanDays(zeroDaysInMillis, now)
 
         // then
         result shouldBeEqualTo true
@@ -92,10 +91,10 @@ internal class DateExtensionsTests {
     fun `isLaterThanDays should handle large time differences correctly`() {
         // given
         val oneYearInMillis = TimeUnit.DAYS.toMillis(365)
-        val twoYearsAgo = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(365 * 2))
+        val twoYearsAgo = Date(now.time - TimeUnit.DAYS.toMillis(365 * 2))
 
         // when
-        val result = twoYearsAgo.isLaterThanDays(oneYearInMillis)
+        val result = twoYearsAgo.isLaterThanDays(oneYearInMillis, now)
 
         // then
         result shouldBeEqualTo true


### PR DESCRIPTION
<!-- pr:test -->

### Goal

`DateExtensionsTests` flakes on CI. The "exactly as old as specified days" case builds a date `now - 5 days` and expects `isLaterThanDays(5 days)` to be false, but `isLaterThanDays` reads the clock again internally, so it only holds when both reads land in the same millisecond. Any tick between them flips the result and fails the test.

Port of #6690 to develop.

Part of [AND-1514](https://linear.app/stream/issue/AND-1514/flaky-dateextensionstests-islaterthandays-boundary-test-races-the)

### Implementation

- Add a defaulted `now: Date = Date()` parameter to `isLaterThanDays` so the reference instant can be injected. Production callers use the default and are unchanged.
- Derive every test's date from a single fixed `now` and pass it in, removing the wall-clock dependence from the whole suite.

Both are `internal`, so no public API change.

### Testing

- `:stream-chat-android-client:testDebugUnitTest --tests "*DateExtensionsTests"` passes; the boundary case is now deterministic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved date-related test consistency by using a shared reference time.
  - Updated coverage for date comparisons with an explicitly provided current time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->