### PR TITLE
Fix malformed format specifiers in localized strings

### DIFF
--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -42,8 +42,8 @@
     <!-- Common -->
     <string name="stream_compose_member_count_online">%1$s, %2$d Online</string>
     <plurals name="stream_compose_member_count">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
     <string name="stream_compose_ok">OK</string>
     <string name="stream_compose_cancel">Cancel</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -16,8 +16,8 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <plurals name="stream_compose_member_count">
-    <item quantity="one">"%1d Miembro"</item>
-    <item quantity="other">"%1d Miembros"</item>
+    <item quantity="one">"%1$d Miembro"</item>
+    <item quantity="other">"%1$d Miembros"</item>
   </plurals>
   <plurals name="stream_compose_message_list_header_typing_users">
     <item quantity="one">"%1$s está escribiendo"</item>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -16,8 +16,8 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <plurals name="stream_compose_member_count">
-    <item quantity="one">"%1d Membre"</item>
-    <item quantity="other">"%1d Membres"</item>
+    <item quantity="one">"%1$d Membre"</item>
+    <item quantity="other">"%1$d Membres"</item>
   </plurals>
   <plurals name="stream_compose_message_list_header_typing_users">
     <item quantity="one">"%s est en train d\'écrire"</item>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -16,8 +16,8 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <plurals name="stream_compose_member_count">
-    <item quantity="one">"%1d सदस्य"</item>
-    <item quantity="other">"%1d सदस्य"</item>
+    <item quantity="one">"%1$d सदस्य"</item>
+    <item quantity="other">"%1$d सदस्य"</item>
   </plurals>
   <plurals name="stream_compose_message_list_header_typing_users">
     <item quantity="one">"%s लिख रहे/रहीं हैं"</item>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -16,8 +16,8 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <plurals name="stream_compose_member_count">
-    <item quantity="one">"%1d Membro"</item>
-    <item quantity="other">"%1d Membri"</item>
+    <item quantity="one">"%1$d Membro"</item>
+    <item quantity="other">"%1$d Membri"</item>
   </plurals>
   <plurals name="stream_compose_message_list_header_typing_users">
     <item quantity="one">"%s sta scrivendo"</item>
@@ -62,7 +62,7 @@
   <string name="stream_compose_search_input_cancel">"Annulla"</string>
   <string name="stream_compose_search_input_hint">"Cerca i canali per nome"</string>
   <string name="stream_compose_selected_channel_menu_delete_conversation">"Elimina canale"</string>
-  <string name="stream_compose_selected_channel_menu_delete_conversation_confirmation_message">"Vuoi eliminare il canale% 1$s?"</string>
+  <string name="stream_compose_selected_channel_menu_delete_conversation_confirmation_message">"Vuoi eliminare il canale %1$s?"</string>
   <string name="stream_compose_selected_channel_menu_delete_conversation_confirmation_title">"Elimina canale"</string>
   <string name="stream_compose_selected_channel_menu_dismiss">"Annulla"</string>
   <string name="stream_compose_selected_channel_menu_leave_group">"Esci dal gruppo"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -50,11 +50,11 @@
   <string name="stream_compose_search_input_cancel">"キャンセル"</string>
   <string name="stream_compose_search_input_hint">"名前でチャンネルを検索"</string>
   <string name="stream_compose_selected_channel_menu_delete_conversation">"会話を削除する"</string>
-  <string name="stream_compose_selected_channel_menu_delete_conversation_confirmation_message">"チャネル ％1$s を削除しますか"</string>
+  <string name="stream_compose_selected_channel_menu_delete_conversation_confirmation_message">"チャネル %1$s を削除しますか"</string>
   <string name="stream_compose_selected_channel_menu_delete_conversation_confirmation_title">"会話を削除する"</string>
   <string name="stream_compose_selected_channel_menu_dismiss">"キャンセル"</string>
   <string name="stream_compose_selected_channel_menu_leave_group">"グループを離れる"</string>
-  <string name="stream_compose_selected_channel_menu_leave_group_confirmation_message">"％1$s グループを離れますか？"</string>
+  <string name="stream_compose_selected_channel_menu_leave_group_confirmation_message">"%1$s グループを離れますか？"</string>
   <string name="stream_compose_selected_channel_menu_leave_group_confirmation_title">"グループを離れる"</string>
   <string name="stream_compose_selected_channel_menu_mute_channel">"ミュートチャンネル"</string>
   <string name="stream_compose_selected_channel_menu_unmute_channel">"チャネルのミュートを解除する"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -47,8 +47,8 @@
     <!-- Common -->
     <string name="stream_compose_member_count_online">%1$s, %2$d Online</string>
     <plurals name="stream_compose_member_count">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
     <string name="stream_compose_ok">OK</string>
     <string name="stream_compose_cancel">Cancel</string>

--- a/stream-chat-android-docs/src/main/res/values/strings.xml
+++ b/stream-chat-android-docs/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <plurals name="members_count">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
 </resources>

--- a/stream-chat-android-ui-components-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/values/strings.xml
@@ -79,8 +79,8 @@
     <string name="add_group_channel_select_name_choose_title">NAME</string>
     <string name="add_group_channel_select_name_choose_hint">Choose a group chat name</string>
     <plurals name="members_count_title">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
     <string name="add_group_channel_select_name_create_button_title">Create</string>
 

--- a/stream-chat-android-ui-components/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-en/strings.xml
@@ -35,8 +35,8 @@
     <string name="stream_ui_channel_list_dismiss_dialog">Cancel</string>
     <string name="stream_ui_channel_list_delete_channel">Delete conversation</string>
     <plurals name="stream_ui_channel_list_member_info">
-        <item quantity="one">%1d Member, %2d Online</item>
-        <item quantity="other">%1d Members, %2d Online</item>
+        <item quantity="one">%1$d Member, %2$d Online</item>
+        <item quantity="other">%1$d Members, %2$d Online</item>
     </plurals>
     <string name="stream_ui_channel_list_delete_confirmation_title">Delete Channel</string>
     <string name="stream_ui_channel_list_delete_confirmation_message">Are you sure you want to permanently delete this conversation?</string>
@@ -77,8 +77,8 @@
     <string name="stream_ui_message_list_header_retry">Try Again</string>
     <string name="stream_ui_message_list_header_member_count_online">%1$s, %2$d Online</string>
     <plurals name="stream_ui_message_list_header_member_count">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
     <plurals name="stream_ui_message_list_header_typing_users">
         <item quantity="one">%s is typing</item>

--- a/stream-chat-android-ui-components/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-es/strings.xml
@@ -73,8 +73,8 @@
   <string name="stream_ui_message_composer_sending_links_not_allowed">"No se permite enviar enlaces en esta conversación."</string>
   <string name="stream_ui_message_composer_slide_to_cancel">"Deslizar para cancelar"</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="one">"%1d Miembro"</item>
-    <item quantity="other">"%1d Miembros"</item>
+    <item quantity="one">"%1$d Miembro"</item>
+    <item quantity="other">"%1$d Miembros"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%1$s está escribiendo"</item>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings.xml
@@ -24,8 +24,8 @@
   <string name="stream_ui_channel_list_header_disconnected">"En attente de réseau"</string>
   <string name="stream_ui_channel_list_header_offline">"Déconnecté"</string>
   <plurals name="stream_ui_channel_list_member_info">
-    <item quantity="one">"%1d Membre, %2d En ligne"</item>
-    <item quantity="other">"%1d Membres, %2d En ligne"</item>
+    <item quantity="one">"%1$d Membre, %2$d En ligne"</item>
+    <item quantity="other">"%1$d Membres, %2$d En ligne"</item>
   </plurals>
   <string name="stream_ui_channel_list_delete_channel">"Supprimer la conversation"</string>
   <string name="stream_ui_channel_list_delete_confirmation_message">"Êtes-vous sûr de vouloir supprimer définitivement cette conversation?"</string>
@@ -61,8 +61,8 @@
     <string name="stream_ui_message_composer_error_attachment_count">Limite de pièces jointes dépassée : il n\'est pas possible d\'ajouter plus de %d pièces jointes</string>
     <string name="stream_ui_message_composer_sending_links_not_allowed">Sending links is not allowed in this conversation.</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="one">"%1d Membre"</item>
-    <item quantity="other">"%1d Membres"</item>
+    <item quantity="one">"%1$d Membre"</item>
+    <item quantity="other">"%1$d Membres"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%s est en train d\'écrire"</item>

--- a/stream-chat-android-ui-components/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-hi/strings.xml
@@ -26,8 +26,8 @@
   <string name="stream_ui_channel_list_header_disconnected">"नेटवर्क की प्रतीक्षा में"</string>
   <string name="stream_ui_channel_list_header_offline">"डिस्कनेक्टेड"</string>
   <plurals name="stream_ui_channel_list_member_info">
-    <item quantity="one">"%1d सदस्य, %2d ऑनलाइन"</item>
-    <item quantity="other">"%1d सदस्य, %2d ऑनलाइन"</item>
+    <item quantity="one">"%1$d सदस्य, %2$d ऑनलाइन"</item>
+    <item quantity="other">"%1$d सदस्य, %2$d ऑनलाइन"</item>
   </plurals>
   <string name="stream_ui_channel_list_delete_channel">"बातचीत मिटायें"</string>
   <string name="stream_ui_channel_list_delete_confirmation_message">"क्या आप वाकई इस बातचीत को स्थायी रूप से मिटाना चाहते हैं?"</string>
@@ -63,8 +63,8 @@
     <string name="stream_ui_message_composer_error_attachment_count">अटैचमेंट्स संख्या (%d) पार हो गयी</string>
     <string name="stream_ui_message_composer_sending_links_not_allowed">Sending links is not allowed in this conversation.</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="one">"%1d सदस्य"</item>
-    <item quantity="other">"%1d सदस्य"</item>
+    <item quantity="one">"%1$d सदस्य"</item>
+    <item quantity="other">"%1$d सदस्य"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%s लिख रहे/रहीं हैं"</item>

--- a/stream-chat-android-ui-components/src/main/res/values-id/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-id/strings.xml
@@ -25,7 +25,7 @@
   <string name="stream_ui_channel_list_header_disconnected">"Menunggu jaringan"</string>
   <string name="stream_ui_channel_list_header_offline">"Koneksi Terputus"</string>
   <plurals name="stream_ui_channel_list_member_info">
-    <item quantity="other">"%1d Anggota, %2d Online"</item>
+    <item quantity="other">"%1$d Anggota, %2$d Online"</item>
   </plurals>
   <string name="stream_ui_channel_list_delete_channel">"Hapus percakapan"</string>
   <string name="stream_ui_channel_list_delete_confirmation_message">"Anda yakin ingin menghapus percakapan ini?"</string>
@@ -60,7 +60,7 @@
     <string name="stream_ui_message_composer_error_attachment_count">添付ファイルの制限を超えました：%d個のファイル以上を添付することはできません</string>
     <string name="stream_ui_message_composer_sending_links_not_allowed">Sending links is not allowed in this conversation.</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="other">"%1d Anggota"</item>
+    <item quantity="other">"%1$d Anggota"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%s sedang mengetik"</item>

--- a/stream-chat-android-ui-components/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-in/strings.xml
@@ -33,7 +33,7 @@
     <string name="stream_ui_channel_list_dismiss_dialog">Batalkan</string>
     <string name="stream_ui_channel_list_delete_channel">Hapus percakapan</string>
     <plurals name="stream_ui_channel_list_member_info">
-        <item quantity="other">%1d Anggota, %2d Online</item>
+        <item quantity="other">%1$d Anggota, %2$d Online</item>
     </plurals>
     <string name="stream_ui_channel_list_delete_confirmation_title">Hapus Grup</string>
     <string name="stream_ui_channel_list_delete_confirmation_message">Anda yakin ingin menghapus percakapan ini?</string>
@@ -71,7 +71,7 @@
     <string name="stream_ui_message_list_header_retry">Coba Lagi</string>
     <string name="stream_ui_message_list_header_member_count_online">%1$s, %2$d Online</string>
     <plurals name="stream_ui_message_list_header_member_count">
-        <item quantity="other">%1d Anggota</item>
+        <item quantity="other">%1$d Anggota</item>
     </plurals>
     <plurals name="stream_ui_message_list_header_typing_users" tools:ignore="UnusedQuantity">
         <item quantity="one">%s sedang mengetik</item>

--- a/stream-chat-android-ui-components/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-it/strings.xml
@@ -25,8 +25,8 @@
   <string name="stream_ui_channel_list_header_disconnected">"Attendo la rete"</string>
   <string name="stream_ui_channel_list_header_offline">"Disconnesso"</string>
   <plurals name="stream_ui_channel_list_member_info">
-    <item quantity="one">"%1d Membro, %2d Online"</item>
-    <item quantity="other">"%1d Membri, %2d Online"</item>
+    <item quantity="one">"%1$d Membro, %2$d Online"</item>
+    <item quantity="other">"%1$d Membri, %2$d Online"</item>
   </plurals>
   <string name="stream_ui_channel_list_delete_channel">"Elimina canale"</string>
   <string name="stream_ui_channel_list_delete_confirmation_message">"Sei sicuro di voler eliminare questo canale?"</string>
@@ -60,8 +60,8 @@
     <string name="stream_ui_message_composer_error_attachment_count">Attenzione: il limite massimo di %d file è stato superato.</string>
     <string name="stream_ui_message_composer_sending_links_not_allowed">Sending links is not allowed in this conversation.</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="one">"%1d Membro"</item>
-    <item quantity="other">"%1d Membri"</item>
+    <item quantity="one">"%1$d Membro"</item>
+    <item quantity="other">"%1$d Membri"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%s sta scrivendo"</item>

--- a/stream-chat-android-ui-components/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-ja/strings.xml
@@ -26,7 +26,7 @@
   <string name="stream_ui_channel_list_header_disconnected">"ネットワークを検索中"</string>
   <string name="stream_ui_channel_list_header_offline">"切断されました"</string>
   <plurals name="stream_ui_channel_list_member_info">
-    <item quantity="other">"%1d人のメンバー, %2d人がオンライン"</item>
+    <item quantity="other">"%1$d人のメンバー, %2$d人がオンライン"</item>
   </plurals>
   <string name="stream_ui_channel_list_delete_channel">"会話を削除する"</string>
   <string name="stream_ui_channel_list_delete_confirmation_message">"本当にこの会話を削除してもよろしいですか？"</string>
@@ -62,7 +62,7 @@
     <string name="stream_ui_message_composer_error_attachment_count">添付ファイルの制限を超えました：%d個のファイル以上を添付することはできません</string>
     <string name="stream_ui_message_composer_sending_links_not_allowed">Sending links is not allowed in this conversation.</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="other">"%1d人のメンバー"</item>
+    <item quantity="other">"%1$d人のメンバー"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%sが入力しています"</item>

--- a/stream-chat-android-ui-components/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-ko/strings.xml
@@ -26,7 +26,7 @@
   <string name="stream_ui_channel_list_header_disconnected">"네트워크를 검색하는 중입니다"</string>
   <string name="stream_ui_channel_list_header_offline">"연결이 끊어졌습니다"</string>
   <plurals name="stream_ui_channel_list_member_info">
-    <item quantity="other">"%1d명, %2d명이 온라인"</item>
+    <item quantity="other">"%1$d명, %2$d명이 온라인"</item>
   </plurals>
   <string name="stream_ui_channel_list_delete_channel">"대화 삭제하기"</string>
   <string name="stream_ui_channel_list_delete_confirmation_message">"대화를 삭제하시겠습니까?"</string>
@@ -62,7 +62,7 @@
     <string name="stream_ui_message_composer_error_attachment_count">첨부파일 개수가 (%d) 개를 초과하였습니다.</string>
     <string name="stream_ui_message_composer_sending_links_not_allowed">Sending links is not allowed in this conversation.</string>
   <plurals name="stream_ui_message_list_header_member_count">
-    <item quantity="other">"%1d명"</item>
+    <item quantity="other">"%1$d명"</item>
   </plurals>
   <plurals name="stream_ui_message_list_header_typing_users">
     <item quantity="one">"%s 입력 중"</item>

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -220,8 +220,8 @@
     <string name="stream_ui_message_list_header_retry">Try Again</string>
     <string name="stream_ui_message_list_header_member_count_online">%1$s, %2$d Online</string>
     <plurals name="stream_ui_message_list_header_member_count">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
     <plurals name="stream_ui_message_list_header_typing_users">
         <item quantity="one">%s is typing</item>


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Opening the delete channel confirmation dialog in the Compose UI kit crashes on Italian devices. The
translation reads `canale% 1$s`, which `java.util.Formatter` parses as a space flag plus width 1
followed by the conversion character `$`, so `stringResource` throws `UnknownFormatConversionException`.

Closes [AND-1528](https://linear.app/stream/issue/AND-1528/italian-delete-channel-confirmation-crashes-on-a-malformed-format)

### Implementation

- Fix the Italian delete confirmation message to `canale %1$s`.
- Replace the full-width `％` in the Japanese delete and leave group confirmations. It is not
  recognised as a specifier, so those dialogs showed the literal `％1$s` instead of the channel name.
- Replace `%1d`/`%2d` with `%1$d`/`%2$d` in the member count plurals across every locale. These parse
  as implicit argument plus minimum width. Latent rather than visible: the single argument cases render
  identically, and `stream_ui_channel_list_member_info`, where `%2d` would have padded a single digit
  with a leading space, has no code reference in the repo.

The crash and the full width case do not exist on `develop`, where these keys were reworked. The `%1d`
spelling does survive there in `stream-chat-android-docs` and the XML sample, carried over separately.

### Testing

Parsed every `values*/strings.xml` in the repo the way `Formatter` does and checked for unparseable
specifiers, invalid conversion characters, full-width lookalikes and per-quantity argument count drift
against the default locale. The defects above were the only hits, and the pass is clean afterwards.

The crash was hit on a device running the demo app in Italian. Resource only change, so no code paths
move.
