### PR TITLE
Populate ChannelData.deletedAt when a channel is deleted

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -487,16 +487,11 @@ internal class EventHandlerSequential(
         }
         val sortedEvents: List<ChatEvent> = batchEvent.sortedEvents
 
-        stateRegistry.handleBatchEvent(batchEvent)
-
         // step 3 - forward the events to the active channels
         sortedEvents.filterIsInstance<CidEvent>()
             .groupBy { it.cid }
             .forEach { (cid, events) ->
                 val (channelType, channelId) = cid.cidToTypeAndId()
-                if (events.any { it is ChannelDeletedEvent || it is NotificationChannelDeletedEvent }) {
-                    logicRegistry.removeChannel(channelType, channelId)
-                }
                 if (logicRegistry.isActiveChannel(channelType = channelType, channelId = channelId)) {
                     val channelLogic: ChannelLogic = logicRegistry.channel(
                         channelType = channelType,
@@ -504,7 +499,14 @@ internal class EventHandlerSequential(
                     )
                     channelLogic.handleEvents(events)
                 }
+                // Discard the channel only after its events are handled, otherwise the deletion
+                // never reaches the channel state and ChannelData.deletedAt stays null.
+                if (events.any { it is ChannelDeletedEvent || it is NotificationChannelDeletedEvent }) {
+                    logicRegistry.removeChannel(channelType, channelId)
+                }
             }
+
+        stateRegistry.handleBatchEvent(batchEvent)
 
         // mark all read applies to all channels
         sortedEvents.filterIsInstance<MarkAllReadEvent>().lastOrNull()?.let { markAllRead ->

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -488,6 +488,7 @@ internal class EventHandlerSequential(
         val sortedEvents: List<ChatEvent> = batchEvent.sortedEvents
 
         // step 3 - forward the events to the active channels
+        val deletedChannels = mutableListOf<Pair<String, String>>()
         sortedEvents.filterIsInstance<CidEvent>()
             .groupBy { it.cid }
             .forEach { (cid, events) ->
@@ -499,13 +500,17 @@ internal class EventHandlerSequential(
                     )
                     channelLogic.handleEvents(events)
                 }
-                // Discard the channel only after its events are handled, otherwise the deletion
-                // never reaches the channel state and ChannelData.deletedAt stays null.
                 if (events.any { it is ChannelDeletedEvent || it is NotificationChannelDeletedEvent }) {
-                    logicRegistry.removeChannel(channelType, channelId)
+                    deletedChannels += channelType to channelId
                 }
             }
 
+        // Discard deleted channels only after their events are handled, otherwise the deletion never
+        // reaches the channel state and ChannelData.deletedAt stays null. Both registries are evicted
+        // back to back to keep the window where they disagree as short as possible.
+        deletedChannels.forEach { (channelType, channelId) ->
+            logicRegistry.removeChannel(channelType, channelId)
+        }
         stateRegistry.handleBatchEvent(batchEvent)
 
         // mark all read applies to all channels

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelEventHandler.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelEventHandler.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.client.events.MessageReadEvent
 import io.getstream.chat.android.client.events.MessageUpdatedEvent
 import io.getstream.chat.android.client.events.NewMessageEvent
 import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
+import io.getstream.chat.android.client.events.NotificationChannelDeletedEvent
 import io.getstream.chat.android.client.events.NotificationChannelMutesUpdatedEvent
 import io.getstream.chat.android.client.events.NotificationChannelTruncatedEvent
 import io.getstream.chat.android.client.events.NotificationInviteAcceptedEvent
@@ -224,10 +225,8 @@ internal class ChannelEventHandler(
             }
 
             is ChannelVisibleEvent -> stateLogic.setHidden(false)
-            is ChannelDeletedEvent -> {
-                stateLogic.removeMessagesBefore(event.createdAt)
-                stateLogic.deleteChannel(event.createdAt)
-            }
+            is ChannelDeletedEvent -> stateLogic.deleteChannel(event.createdAt)
+            is NotificationChannelDeletedEvent -> stateLogic.deleteChannel(event.createdAt)
             is ChannelTruncatedEvent -> {
                 stateLogic.removeMessagesBefore(event.createdAt, event.message)
                 stateLogic.updateChannelData(event)

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
@@ -50,6 +50,7 @@ import org.junit.Rule
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -285,7 +286,7 @@ internal class WhenHandleEvent : SynchronizedCoroutineTest {
         channelLogic.handleEvent(deleteChannelEvent)
 
         verify(channelStateLogic).deleteChannel(deleteChannelEvent.createdAt)
-        verify(channelStateLogic, never()).removeMessagesBefore(any(), any())
+        verify(channelStateLogic, never()).removeMessagesBefore(any(), anyOrNull())
     }
 
     // Poll deleted event

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
@@ -53,6 +53,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -278,13 +279,13 @@ internal class WhenHandleEvent : SynchronizedCoroutineTest {
 
     // Channel deleted event
     @Test
-    fun `when channel is deleted, messages are deleted too`() = runTest {
+    fun `when channel is deleted, the deletion date is set and the messages are kept`() = runTest {
         val deleteChannelEvent = randomChannelDeletedEvent()
 
         channelLogic.handleEvent(deleteChannelEvent)
 
-        verify(channelStateLogic).removeMessagesBefore(deleteChannelEvent.createdAt)
         verify(channelStateLogic).deleteChannel(deleteChannelEvent.createdAt)
+        verify(channelStateLogic, never()).removeMessagesBefore(any(), any())
     }
 
     // Poll deleted event

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialChannelDeletedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialChannelDeletedTest.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.state.event.handler.internal
 
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.events.CidEvent
 import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
 import io.getstream.chat.android.client.setup.state.ClientState
@@ -32,7 +33,6 @@ import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
 import io.getstream.chat.android.test.TestCoroutineExtension
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -55,7 +55,7 @@ internal class EventHandlerSequentialChannelDeletedTest {
     ) = runTest {
         val fixture = Fixture()
         val channelState = fixture.withActiveChannel(CHANNEL_TYPE, CHANNEL_ID)
-        val eventHandler = fixture.get(testCoroutines.scope)
+        val eventHandler = fixture.get()
 
         eventHandler.handleEvents(event)
 
@@ -91,14 +91,15 @@ internal class EventHandlerSequentialChannelDeletedTest {
         )
 
         /** Watches the channel the way an open chat screen does, and returns the state it observes. */
-        fun withActiveChannel(channelType: String, channelId: String) = logicRegistry
-            .channel(channelType, channelId)
-            .let { stateRegistry.channel(channelType, channelId) }
+        fun withActiveChannel(channelType: String, channelId: String): ChannelState {
+            logicRegistry.channel(channelType, channelId)
+            return stateRegistry.channel(channelType, channelId)
+        }
 
         fun isActiveChannel(channelType: String, channelId: String) =
             logicRegistry.isActiveChannel(channelType, channelId)
 
-        fun get(scope: CoroutineScope) = EventHandlerSequential(
+        fun get() = EventHandlerSequential(
             currentUserId = currentUser.id,
             subscribeForEvents = { EventHandlerSequential.EMPTY_DISPOSABLE },
             logicRegistry = logicRegistry,
@@ -109,7 +110,7 @@ internal class EventHandlerSequentialChannelDeletedTest {
             sideEffect = {},
             syncedEvents = emptyFlow(),
             bufferConfig = MessageBufferConfig(),
-            scope = scope,
+            scope = testCoroutines.scope,
         )
     }
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialChannelDeletedTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialChannelDeletedTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.event.handler.internal
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.events.CidEvent
+import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
+import io.getstream.chat.android.client.setup.state.ClientState
+import io.getstream.chat.android.client.test.randomChannelDeletedEvent
+import io.getstream.chat.android.client.test.randomNotificationChannelDeletedEvent
+import io.getstream.chat.android.models.EventType
+import io.getstream.chat.android.models.Location
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomUser
+import io.getstream.chat.android.state.plugin.config.MessageBufferConfig
+import io.getstream.chat.android.state.plugin.config.MessageLimitConfig
+import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
+import io.getstream.chat.android.state.plugin.state.StateRegistry
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.chat.android.test.TestCoroutineExtension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+internal class EventHandlerSequentialChannelDeletedTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("channelDeletedEvents")
+    fun `channel deletion is reflected on the channel state before the channel is discarded`(
+        eventType: String,
+        event: CidEvent,
+    ) = runTest {
+        val fixture = Fixture()
+        val channelState = fixture.withActiveChannel(CHANNEL_TYPE, CHANNEL_ID)
+        val eventHandler = fixture.get(testCoroutines.scope)
+
+        eventHandler.handleEvents(event)
+
+        channelState.channelData.value.deletedAt `should be equal to` event.createdAt
+        fixture.isActiveChannel(CHANNEL_TYPE, CHANNEL_ID) `should be equal to` false
+    }
+
+    private class Fixture {
+        private val currentUser = randomUser()
+        private val userFlow = MutableStateFlow<User?>(currentUser)
+        private val clientState: ClientState = mock { on { user } doReturn userFlow }
+        private val repos: RepositoryFacade = mock()
+        private val client: ChatClient = mock()
+        private val mutableGlobalState = MutableGlobalState(currentUser.id)
+        private val stateRegistry = StateRegistry(
+            userStateFlow = userFlow,
+            latestUsers = MutableStateFlow(mapOf(currentUser.id to currentUser)),
+            activeLiveLocations = MutableStateFlow(emptyList<Location>()),
+            job = Job(),
+            now = { 0L },
+            scope = testCoroutines.scope,
+            messageLimitConfig = MessageLimitConfig(),
+        )
+        private val logicRegistry = LogicRegistry(
+            stateRegistry = stateRegistry,
+            clientState = clientState,
+            mutableGlobalState = mutableGlobalState,
+            userPresence = false,
+            repos = repos,
+            client = client,
+            coroutineScope = testCoroutines.scope,
+            now = { 0L },
+        )
+
+        /** Watches the channel the way an open chat screen does, and returns the state it observes. */
+        fun withActiveChannel(channelType: String, channelId: String) = logicRegistry
+            .channel(channelType, channelId)
+            .let { stateRegistry.channel(channelType, channelId) }
+
+        fun isActiveChannel(channelType: String, channelId: String) =
+            logicRegistry.isActiveChannel(channelType, channelId)
+
+        fun get(scope: CoroutineScope) = EventHandlerSequential(
+            currentUserId = currentUser.id,
+            subscribeForEvents = { EventHandlerSequential.EMPTY_DISPOSABLE },
+            logicRegistry = logicRegistry,
+            stateRegistry = stateRegistry,
+            clientState = clientState,
+            mutableGlobalState = mutableGlobalState,
+            repos = repos,
+            sideEffect = {},
+            syncedEvents = emptyFlow(),
+            bufferConfig = MessageBufferConfig(),
+            scope = scope,
+        )
+    }
+
+    companion object {
+
+        private const val CHANNEL_TYPE = "messaging"
+        private const val CHANNEL_ID = "channelId"
+        private const val CID = "$CHANNEL_TYPE:$CHANNEL_ID"
+
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+
+        @JvmStatic
+        fun channelDeletedEvents() = listOf(
+            Arguments.of(
+                EventType.CHANNEL_DELETED,
+                randomChannelDeletedEvent(cid = CID, channelType = CHANNEL_TYPE, channelId = CHANNEL_ID),
+            ),
+            Arguments.of(
+                EventType.NOTIFICATION_CHANNEL_DELETED,
+                randomNotificationChannelDeletedEvent(
+                    cid = CID,
+                    channelType = CHANNEL_TYPE,
+                    channelId = CHANNEL_ID,
+                ),
+            ),
+        )
+    }
+}

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelEventHandlerTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelEventHandlerTest.kt
@@ -47,6 +47,7 @@ import io.getstream.chat.android.client.test.randomMessageReadEvent
 import io.getstream.chat.android.client.test.randomMessageUpdateEvent
 import io.getstream.chat.android.client.test.randomNewMessageEvent
 import io.getstream.chat.android.client.test.randomNotificationAddedToChannelEvent
+import io.getstream.chat.android.client.test.randomNotificationChannelDeletedEvent
 import io.getstream.chat.android.client.test.randomNotificationChannelMutesUpdatedEvent
 import io.getstream.chat.android.client.test.randomNotificationChannelTruncatedEvent
 import io.getstream.chat.android.client.test.randomNotificationMarkReadEvent
@@ -575,13 +576,23 @@ internal class ChannelEventHandlerTest {
     }
 
     @Test
-    fun `When ChannelDeletedEvent is handled, Then messages are removed and channel is deleted`() {
+    fun `When ChannelDeletedEvent is handled, Then the deletion date is set and the messages are kept`() {
         val event = randomChannelDeletedEvent(cid = cid)
 
         handler.handle(event)
 
-        verify(stateLogic).removeMessagesBefore(event.createdAt)
         verify(stateLogic).deleteChannel(event.createdAt)
+        verify(stateLogic, never()).removeMessagesBefore(any(), any())
+    }
+
+    @Test
+    fun `When NotificationChannelDeletedEvent is handled, Then the deletion date is set and the messages are kept`() {
+        val event = randomNotificationChannelDeletedEvent(cid = cid)
+
+        handler.handle(event)
+
+        verify(stateLogic).deleteChannel(event.createdAt)
+        verify(stateLogic, never()).removeMessagesBefore(any(), any())
     }
 
     @Test

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelEventHandlerTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelEventHandlerTest.kt
@@ -582,7 +582,7 @@ internal class ChannelEventHandlerTest {
         handler.handle(event)
 
         verify(stateLogic).deleteChannel(event.createdAt)
-        verify(stateLogic, never()).removeMessagesBefore(any(), any())
+        verify(stateLogic, never()).removeMessagesBefore(any(), anyOrNull())
     }
 
     @Test
@@ -592,7 +592,7 @@ internal class ChannelEventHandlerTest {
         handler.handle(event)
 
         verify(stateLogic).deleteChannel(event.createdAt)
-        verify(stateLogic, never()).removeMessagesBefore(any(), any())
+        verify(stateLogic, never()).removeMessagesBefore(any(), anyOrNull())
     }
 
     @Test


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

`ChannelState.channelData.deletedAt` was never populated, so an open chat screen had no way to tell that its
channel had been deleted. Listening for `ChannelDeletedEvent` was the only working signal.

Closes [AND-1522](https://linear.app/stream/issue/AND-1522/channeldatadeletedat-is-never-populated-when-a-channel-is-deleted)

### Implementation

- Forward a batch to the channel logic before discarding the channel. `EventHandlerSequential` evicted the
  channel from both registries first, so `channel.deleted` never reached `ChannelEventHandler` and the branch
  setting the deletion date had been dead since the eviction was introduced. The channel is still discarded
  right after, and `channelData` keeps the value for consumers already holding the state.
- Handle `notification.channel_deleted` in `ChannelEventHandler`, which had no branch for it at all.
- Stop clearing the messages on deletion. Truncation remains the one event that empties a channel, matching
  iOS, where message visibility is gated on the channel's `truncatedAt` and never on its deletion date. No
  released version cleared them here, since the branch was unreachable.

### Testing

- New `EventHandlerSequentialChannelDeletedTest` covers both event types over the real `StateRegistry` and
  `LogicRegistry`, asserting the deletion date reaches an active channel's state and that the channel is
  still discarded afterwards. Both rows fail without the reorder, which a registry mock would not catch.
- Verified on a device against the demo app: with a channel open, deleting it server-side moved `deletedAt`
  from null to the deletion date while the message count stayed put.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Channel deletion events now update the channel’s deleted status before the channel is removed from active state.
  - Both standard and notification-based channel deletion events are handled consistently.
  - Messages are retained when a channel is deleted instead of being removed automatically.
  - Improved event processing ensures deletion-related state changes are observable before channel disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->