### PR TITLE
Fail the build on translations whose placeholders drift

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,9 @@ subprojects {
                 lint.targetSdk = libs.versions.targetSdk.get().toInt()
                 testOptions.targetSdk = libs.versions.targetSdk.get().toInt()
             }
+            // A translation whose placeholders drift from the default locale crashes at format time,
+            // so the report this check writes by default is too easy to miss.
+            lint.error += "StringFormatCount"
         }
     }
     pluginManager.withPlugin("com.android.application") {
@@ -98,6 +101,7 @@ subprojects {
                 minSdk = libs.versions.minSdk.get().toInt()
                 targetSdk = libs.versions.targetSdk.get().toInt()
             }
+            lint.error += "StringFormatCount"
         }
     }
 

--- a/stream-chat-android-docs/src/main/res/values/strings.xml
+++ b/stream-chat-android-docs/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <plurals name="members_count">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
 </resources>

--- a/stream-chat-android-ui-components-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/values/strings.xml
@@ -79,8 +79,8 @@
     <string name="add_group_channel_select_name_choose_title">NAME</string>
     <string name="add_group_channel_select_name_choose_hint">Choose a group chat name</string>
     <plurals name="members_count_title">
-        <item quantity="one">%1d Member</item>
-        <item quantity="other">%1d Members</item>
+        <item quantity="one">%1$d Member</item>
+        <item quantity="other">%1$d Members</item>
     </plurals>
     <string name="add_group_channel_select_name_create_button_title">Create</string>
 


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Follow-up to #6695, which fixed a crash on v6 caused by an Italian translation reading `canale% 1$s`.
Lint reports that as `StringFormatCount`, but the check is a warning by default, so `./gradlew lint`
stayed green and the broken string shipped.

Closes [AND-1529](https://linear.app/stream/issue/AND-1529/promote-the-string-format-lint-checks-to-errors)

### Implementation

- Promote `StringFormatCount` to an error for every Android module, in the root `build.gradle.kts`
  next to the existing shared lint config. A translation whose placeholders drift from the default
  locale now fails the build instead of adding a line to a report nobody opens.
- Carry over the two `%1d` spellings still left in `stream-chat-android-docs` and the XML sample,
  spotted in review on #6695. Single argument strings, so nothing renders differently.

Scoped to this one check rather than `warningsAsErrors`, which would pull in the existing backlog
(121 warnings in the Compose module alone).

### Testing

- `./gradlew lint` passes across every module. No `StringFormat` finding exists anywhere today, so
  the promotion starts from a clean slate.
- Injected both shapes of the original defect into an Italian string, the misplaced space and the
  full width `％`, and confirmed the build now fails on each with `StringFormatCount`. Reverted after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected singular and plural member-count messages so numeric values display reliably across supported translations.
  - Fixed formatting for member counts in the documentation and sample application, preventing incorrect or potentially failed text rendering.

- **Quality Improvements**
  - Added validation to catch inconsistent number placeholders in localized strings before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->